### PR TITLE
fix(runner): swallow the error form exec.Command.Run

### DIFF
--- a/runner/directrun.go
+++ b/runner/directrun.go
@@ -64,10 +64,8 @@ func DirectRun(cmd *cobra.Command, args []string, pluginTask core.PluginTask, op
 		panic(err)
 	}
 
-	err = exec.Command("stty", "-F", "/dev/tty", "cbreak", "min", "1").Run()
-	if err != nil {
-		panic(err)
-	}
+	exec.Command("stty", "-F", "/dev/tty", "cbreak", "min", "1").Run()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		buf := make([]byte, 1)


### PR DESCRIPTION
# Summary
swallow the error from exec.Command.Run()


### Does this close any open issues?
closes #1973

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
