### PR TITLE
Fix: `handleResponseWithPages`, collect pages in another goroutine

### DIFF
--- a/plugins/helper/api_async_client.go
+++ b/plugins/helper/api_async_client.go
@@ -185,11 +185,19 @@ func (apiClient *ApiAsyncClient) WaitAsync() error {
 func (apiClient *ApiAsyncClient) GetQps() float64 {
 	return apiClient.qps
 }
+func (apiClient *ApiAsyncClient) Add(delta int) {
+	apiClient.scheduler.Add(delta)
+}
+func (apiClient *ApiAsyncClient) Done() {
+	apiClient.scheduler.Done()
+}
 
 type RateLimitedApiClient interface {
 	GetAsync(path string, query url.Values, header http.Header, handler ApiAsyncCallback) error
 	WaitAsync() error
 	GetQps() float64
+	Add(delta int)
+	Done()
 }
 
 var _ RateLimitedApiClient = (*ApiAsyncClient)(nil)

--- a/plugins/helper/api_collector.go
+++ b/plugins/helper/api_collector.go
@@ -397,7 +397,6 @@ func (collector *ApiCollector) pagerFetch(reqData *RequestData) error {
 				err = e
 				return e
 			}
-			collector.args.Ctx.GetLogger().Info("=========")
 			// gather total pages
 			var body []byte
 			body, err = ioutil.ReadAll(res.Body)
@@ -443,7 +442,6 @@ func (collector *ApiCollector) pagerFetch(reqData *RequestData) error {
 			return err1
 		}
 	}
-	collector.args.Ctx.GetLogger().Info("++++++++++++++++")
 	return nil
 }
 

--- a/plugins/helper/api_collector.go
+++ b/plugins/helper/api_collector.go
@@ -412,7 +412,12 @@ func (collector *ApiCollector) handleResponseWithPages(reqData *RequestData) Api
 			collector.args.Ctx.SetProgress(1, totalPages)
 		}
 		// fetch other pages in parallel
+		collector.args.ApiClient.Add(1)
 		go func() {
+			defer func() {
+				collector.args.ApiClient.Done()
+				recover()
+			}()
 			for page := 2; page <= totalPages; page++ {
 				reqDataTemp := &RequestData{
 					Pager: &Pager{

--- a/plugins/helper/api_collector.go
+++ b/plugins/helper/api_collector.go
@@ -229,7 +229,7 @@ func (collector *ApiCollector) exec(input interface{}) error {
 	if collector.args.GetTotalPages != nil {
 		/* when total pages is available from api*/
 		// fetch the very first page
-		err = collector.fetchAsync(reqData, collector.handleResponseWithPages(reqData))
+		err = collector.pagerFetch(reqData)
 	} else {
 		// if api doesn't return total number of pages, employ a step concurrent technique
 		// when `Concurrency` was set to 3:
@@ -384,6 +384,67 @@ func (collector *ApiCollector) handleResponse(reqData *RequestData) ApiAsyncCall
 		collector.args.Ctx.IncProgress(1)
 		return err
 	}
+}
+func (collector *ApiCollector) pagerFetch(reqData *RequestData) error {
+	c := make(chan *RequestData)
+	go func() {
+		c <- reqData
+	}()
+	var err error
+	handlerWrap := func(c chan *RequestData, reqData *RequestData) ApiAsyncCallback {
+		return func(res *http.Response, e error) error {
+			if e != nil {
+				err = e
+				return e
+			}
+			collector.args.Ctx.GetLogger().Info("=========")
+			// gather total pages
+			var body []byte
+			body, err = ioutil.ReadAll(res.Body)
+			if err != nil {
+				return err
+			}
+			res.Body.Close()
+			res.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+			var totalPages int
+			totalPages, err = collector.args.GetTotalPages(res, collector.args)
+			if err != nil {
+				return err
+			}
+			// save response body of first page
+			res.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+			_, err = collector.saveRawData(res, reqData.Input)
+			if err != nil {
+				return err
+			}
+			if collector.args.Input == nil {
+				collector.args.Ctx.SetProgress(1, totalPages)
+			}
+
+			if reqData.Pager.Page >= totalPages {
+				close(c)
+				return nil
+			}
+			reqData.Pager.Page++
+			go func() {
+				c <- reqData
+			}()
+			return nil
+		}
+
+	}
+
+	for reqData := range c {
+		if err != nil {
+			return err
+		}
+		err1 := collector.fetchAsync(reqData, handlerWrap(c, reqData))
+		if err1 != nil {
+			return err1
+		}
+	}
+	collector.args.Ctx.GetLogger().Info("++++++++++++++++")
+	return nil
 }
 
 func (collector *ApiCollector) handleResponseWithPages(reqData *RequestData) ApiAsyncCallback {

--- a/plugins/helper/worker_scheduler.go
+++ b/plugins/helper/worker_scheduler.go
@@ -144,3 +144,11 @@ func (s *WorkerScheduler) Release() {
 		s.ticker.Stop()
 	}
 }
+
+func (s *WorkerScheduler) Add(delta int) {
+	s.waitGroup.Add(delta)
+}
+
+func (s *WorkerScheduler) Done() {
+	s.waitGroup.Done()
+}


### PR DESCRIPTION
# Summary

In the `ApiCollector.exec()`:
```go
if collector.args.GetTotalPages != nil {
		err = collector.fetchAsync(reqData, collector.handleResponseWithPages(reqData))
	}
```

the ` handleResponseWithPages` method
```go
func (collector *ApiCollector) handleResponseWithPages(reqData *RequestData) ApiAsyncCallback {
	return func(res *http.Response, e error) error {
		...
		for page := 2; page <= totalPages; page++ {
			...
			e = collector.fetchAsync(reqDataTemp, collector.handleResponse(reqDataTemp))
		}
		return nil
	}
}
```
The `fetchAsync` will submit a task to the goroutine pool, if the goroutine pool is reached its capacity, the `Submit` will block until some earlier tasks are finished. Due to the FILO nature of recursive calls, tasks are waiting for each other, and deadlock occurs.


### Does this close any open issues?
#1984 

### Screenshots
![middle_img_v2_f7fd5a64-392a-4aa6-9655-3e95f9d0311g](https://user-images.githubusercontent.com/8455907/169959334-2d177835-7d00-484b-85e2-9617e934d335.jpg)

### Other Information
Any other information that is important to this PR.
