### PR TITLE
Release v0.11.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,6 @@ TEMPORAL_TASK_QUEUE=
 # Debug Info Warn Error
 LOGGING_LEVEL=
 
-
 ########################
 # Docker configuration #
 ########################

--- a/config-ui/src/hooks/useSettingsManager.jsx
+++ b/config-ui/src/hooks/useSettingsManager.jsx
@@ -26,36 +26,36 @@ function useSettingsManager ({
         connectionPayload = {
           ...connectionPayload,
           name: connection.name,
-          Endpoint: connection.endpoint,
-          BasicAuthEncoded: connection.basicAuthEncoded,
-          Proxy: connection.proxy || connection.Proxy
+          endPoing: connection.endpoint,
+          basicAuthEncoded: connection.basicAuthEncoded,
+          proxy: connection.proxy || connection.Proxy
         }
         break
       case Providers.GITHUB:
         connectionPayload = {
           ...connectionPayload,
           name: connection.name,
-          GITHUB_ENDPOINT: connection.endpoint,
-          GITHUB_AUTH: connection.auth,
-          GITHUB_PROXY: connection.proxy || connection.Proxy
+          endpoint: connection.endpoint,
+          auth: connection.auth,
+          proxy: connection.proxy || connection.Proxy
         }
         break
       case Providers.JENKINS:
         connectionPayload = {
           ...connectionPayload,
           name: connection.name,
-          JENKINS_ENDPOINT: connection.endpoint,
-          JENKINS_USERNAME: connection.username,
-          JENKINS_PASSWORD: connection.password
+          endpoint: connection.endpoint,
+          username: connection.username,
+          password: connection.password
         }
         break
       case Providers.GITLAB:
         connectionPayload = {
           ...connectionPayload,
           name: connection.name,
-          GITLAB_ENDPOINT: connection.endpoint,
-          GITLAB_AUTH: connection.auth,
-          GITLAB_PROXY: connection.proxy || connection.Proxy
+          endpoint: connection.endpoint,
+          auth: connection.auth,
+          proxy: connection.proxy || connection.Proxy
         }
         break
     }

--- a/config/config.go
+++ b/config/config.go
@@ -1,8 +1,14 @@
 package config
 
 import (
+	"fmt"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
 	"github.com/spf13/viper"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
 )
 
 // Lowcase V for private this. You can use it by call GetConfig.
@@ -20,6 +26,85 @@ func setDefaultValue() {
 	v.SetDefault("TEMPORAL_TASK_QUEUE", "DEVLAKE_TASK_QUEUE")
 	v.SetDefault("GITLAB_ENDPOINT", "https://gitlab.com/api/v4/")
 	v.SetDefault("GITHUB_ENDPOINT", "https://api.github.com/")
+}
+
+// replaceNewEnvItemInOldContent replace old config to new config in env file content
+func replaceNewEnvItemInOldContent(v *viper.Viper, envFileContent string) (error, string) {
+	// prepare reg exp
+	encodeEnvNameReg := regexp.MustCompile(`[^a-zA-Z0-9]`)
+	if encodeEnvNameReg == nil {
+		return fmt.Errorf("encodeEnvNameReg err"), ``
+	}
+
+	for _, key := range v.AllKeys() {
+		envName := strings.ToUpper(key)
+		val := v.Get(envName)
+		encodeEnvName := encodeEnvNameReg.ReplaceAllStringFunc(envName, func(s string) string {
+			return fmt.Sprintf(`\%v`, s)
+		})
+		envItemReg := regexp.MustCompile(fmt.Sprintf(`(?im)^\s*%v\s*\=.*$`, encodeEnvName))
+		if envItemReg == nil {
+			return fmt.Errorf("regexp err"), ``
+		}
+		envFileContent = envItemReg.ReplaceAllStringFunc(envFileContent, func(s string) string {
+			switch ret := val.(type) {
+			case string:
+				ret = strings.Replace(ret, `\`, `\\`, -1)
+				ret = strings.Replace(ret, `=`, `\=`, -1)
+				ret = strings.Replace(ret, `'`, `\'`, -1)
+				ret = strings.Replace(ret, `"`, `\"`, -1)
+				return fmt.Sprintf(`%v="%v"`, envName, ret)
+			default:
+				return fmt.Sprintf(`%v="%v"`, envName, ret)
+			}
+		})
+	}
+	return nil, envFileContent
+}
+
+// WriteConfig save viper to .env file
+func WriteConfig(v *viper.Viper) error {
+	return WriteConfigAs(v, `.env`)
+}
+
+// WriteConfigAs save viper to custom filename
+func WriteConfigAs(v *viper.Viper, filename string) error {
+	aferoFile := afero.NewOsFs()
+	fmt.Println("Attempting to write configuration to .env file.")
+	var configType string
+
+	ext := filepath.Ext(filename)
+	if ext != "" {
+		configType = ext[1:]
+	}
+	if configType != "env" && configType != "dotenv" {
+		return v.WriteConfigAs(filename)
+	}
+
+	// FIXME viper just have setter and have no getter so create new configPermissions and file
+	flags := os.O_CREATE | os.O_TRUNC | os.O_WRONLY
+	configPermissions := os.FileMode(0644)
+	file, err := afero.ReadFile(aferoFile, filename)
+	if err != nil {
+		return err
+	}
+
+	envFileContent := string(file)
+	f, err := aferoFile.OpenFile(filename, flags, configPermissions)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	err, envFileContent = replaceNewEnvItemInOldContent(v, envFileContent)
+	if err != nil {
+		return err
+	}
+
+	if _, err := f.WriteString(envFileContent); err != nil {
+		return err
+	}
+	return f.Sync()
 }
 
 func init() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -21,3 +21,52 @@ func TestReadAndWriteToConfig(t *testing.T) {
 	err = v.WriteConfig()
 	assert.Equal(t, err == nil, true)
 }
+
+func TestReplaceNewEnvItemInOldContent(t *testing.T) {
+	v := GetConfig()
+	v.Set(`aa`, `aaaa`)
+	v.Set(`bb`, `1#1`)
+	v.Set(`cc`, `1"'1`)
+	v.Set(`dd`, `1\"1`)
+	v.Set(`ee`, `=`)
+	v.Set(`ff`, 1.01)
+	v.Set(`gGg`, `gggg`)
+	v.Set(`h.278`, 278)
+	err, s := replaceNewEnvItemInOldContent(v, `
+some unuseful message
+# comment
+
+a blank
+ AA =123
+bB=
+  cc	=
+  dd	 =
+
+# some comment
+eE=
+ff="some content" and some comment
+Ggg=132
+h.278=1
+
+`)
+	if err != nil {
+		panic(err)
+	}
+	assert.Equal(t, `
+some unuseful message
+# comment
+
+a blank
+AA="aaaa"
+BB="1#1"
+CC="1\"\'1"
+DD="1\\\"1"
+
+# some comment
+EE="\="
+FF="1.01"
+GGG="gggg"
+H.278="278"
+
+`, s)
+}

--- a/models/domainlayer/code/refs_pr_cherry_pick.go
+++ b/models/domainlayer/code/refs_pr_cherry_pick.go
@@ -2,6 +2,7 @@ package code
 
 import "github.com/merico-dev/lake/models/common"
 
+// multi pk
 type RefsPrCherrypick struct {
 	RepoName               string `gorm:"type:varchar(255)"`
 	ParentPrKey            int

--- a/models/domainlayer/crossdomain/refs_issues_diff.go
+++ b/models/domainlayer/crossdomain/refs_issues_diff.go
@@ -3,11 +3,11 @@ package crossdomain
 import "github.com/merico-dev/lake/models/common"
 
 type RefsIssuesDiffs struct {
-	NewRefId        string `gorm:"type:varchar(255)"`
-	OldRefId        string `gorm:"type:varchar(255)"`
+	NewRefId        string `gorm:"primaryKey;type:varchar(255)"`
+	OldRefId        string `gorm:"primaryKey;type:varchar(255)"`
 	NewRefCommitSha string `gorm:"type:varchar(40)"`
 	OldRefCommitSha string `gorm:"type:varchar(40)"`
 	IssueNumber     string `gorm:"type:varchar(255)"`
-	IssueId         string `gorm:";type:varchar(255)"`
+	IssueId         string `gorm:"primaryKey;type:varchar(255)"`
 	common.NoPKModel
 }

--- a/models/migrationscripts/register.go
+++ b/models/migrationscripts/register.go
@@ -4,5 +4,6 @@ import "github.com/merico-dev/lake/migration"
 
 // RegisterAll register all the migration scripts of framework
 func RegisterAll() {
-	migration.Register([]migration.Script{new(initSchemas), new(updateSchemas20220505), new(updateSchemas20220507), new(updateSchemas20220510), new(updateSchemas20220513)}, "Framework")
+	migration.Register([]migration.Script{new(initSchemas), new(updateSchemas20220505), new(updateSchemas20220507),
+						new(updateSchemas20220510), new(updateSchemas20220513)}, "Framework")
 }

--- a/models/migrationscripts/register.go
+++ b/models/migrationscripts/register.go
@@ -4,5 +4,5 @@ import "github.com/merico-dev/lake/migration"
 
 // RegisterAll register all the migration scripts of framework
 func RegisterAll() {
-	migration.Register([]migration.Script{new(initSchemas), new(updateSchemas20220505), new(updateSchemas20220507), new(updateSchemas20220510)}, "Framework")
+	migration.Register([]migration.Script{new(initSchemas), new(updateSchemas20220505), new(updateSchemas20220507), new(updateSchemas20220510), new(updateSchemas20220513)}, "Framework")
 }

--- a/models/migrationscripts/updateSchemas20220513.go
+++ b/models/migrationscripts/updateSchemas20220513.go
@@ -1,0 +1,72 @@
+package migrationscripts
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/merico-dev/lake/models/migrationscripts/archived"
+	"gorm.io/gorm"
+)
+
+type RefsIssuesDiffs20220513 struct {
+	NewRefId        string `gorm:"primaryKey;type:varchar(255)"`
+	OldRefId        string `gorm:"primaryKey;type:varchar(255)"`
+	NewRefCommitSha string `gorm:"type:varchar(40)"`
+	OldRefCommitSha string `gorm:"type:varchar(40)"`
+	IssueNumber     string `gorm:"type:varchar(255)"`
+	IssueId         string `gorm:"primaryKey;type:varchar(255)"`
+	archived.NoPKModel
+}
+
+func (RefsIssuesDiffs20220513) TableName() string {
+	return "refs_issues_diffs"
+}
+
+type updateSchemas20220513 struct{}
+
+func (*updateSchemas20220513) Up(ctx context.Context, db *gorm.DB) error {
+	cursor, err := db.Model(archived.RefsIssuesDiffs{}).Rows()
+	if err != nil {
+		return err
+	}
+	defer cursor.Close()
+
+	duplicateData := make(map[string]interface{})
+	for cursor.Next() {
+		inputRow := archived.RefsIssuesDiffs{}
+		err := db.ScanRows(cursor, &inputRow)
+		if err != nil {
+			return err
+
+		}
+
+		inputRowkey := fmt.Sprintf("%s%s%s", inputRow.NewRefId, inputRow.OldRefId, inputRow.IssueId)
+		if inputRowkey != "" {
+			duplicateData[inputRowkey] = inputRow
+		}
+	}
+
+	err = db.Migrator().DropTable(archived.RefsIssuesDiffs{})
+	if err != nil {
+		return err
+	}
+
+	err = db.Migrator().CreateTable(RefsIssuesDiffs20220513{})
+	if err != nil {
+		return err
+	}
+
+	for _, v := range duplicateData {
+		db.Create(v)
+	}
+
+	return nil
+}
+
+func (*updateSchemas20220513) Version() uint64 {
+	return 20220513212319
+}
+
+func (*updateSchemas20220513) Name() string {
+	return "refs_issues_diffs add primary key"
+}

--- a/plugins/ae/api/connection.go
+++ b/plugins/ae/api/connection.go
@@ -35,7 +35,7 @@ func PatchConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, err
 	if err != nil {
 		return nil, err
 	}
-	err = v.WriteConfig()
+	err = config.WriteConfig(v)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/core/plugin_utils.go
+++ b/plugins/core/plugin_utils.go
@@ -70,6 +70,9 @@ func PKCS7Padding(ciphertext []byte, blockSize int) []byte {
 // PKCS7 unPadding
 func PKCS7UnPadding(origData []byte) []byte {
 	length := len(origData)
+	if length == 0 {
+		return nil
+	}
 	unpadding := int(origData[length-1])
 	if unpadding >= length {
 		return nil

--- a/plugins/gitextractor/main.go
+++ b/plugins/gitextractor/main.go
@@ -43,10 +43,7 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		storage, err = store.NewDatabase(database)
-		if err != nil {
-			panic(err)
-		}
+		storage = store.NewDatabase(database)
 	} else {
 		panic("either specify `-output` or `-db` argument as destination")
 	}

--- a/plugins/gitextractor/main.go
+++ b/plugins/gitextractor/main.go
@@ -43,7 +43,10 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		storage = store.NewDatabase(database)
+		storage, err = store.NewDatabase(database)
+		if err != nil {
+			panic(err)
+		}
 	} else {
 		panic("either specify `-output` or `-db` argument as destination")
 	}

--- a/plugins/gitextractor/models/interface.go
+++ b/plugins/gitextractor/models/interface.go
@@ -10,6 +10,5 @@ type Store interface {
 	Refs(ref *code.Ref) error
 	CommitFiles(file *code.CommitFile) error
 	CommitParents(pp []*code.CommitParent) error
-	Flush() error
 	Close() error
 }

--- a/plugins/gitextractor/parser/libgit2.go
+++ b/plugins/gitextractor/parser/libgit2.go
@@ -260,8 +260,5 @@ func (l *LibGit2) run(repo *git.Repository, repoId string) error {
 		l.subTaskCtx.IncProgress(1)
 		return nil
 	})
-	if err == nil {
-		err = l.store.Flush()
-	}
 	return err
 }

--- a/plugins/gitextractor/store/csv.go
+++ b/plugins/gitextractor/store/csv.go
@@ -145,6 +145,3 @@ func (c *CsvStore) Close() error {
 	}
 	return nil
 }
