### PR TITLE
fix(github): modify issueTypeIncident

### DIFF
--- a/plugins/github/models/connection.go
+++ b/plugins/github/models/connection.go
@@ -15,7 +15,7 @@ type Config struct {
 	IssuePriority        string `mapstructure:"issuePriority" env:"GITHUB_ISSUE_PRIORITY" json:"issuePriority"`
 	IssueComponent       string `mapstructure:"issueComponent" env:"GITHUB_ISSUE_COMPONENT" json:"issueComponent"`
 	IssueTypeBug         string `mapstructure:"issueTypeBug" env:"GITHUB_ISSUE_TYPE_BUG" json:"issueTypeBug"`
-	IssueTypeIncident    string `mapstructure:"typeIncident" env:"GITHUB_ISSUE_TYPE_INCIDENT" json:"typeIncident"`
+	IssueTypeIncident    string `mapstructure:"issueTypeIncident" env:"GITHUB_ISSUE_TYPE_INCIDENT" json:"issueTypeIncident"`
 	IssueTypeRequirement string `mapstructure:"issueTypeRequirement" env:"GITHUB_ISSUE_TYPE_REQUIREMENT" json:"issueTypeRequirement"`
 }
 


### PR DESCRIPTION
# Summary

In `github.models.Config`, `IssueTypeIncident` has wrong tag.
Modify `IssueTypeIncident` tag to unify all the fields in both frontend and backend

### Does this close any open issues?
closes #1887


### Screenshots
![image](https://user-images.githubusercontent.com/39366025/169059230-1891aa14-8705-4c05-8c03-b10206ef62a5.png)