### PR TITLE
refactor: accelerate jira changelog collecting

### DIFF
--- a/plugins/jira/tasks/changelog_collector.go
+++ b/plugins/jira/tasks/changelog_collector.go
@@ -75,11 +75,12 @@ func CollectChangelogs(taskCtx core.SubTaskContext) error {
 			},
 			Table: RAW_CHANGELOG_TABLE,
 		},
-		ApiClient:   data.ApiClient,
-		PageSize:    50,
-		Incremental: true,
-		Input:       iterator,
-		UrlTemplate: "api/3/issue/{{ .Input.IssueId }}/changelog",
+		ApiClient:     data.ApiClient,
+		PageSize:      50,
+		Incremental:   true,
+		GetTotalPages: GetTotalPagesFromResponse,
+		Input:         iterator,
+		UrlTemplate:   "api/3/issue/{{ .Input.IssueId }}/changelog",
 		Query: func(reqData *helper.RequestData) (url.Values, error) {
 			query := url.Values{}
 			query.Set("startAt", fmt.Sprintf("%v", reqData.Pager.Skip))

--- a/plugins/jira/tasks/issue_extractor.go
+++ b/plugins/jira/tasks/issue_extractor.go
@@ -124,6 +124,9 @@ func ExtractIssues(taskCtx core.SubTaskContext) error {
 			issue.StdType = getStdType(issue.Type)
 			issue.StdStatus = getStdStatus(issue.StatusKey)
 			issue.SpentMinutes = issue.AggregateEstimateMinutes - issue.RemainingEstimateMinutes
+			if len(changelogs) < 100 {
+				issue.ChangelogUpdated = &row.CreatedAt
+			}
 			results = append(results, issue)
 			for _, worklog := range worklogs {
 				results = append(results, worklog)


### PR DESCRIPTION

# Summary
Accelerate jira changelog collecting.
- set `GetTotalPages` as `GetTotalPagesFromResponse` for Jira issue changelog collector
- set `changelog_updated` as issue collecting time 