-func (c *CsvStore) Flush() error {
-	return nil
-}

--- a/plugins/gitextractor/tasks/git_repo_collector.go
+++ b/plugins/gitextractor/tasks/git_repo_collector.go
@@ -37,11 +37,9 @@ func (o GitExtractorOptions) Valid() error {
 }
 
 func CollectGitRepo(subTaskCtx core.SubTaskContext) error {
+	var err error
 	db := subTaskCtx.GetDb()
-	storage, err := store.NewDatabase(db)
-	if err != nil {
-		return err
-	}
+	storage := store.NewDatabase(db)
 	op := subTaskCtx.GetData().(GitExtractorOptions)
 	p := parser.NewLibGit2(storage, subTaskCtx)
 	if strings.HasPrefix(op.Url, "http") {

--- a/plugins/gitextractor/tasks/git_repo_collector.go
+++ b/plugins/gitextractor/tasks/git_repo_collector.go
@@ -38,10 +38,12 @@ func (o GitExtractorOptions) Valid() error {
 
 func CollectGitRepo(subTaskCtx core.SubTaskContext) error {
 	db := subTaskCtx.GetDb()
-	storage := store.NewDatabase(db)
+	storage, err := store.NewDatabase(db)
+	if err != nil {
+		return err
+	}
 	op := subTaskCtx.GetData().(GitExtractorOptions)
 	p := parser.NewLibGit2(storage, subTaskCtx)
-	var err error
 	if strings.HasPrefix(op.Url, "http") {
 		err = p.CloneOverHTTP(op.RepoId, op.Url, op.User, op.Password, op.Proxy)
 	} else if url := strings.TrimPrefix(op.Url, "ssh://"); strings.HasPrefix(url, "git@") {

--- a/plugins/github/api/connection.go
+++ b/plugins/github/api/connection.go
@@ -106,7 +106,7 @@ func PatchConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, err
 	if err != nil {
 		return nil, err
 	}
-	err = v.WriteConfig()
+	err = config.WriteConfig(v)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/github/models/connection.go
+++ b/plugins/github/models/connection.go
@@ -5,18 +5,18 @@ type GithubConnection struct {
 	Auth     string `mapstructure:"auth" validate:"required" env:"GITHUB_AUTH" json:"auth"`
 	Proxy    string `mapstructure:"proxy" env:"GITHUB_PROXY" json:"proxy"`
 
-	Config
+	Config `mapstructure:",squash"`
 }
 
 type Config struct {
-	PrType               string `mapstructure:"prType,squash" env:"GITHUB_PR_TYPE" json:"prType"`
-	PrComponent          string `mapstructure:"prComponent,squash" env:"GITHUB_PR_COMPONENT" json:"prComponent"`
-	IssueSeverity        string `mapstructure:"issueSeverity,squash" env:"GITHUB_ISSUE_SEVERITY" json:"issueSeverity"`
-	IssuePriority        string `mapstructure:"issuePriority,squash" env:"GITHUB_ISSUE_PRIORITY" json:"issuePriority"`
-	IssueComponent       string `mapstructure:"issueComponent,squash" env:"GITHUB_ISSUE_COMPONENT" json:"issueComponent"`
-	IssueTypeBug         string `mapstructure:"issueTypeBug,squash" env:"GITHUB_ISSUE_TYPE_BUG" json:"issueTypeBug"`
-	IssueTypeIncident    string `mapstructure:"typeIncident,squash" env:"GITHUB_ISSUE_TYPE_INCIDENT" json:"typeIncident"`
-	IssueTypeRequirement string `mapstructure:"issueTypeRequirement,squash" env:"GITHUB_ISSUE_TYPE_REQUIREMENT" json:"issueTypeRequirement"`
+	PrType               string `mapstructure:"prType" env:"GITHUB_PR_TYPE" json:"prType"`
+	PrComponent          string `mapstructure:"prComponent" env:"GITHUB_PR_COMPONENT" json:"prComponent"`
+	IssueSeverity        string `mapstructure:"issueSeverity" env:"GITHUB_ISSUE_SEVERITY" json:"issueSeverity"`
+	IssuePriority        string `mapstructure:"issuePriority" env:"GITHUB_ISSUE_PRIORITY" json:"issuePriority"`
+	IssueComponent       string `mapstructure:"issueComponent" env:"GITHUB_ISSUE_COMPONENT" json:"issueComponent"`
+	IssueTypeBug         string `mapstructure:"issueTypeBug" env:"GITHUB_ISSUE_TYPE_BUG" json:"issueTypeBug"`
+	IssueTypeIncident    string `mapstructure:"typeIncident" env:"GITHUB_ISSUE_TYPE_INCIDENT" json:"typeIncident"`
+	IssueTypeRequirement string `mapstructure:"issueTypeRequirement" env:"GITHUB_ISSUE_TYPE_REQUIREMENT" json:"issueTypeRequirement"`
 }
 
 // This object conforms to what the frontend currently expects.

--- a/plugins/gitlab/api/connection.go
+++ b/plugins/gitlab/api/connection.go
@@ -75,7 +75,7 @@ func PatchConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, err
 	if err != nil {
 		return nil, err
 	}
-	err = v.WriteConfig()
+	err = config.WriteConfig(v)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/helper/api_client.go
+++ b/plugins/helper/api_client.go
@@ -196,7 +196,7 @@ func (apiClient *ApiClient) Do(
 	apiClient.logDebug("[api-client] %v %v", method, *uri)
 	res, err = apiClient.client.Do(req)
 	if err != nil {
-		apiClient.logError("[api-client] failed to request %s with error:\n%w", req.URL.String(), err)
+		apiClient.logError("[api-client] failed to request %s with error:\n%s", req.URL.String(), err.Error())
 		return nil, err
 	}
 
@@ -261,6 +261,7 @@ func GetURIStringPointer(baseUrl string, relativePath string, query url.Values) 
 		for key, value := range query {
 			queryString.Set(key, strings.Join(value, ""))
 		}
+
 		u.RawQuery = queryString.Encode()
 	}
 	uri := base.ResolveReference(u).String()

--- a/plugins/helper/api_collector.go
+++ b/plugins/helper/api_collector.go
@@ -272,13 +272,22 @@ func (collector *ApiCollector) generateUrl(pager *Pager, input interface{}) (str
 func (collector *ApiCollector) stepFetch(ctx context.Context, cancel func(), reqData RequestData) error {
 	// channel `c` is used to make sure fetchAsync is called serially
 	c := make(chan struct{})
+	var err1 error
 	handler := func(res *http.Response, err error) error {
+		select {
+		case <-ctx.Done():
+			err = ctx.Err()
+		default:
+
+		}
 		if err != nil {
+			err1 = err
 			close(c)
 			return err
 		}
 		count, err := collector.saveRawData(res, reqData.Input)
 		if err != nil {
+			err1 = err
 			close(c)
 			cancel()
 			return err
@@ -294,15 +303,24 @@ func (collector *ApiCollector) stepFetch(ctx context.Context, cancel func(), req
 	}
 	// kick off
 	go func() { c <- struct{}{} }()
-	for range c {
-		err := collector.fetchAsync(&reqData, handler)
-		if err != nil {
-			close(c)
-			cancel()
-			return err
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case _, ok := <-c:
+			if !ok || err1 != nil {
+				return err1
+			} else {
+				err := collector.fetchAsync(&reqData, handler)
+				if err != nil {
+					close(c)
+					cancel()
+					return err
+				}
+			}
 		}
 	}
-	return nil
+	return err1
 }
 
 func (collector *ApiCollector) fetchAsync(reqData *RequestData, handler ApiAsyncCallback) error {
@@ -312,6 +330,13 @@ func (collector *ApiCollector) fetchAsync(reqData *RequestData, handler ApiAsync
 			Size: 100,
 			Skip: 0,
 		}
+	}
+	ctx := collector.args.Ctx.GetContext()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+
 	}
 	apiUrl, err := collector.generateUrl(reqData.Pager, reqData.Input)
 	if err != nil {

--- a/plugins/helper/api_collector.go
+++ b/plugins/helper/api_collector.go
@@ -13,7 +13,6 @@ import (
 	"text/template"
 
 	"github.com/merico-dev/lake/plugins/core"
-	"gorm.io/datatypes"
 )
 
 type Pager struct {
@@ -434,7 +433,7 @@ func (collector *ApiCollector) saveRawData(res *http.Response, input interface{}
 	for i, msg := range items {
 		dd[i] = &RawData{
 			Params: collector.params,
-			Data:   datatypes.JSON(msg),
+			Data:   msg,
 			Url:    u,
 			Input:  inputJson,
 		}

--- a/plugins/helper/api_collector_test.go
+++ b/plugins/helper/api_collector_test.go
@@ -284,7 +284,7 @@ func TestSaveRawData(t *testing.T) {
 		for _, v := range rd {
 			// check data and url
 			assert.Equal(t, v.Params, string(params))
-			assert.Equal(t, v.Data.String(), TestRawMessage)
+			assert.Equal(t, string(v.Data), TestRawMessage)
 			assert.Equal(t, v.Url, TestUrl)
 			assert.Equal(t, v.Input.String(), string(input))
 		}

--- a/plugins/helper/api_rawdata.go
+++ b/plugins/helper/api_rawdata.go
@@ -13,7 +13,7 @@ import (
 type RawData struct {
 	ID        uint64 `gorm:"primaryKey"`
 	Params    string `gorm:"type:varchar(255);index"`
-	Data      datatypes.JSON
+	Data      []byte
 	Url       string
 	Input     datatypes.JSON
 	CreatedAt time.Time

--- a/plugins/helper/batch_save_test.go
+++ b/plugins/helper/batch_save_test.go
@@ -68,3 +68,49 @@ func Test_getPrimaryKeyValue(t *testing.T) {
 		})
 	}
 }
+
+func Test_hasPrimaryKey(t *testing.T) {
+	type args struct {
+		iface interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			"",
+			args{ticket.SprintIssue{
+				SprintId: "abc",
+				IssueId:  "123",
+			},
+			},
+			true,
+		},
+		{
+			"",
+			args{&ticket.SprintIssue{
+				SprintId: "abc",
+				IssueId:  "123",
+			},
+			},
+			true,
+		},
+		{
+			"",
+			args{ticket.Issue{}},
+			true,
+		},
+		{
+			"",
+			args{&ticket.Issue{}},
+			true,
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, hasPrimaryKey(tt.args.iface), "hasPrimaryKey(%v)", tt.args.iface)
+		})
+	}
+}

--- a/plugins/helper/batch_save_test.go
+++ b/plugins/helper/batch_save_test.go
@@ -1,6 +1,7 @@
 package helper
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/merico-dev/lake/models/domainlayer"
@@ -107,10 +108,10 @@ func Test_hasPrimaryKey(t *testing.T) {
 			true,
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, hasPrimaryKey(tt.args.iface), "hasPrimaryKey(%v)", tt.args.iface)
+			assert.Equalf(t, tt.want, hasPrimaryKey(reflect.TypeOf(tt.args.iface)), "hasPrimaryKey(%v)", tt.args.iface)
 		})
 	}
 }

--- a/plugins/jenkins/api/connection.go
+++ b/plugins/jenkins/api/connection.go
@@ -74,7 +74,7 @@ func PatchConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, err
 	if err != nil {
 		return nil, err
 	}
-	err = v.WriteConfig()
+	err = config.WriteConfig(v)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/jira/api/connection.go
+++ b/plugins/jira/api/connection.go
@@ -433,7 +433,7 @@ func getEncKey() (string, error) {
 		// Randomly generate a bunch of encryption keys and set them to config
 		encKey = core.RandomEncKey()
 		v.Set(core.EncodeKeyEnvStr, encKey)
-		err := v.WriteConfig()
+		err := config.WriteConfig(v)
 		if err != nil {
 			return encKey, err
 		}

--- a/plugins/jira/jira.go
+++ b/plugins/jira/jira.go
@@ -87,7 +87,7 @@ func (plugin Jira) PrepareTaskData(taskCtx core.TaskContext, options map[string]
 		return nil, fmt.Errorf("connectionId is invalid")
 	}
 	connection := &models.JiraConnection{}
-	err = db.Find(connection, op.ConnectionId).Error
+	err = db.First(connection, op.ConnectionId).Error
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/refdiff/tasks/refs_pr_cherry_pick_calculator.go
+++ b/plugins/refdiff/tasks/refs_pr_cherry_pick_calculator.go
@@ -4,11 +4,23 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
+	"time"
 
 	"github.com/merico-dev/lake/models/domainlayer/code"
 	"github.com/merico-dev/lake/plugins/core"
 	"gorm.io/gorm/clause"
 )
+
+type cherryPick struct {
+	RepoName             string `gorm:"type:varchar(255)"`
+	ParentPrKey          int
+	CherrypickBaseBranch string `gorm:"type:varchar(255)"`
+	CherrypickPrKey      int
+	ParentPrUrl          string `gorm:"type:varchar(255)"`
+	ParentPrId           string `gorm:"type:varchar(255)"`
+	CreatedDate          time.Time
+}
 
 func CalculatePrCherryPick(taskCtx core.SubTaskContext) error {
 	data := taskCtx.GetData().(*RefdiffTaskData)
@@ -80,31 +92,100 @@ func CalculatePrCherryPick(taskCtx core.SubTaskContext) error {
 		taskCtx.IncProgress(1)
 	}
 
-	cursor2, err := db.Table("pull_requests pr1").
-		Joins("left join pull_requests pr2 on pr1.parent_pr_id = pr2.id").Group("pr1.parent_pr_id, pr2.created_date").Where("pr1.parent_pr_id != ''").
-		Joins("left join repos on pr2.base_repo_id = repos.id").
-		Order("pr2.created_date ASC").
-		Select(`pr2.key as parent_pr_key, pr1.parent_pr_id as parent_pr_id, GROUP_CONCAT(pr1.base_ref order by pr1.base_ref ASC) as cherrypick_base_branches, 
-			GROUP_CONCAT(pr1.key order by pr1.base_ref ASC) as cherrypick_pr_keys, repos.name as repo_name, 
-			concat(repos.url, '/pull/', pr2.key) as parent_pr_url`).Rows()
+	//cursor2, err := db.Table("pull_requests pr1").
+	//	Joins("left join pull_requests pr2 on pr1.parent_pr_id = pr2.id").Group("pr1.parent_pr_id, pr2.created_date").Where("pr1.parent_pr_id != ''").
+	//	Joins("left join repos on pr2.base_repo_id = repos.id").
+	//	Order("pr2.created_date ASC").
+	//	Select(`pr2.key as parent_pr_key, pr1.parent_pr_id as parent_pr_id, GROUP_CONCAT(pr1.base_ref order by pr1.base_ref ASC) as cherrypick_base_branches,
+	//		GROUP_CONCAT(pr1.key order by pr1.base_ref ASC) as cherrypick_pr_keys, repos.name as repo_name,
+	//		concat(repos.url, '/pull/', pr2.key) as parent_pr_url`).Rows()
+	/*
+		SELECT pr2.key                                              AS parent_pr_key,
+			pr1.parent_pr_id                                     AS parent_pr_id,
+			Group_concat(pr1.base_ref ORDER BY pr1.base_ref ASC) AS cherrypick_base_branches,
+			Group_concat(pr1.key ORDER BY pr1.base_ref ASC)      AS cherrypick_pr_keys,
+			pr1.base_ref,
+			pr1.key,
+			repos.name                                           AS repo_name,
+			Concat(repos.url, '/pull/', pr2.key)                 AS parent_pr_url
+		FROM   pull_requests pr1
+		LEFT JOIN pull_requests pr2
+		ON pr1.parent_pr_id = pr2.id
+		LEFT JOIN repos
+		ON pr2.base_repo_id = repos.id
+		WHERE  pr1.parent_pr_id != ''
+		GROUP  BY pr1.parent_pr_id,
+			pr2.created_date
+		ORDER  BY pr1.parent_pr_id, pr2.created_date ASC
+	*/
+	cursor2, err := db.Exec(
+		`
+			SELECT pr2.KEY                              AS parent_pr_key,
+			       pr1.parent_pr_id                     AS parent_pr_id,
+			       pr1.base_ref                         AS cherrypick_base_branch,
+			       pr1.KEY                              AS cherrypick_pr_key,
+			       repos.NAME                           AS repo_name,
+			       Concat(repos.url, '/pull/', pr2.KEY) AS parent_pr_url,
+ 				   pr2.created_date
+			FROM   pull_requests pr1
+			       LEFT JOIN pull_requests pr2
+			              ON pr1.parent_pr_id = pr2.id
+			       LEFT JOIN repos
+			              ON pr2.base_repo_id = repos.id
+			WHERE  pr1.parent_pr_id != ''
+			ORDER  BY pr1.parent_pr_id,
+			          pr2.created_date ASC,
+					  pr1.base_ref ASC
+			`).Rows()
 	if err != nil {
 		return err
 	}
 	defer cursor2.Close()
 
-	refsPrCherryPick := &code.RefsPrCherrypick{}
+	var refsPrCherryPick *code.RefsPrCherrypick
+	var lastParentPrId string
+	var lastCreatedDate time.Time
+	var cherrypickBaseBranches []string
+	var cherrypickPrKeys []string
 	for cursor2.Next() {
-		err = db.ScanRows(cursor2, refsPrCherryPick)
+		var item cherryPick
+		err = db.ScanRows(cursor2, &item)
 		if err != nil {
 			return err
 		}
-		err = db.Clauses(clause.OnConflict{
-			UpdateAll: true,
-		}).Create(refsPrCherryPick).Error
-		if err != nil {
-			return err
+		if item.ParentPrId == lastParentPrId && item.CreatedDate == lastCreatedDate {
+			cherrypickBaseBranches = append(cherrypickPrKeys, item.CherrypickBaseBranch)
+			cherrypickPrKeys = append(cherrypickPrKeys, strconv.Itoa(item.CherrypickPrKey))
+		} else {
+			if refsPrCherryPick != nil {
+				refsPrCherryPick.CherrypickBaseBranches = strings.Join(cherrypickBaseBranches, ",")
+				refsPrCherryPick.CherrypickPrKeys = strings.Join(cherrypickPrKeys, ",")
+				err = db.Clauses(clause.OnConflict{
+					UpdateAll: true,
+				}).Create(refsPrCherryPick).Error
+				if err != nil {
+					return err
+				}
+			}
+			lastParentPrId = item.ParentPrId
+			lastCreatedDate = item.CreatedDate
+			cherrypickBaseBranches = []string{item.CherrypickBaseBranch}
+			cherrypickPrKeys = []string{strconv.Itoa(item.CherrypickPrKey)}
+			refsPrCherryPick = &code.RefsPrCherrypick{
+				RepoName:    item.RepoName,
+				ParentPrKey: item.ParentPrKey,
+				ParentPrUrl: item.ParentPrUrl,
+				ParentPrId:  item.ParentPrId,
+			}
 		}
 	}
+	err = db.Clauses(clause.OnConflict{
+		UpdateAll: true,
+	}).Create(refsPrCherryPick).Error
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/plugins/refdiff/tasks/refs_pr_cherry_pick_calculator.go
+++ b/plugins/refdiff/tasks/refs_pr_cherry_pick_calculator.go
@@ -92,32 +92,6 @@ func CalculatePrCherryPick(taskCtx core.SubTaskContext) error {
 		taskCtx.IncProgress(1)
 	}
 
-	//cursor2, err := db.Table("pull_requests pr1").
-	//	Joins("left join pull_requests pr2 on pr1.parent_pr_id = pr2.id").Group("pr1.parent_pr_id, pr2.created_date").Where("pr1.parent_pr_id != ''").
-	//	Joins("left join repos on pr2.base_repo_id = repos.id").
-	//	Order("pr2.created_date ASC").
-	//	Select(`pr2.key as parent_pr_key, pr1.parent_pr_id as parent_pr_id, GROUP_CONCAT(pr1.base_ref order by pr1.base_ref ASC) as cherrypick_base_branches,
-	//		GROUP_CONCAT(pr1.key order by pr1.base_ref ASC) as cherrypick_pr_keys, repos.name as repo_name,
-	//		concat(repos.url, '/pull/', pr2.key) as parent_pr_url`).Rows()
-	/*
-		SELECT pr2.key                                              AS parent_pr_key,
-			pr1.parent_pr_id                                     AS parent_pr_id,
-			Group_concat(pr1.base_ref ORDER BY pr1.base_ref ASC) AS cherrypick_base_branches,
-			Group_concat(pr1.key ORDER BY pr1.base_ref ASC)      AS cherrypick_pr_keys,
-			pr1.base_ref,
-			pr1.key,
-			repos.name                                           AS repo_name,
-			Concat(repos.url, '/pull/', pr2.key)                 AS parent_pr_url
-		FROM   pull_requests pr1
-		LEFT JOIN pull_requests pr2
-		ON pr1.parent_pr_id = pr2.id
-		LEFT JOIN repos
-		ON pr2.base_repo_id = repos.id
-		WHERE  pr1.parent_pr_id != ''
-		GROUP  BY pr1.parent_pr_id,
-			pr2.created_date
-		ORDER  BY pr1.parent_pr_id, pr2.created_date ASC
-	*/
 	cursor2, err := db.Raw(
 		`
 			SELECT pr2.KEY                              AS parent_pr_key,

--- a/plugins/refdiff/tasks/refs_pr_cherry_pick_calculator.go
+++ b/plugins/refdiff/tasks/refs_pr_cherry_pick_calculator.go
@@ -153,11 +153,14 @@ func CalculatePrCherryPick(taskCtx core.SubTaskContext) error {
 			}
 		}
 	}
-	err = db.Clauses(clause.OnConflict{
-		UpdateAll: true,
-	}).Create(refsPrCherryPick).Error
-	if err != nil {
-		return err
+
+	if refsPrCherryPick != nil {
+		err = db.Clauses(clause.OnConflict{
+			UpdateAll: true,
+		}).Create(refsPrCherryPick).Error
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/plugins/tapd/api/connection.go
+++ b/plugins/tapd/api/connection.go
@@ -126,7 +126,7 @@ func refreshAndSaveTapdConnection(tapdConnection *models.TapdConnection, data ma
 		// Randomly generate a bunch of encryption keys and set them to config
 		encKey = core.RandomEncKey()
 		v.Set(core.EncodeKeyEnvStr, encKey)
-		err := v.WriteConfig()
+		err := config.WriteConfig(v)
 		if err != nil {
 			return err
 		}

--- a/plugins/tapd/tapd.go
+++ b/plugins/tapd/tapd.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/merico-dev/lake/migration"
 	"github.com/merico-dev/lake/models/domainlayer/didgen"
 	"github.com/merico-dev/lake/plugins/core"
@@ -14,7 +16,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"gorm.io/gorm"
-	"time"
 )
 
 var _ core.PluginMeta = (*Tapd)(nil)
@@ -94,7 +95,7 @@ func (plugin Tapd) PrepareTaskData(taskCtx core.TaskContext, options map[string]
 		return nil, fmt.Errorf("ConnectionId is required for Tapd execution")
 	}
 	connection := &models.TapdConnection{}
-	err = db.Find(connection, op.ConnectionId).Error
+	err = db.First(connection, op.ConnectionId).Error
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Summary
Combine several PRs:
#1871 Add some critical point checks to see if the context was canceled
#1874 fix(github): fix unicode for pg
#1876 feat: save .env as original format
#1877 fix: refdiff incompatible with postgres


### Key Points

- [x] This is a breaking change
- [ ] New or existing documentation is updated

DB_URL format
`issues` add `icon_url` column
`notes.system` -> `notes.is_system`
PUT -> PATCH for all plugin connection api
Jira plugin: change subtask name `ConvertUsers` to `convertUsers`

### Does this close any open issues?

close #1870 The github plugin failed to collect tidb on postgres
close #1869 refdiff (calculateIssuesDiff) is incompatible with postgres 
close #1868 jira use empty connection data without any error 
close #1867 tapd not sent out error when find connection empty
close #1866 PKCS7UnPadding panic with empty origData 
close #1865 github save connection action will make some params trunced in .env file 
close #1844 config-ui: pipelines - cancel running pipeline not successful 
close #1842 Postgres Support: some SQL include functions that are only available in Postgres 
close #1873 refdiff (calculatePrCherryPick) is incompatible with postgres 


