### PR TITLE
feat: save .env as original format

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,6 @@ TEMPORAL_TASK_QUEUE=
 # Debug Info Warn Error
 LOGGING_LEVEL=
 
-
 ########################
 # Docker configuration #
 ########################

--- a/config/config.go
+++ b/config/config.go
@@ -1,8 +1,14 @@
 package config
 
 import (
+	"fmt"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
 	"github.com/spf13/viper"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
 )
 
 // Lowcase V for private this. You can use it by call GetConfig.
@@ -20,6 +26,85 @@ func setDefaultValue() {
 	v.SetDefault("TEMPORAL_TASK_QUEUE", "DEVLAKE_TASK_QUEUE")
 	v.SetDefault("GITLAB_ENDPOINT", "https://gitlab.com/api/v4/")
 	v.SetDefault("GITHUB_ENDPOINT", "https://api.github.com/")
+}
+
+// replaceNewEnvItemInOldContent replace old config to new config in env file content
+func replaceNewEnvItemInOldContent(v *viper.Viper, envFileContent string) (error, string) {
+	// prepare reg exp
+	encodeEnvNameReg := regexp.MustCompile(`[^a-zA-Z0-9]`)
+	if encodeEnvNameReg == nil {
+		return fmt.Errorf("encodeEnvNameReg err"), ``
+	}
+
+	for _, key := range v.AllKeys() {
+		envName := strings.ToUpper(key)
+		val := v.Get(envName)
+		encodeEnvName := encodeEnvNameReg.ReplaceAllStringFunc(envName, func(s string) string {
+			return fmt.Sprintf(`\%v`, s)
+		})
+		envItemReg := regexp.MustCompile(fmt.Sprintf(`(?im)^\s*%v\s*\=.*$`, encodeEnvName))
+		if envItemReg == nil {
+			return fmt.Errorf("regexp err"), ``
+		}
+		envFileContent = envItemReg.ReplaceAllStringFunc(envFileContent, func(s string) string {
+			switch ret := val.(type) {
+			case string:
+				ret = strings.Replace(ret, `\`, `\\`, -1)
+				ret = strings.Replace(ret, `=`, `\=`, -1)
+				ret = strings.Replace(ret, `'`, `\'`, -1)
+				ret = strings.Replace(ret, `"`, `\"`, -1)
+				return fmt.Sprintf(`%v="%v"`, envName, ret)
+			default:
+				return fmt.Sprintf(`%v="%v"`, envName, ret)
+			}
+		})
+	}
+	return nil, envFileContent
+}
+
+// WriteConfig save viper to .env file
+func WriteConfig(v *viper.Viper) error {
+	return WriteConfigAs(v, `.env`)
+}
+
+// WriteConfigAs save viper to custom filename
+func WriteConfigAs(v *viper.Viper, filename string) error {
+	aferoFile := afero.NewOsFs()
+	fmt.Println("Attempting to write configuration to .env file.")
+	var configType string
+
+	ext := filepath.Ext(filename)
+	if ext != "" {
+		configType = ext[1:]
+	}
+	if configType != "env" && configType != "dotenv" {
+		return v.WriteConfigAs(filename)
+	}
+
+	// FIXME viper just have setter and have no getter so create new configPermissions and file
+	flags := os.O_CREATE | os.O_TRUNC | os.O_WRONLY
+	configPermissions := os.FileMode(0644)
+	file, err := afero.ReadFile(aferoFile, filename)
+	if err != nil {
+		return err
+	}
+
+	envFileContent := string(file)
+	f, err := aferoFile.OpenFile(filename, flags, configPermissions)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	err, envFileContent = replaceNewEnvItemInOldContent(v, envFileContent)
+	if err != nil {
+		return err
+	}
+
+	if _, err := f.WriteString(envFileContent); err != nil {
+		return err
+	}
+	return f.Sync()
 }
 
 func init() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -21,3 +21,52 @@ func TestReadAndWriteToConfig(t *testing.T) {
 	err = v.WriteConfig()
 	assert.Equal(t, err == nil, true)
 }
+
+func TestReplaceNewEnvItemInOldContent(t *testing.T) {
+	v := GetConfig()
+	v.Set(`aa`, `aaaa`)
+	v.Set(`bb`, `1#1`)
+	v.Set(`cc`, `1"'1`)
+	v.Set(`dd`, `1\"1`)
+	v.Set(`ee`, `=`)
+	v.Set(`ff`, 1.01)
+	v.Set(`gGg`, `gggg`)
+	v.Set(`h.278`, 278)
+	err, s := replaceNewEnvItemInOldContent(v, `
+some unuseful message
+# comment
+
+a blank
+ AA =123
+bB=
+  cc	=
+  dd	 =
+
+# some comment
+eE=
+ff="some content" and some comment
+Ggg=132
+h.278=1
+
+`)
+	if err != nil {
+		panic(err)
+	}
+	assert.Equal(t, `
+some unuseful message
+# comment
+
+a blank
+AA="aaaa"
+BB="1#1"
+CC="1\"\'1"
+DD="1\\\"1"
+
+# some comment
+EE="\="
+FF="1.01"
+GGG="gggg"
+H.278="278"
+
+`, s)
+}

--- a/plugins/ae/api/connection.go
+++ b/plugins/ae/api/connection.go
@@ -35,7 +35,7 @@ func PatchConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, err
 	if err != nil {
 		return nil, err
 	}
-	err = v.WriteConfig()
+	err = config.WriteConfig(v)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/github/api/connection.go
+++ b/plugins/github/api/connection.go
@@ -106,7 +106,7 @@ func PatchConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, err
 	if err != nil {
 		return nil, err
 	}
-	err = v.WriteConfig()
+	err = config.WriteConfig(v)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/gitlab/api/connection.go
+++ b/plugins/gitlab/api/connection.go
@@ -75,7 +75,7 @@ func PatchConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, err
 	if err != nil {
 		return nil, err
 	}
-	err = v.WriteConfig()
+	err = config.WriteConfig(v)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/jenkins/api/connection.go
+++ b/plugins/jenkins/api/connection.go
@@ -74,7 +74,7 @@ func PatchConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, err
 	if err != nil {
 		return nil, err
 	}
-	err = v.WriteConfig()
+	err = config.WriteConfig(v)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/jira/api/connection.go
+++ b/plugins/jira/api/connection.go
@@ -433,7 +433,7 @@ func getEncKey() (string, error) {
 		// Randomly generate a bunch of encryption keys and set them to config
 		encKey = core.RandomEncKey()
 		v.Set(core.EncodeKeyEnvStr, encKey)
-		err := v.WriteConfig()
+		err := config.WriteConfig(v)
 		if err != nil {
 			return encKey, err
 		}

--- a/plugins/tapd/api/connection.go
+++ b/plugins/tapd/api/connection.go
@@ -126,7 +126,7 @@ func refreshAndSaveTapdConnection(tapdConnection *models.TapdConnection, data ma
 		// Randomly generate a bunch of encryption keys and set them to config
 		encKey = core.RandomEncKey()
 		v.Set(core.EncodeKeyEnvStr, encKey)
-		err := v.WriteConfig()
+		err := config.WriteConfig(v)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
#1863

### ⚠️ &nbsp;&nbsp;Pre Checklist

- [ ] This PR is using a `label` (bug, feature etc.)

# Summary

Save origin format to .env file.

A new methods `WriteConfig` to replace old item from `\s*envName\s*\=.*$` to `envName=newValue`

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Does this close any open issues?
#1863

### Current Behavior
Save new format to .env file without comment or other information.

### New Behavior
Save original format to .env file with comment or other information.
![image](https://user-images.githubusercontent.com/3294100/168294995-9ad9a629-7f50-44ab-8eef-9c0fbc1034a1.png)

