### PR TITLE
Add gitlab commits' parent and fix a bug

### DIFF
--- a/plugins/gitlab/models/gitlab_commit.go
+++ b/plugins/gitlab/models/gitlab_commit.go
@@ -18,6 +18,7 @@ type GitlabCommit struct {
 	CommitterEmail string
 	CommittedDate  time.Time
 	WebUrl         string
+	ParentIdsStr   string
 	Additions      int `gorm:"comment:Added lines of code"`
 	Deletions      int `gorm:"comment:Deleted lines of code"`
 	Total          int `gorm:"comment:Sum of added/deleted lines of code"`

--- a/plugins/gitlab/models/gitlab_tag.go
+++ b/plugins/gitlab/models/gitlab_tag.go
@@ -5,10 +5,11 @@ import (
 )
 
 type GitlabTag struct {
-	Name               string `gorm:"primaryKey;type:char(60)"`
+	common.Model
+	Name               string `gorm:"type:varchar(255)"`
+	ProjectId          int `gorm:"index"`
 	Message            string
 	Target             string
 	Protected          bool
 	ReleaseDescription string
-	common.NoPKModel
 }

--- a/plugins/gitlab/tasks/gitlab_commit_collector.go
+++ b/plugins/gitlab/tasks/gitlab_commit_collector.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/merico-dev/lake/logger"
 	lakeModels "github.com/merico-dev/lake/models"
@@ -27,6 +28,7 @@ type GitlabApiCommit struct {
 	CommitterEmail string           `json:"committer_email"`
 	CommittedDate  core.Iso8601Time `json:"committed_date"`
 	WebUrl         string           `json:"web_url"`
+	ParentIds      []string         `json:"parent_ids"`
 	Stats          struct {
 		Additions int
 		Deletions int
@@ -116,6 +118,7 @@ func convertCommit(commit *GitlabApiCommit, projectId int) (*models.GitlabCommit
 		CommitterEmail: commit.CommitterEmail,
 		CommittedDate:  commit.CommittedDate.ToTime(),
 		WebUrl:         commit.WebUrl,
+		ParentIdsStr:   strings.Join(commit.ParentIds, ","),
 		Additions:      commit.Stats.Additions,
 		Deletions:      commit.Stats.Deletions,
 		Total:          commit.Stats.Total,


### PR DESCRIPTION
# Summary

1. Collect commits' parent  sha in gitlab;
2. fix bug in collect gitlab tags:
  2.1. delete old data before save new tag
  2.2. add `project_id` column in table `gitlab_tags`

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Does this close any open issues?
no

### Screenshots
![image](https://user-images.githubusercontent.com/3294100/155346410-c876db28-2710-4084-82ad-3e2275966318.png)
![image](https://user-images.githubusercontent.com/3294100/155346597-3b1c9404-20f8-43e9-bfd7-a399042254c1.png)

