### PR TITLE
add migration for directrun; update feishu model

### DIFF
--- a/plugins/feishu/feishu.go
+++ b/plugins/feishu/feishu.go
@@ -73,7 +73,9 @@ func (plugin Feishu) RootPkgPath() string {
 }
 
 func (plugin Feishu) MigrationScripts() []migration.Script {
-	return []migration.Script{new(migrationscripts.InitSchemas)}
+	return []migration.Script{
+		new(migrationscripts.InitSchemas), new(migrationscripts.UpdateSchemas20220524),
+	}
 }
 
 func (plugin Feishu) ApiResources() map[string]map[string]core.ApiResourceHandler {

--- a/plugins/feishu/models/meeting_top_user_item.go
+++ b/plugins/feishu/models/meeting_top_user_item.go
@@ -23,13 +23,12 @@ import (
 )
 
 type FeishuMeetingTopUserItem struct {
-	common.Model    `json:"-"`
-	StartTime       time.Time
-	MeetingCount    string `json:"meeting_count" gorm:"type:varchar(255)"`
-	MeetingDuration string `json:"meeting_duration" gorm:"type:varchar(255)"`
-	Name            string `json:"name" gorm:"type:varchar(255)"`
-	UserType        int64  `json:"user_type"`
-	common.RawDataOrigin
+	common.NoPKModel `json:"-"`
+	StartTime        time.Time `gorm:"primaryKey"`
+	Name             string    `json:"name" gorm:"primaryKey;type:varchar(255)"`
+	MeetingCount     string    `json:"meeting_count" gorm:"type:varchar(255)"`
+	MeetingDuration  string    `json:"meeting_duration" gorm:"type:varchar(255)"`
+	UserType         int64     `json:"user_type"`
 }
 
 func (FeishuMeetingTopUserItem) TableName() string {

--- a/plugins/feishu/models/migrationscripts/updateSchemas20220526.go
+++ b/plugins/feishu/models/migrationscripts/updateSchemas20220526.go
@@ -1,0 +1,90 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"context"
+	"github.com/apache/incubator-devlake/models/common"
+	"github.com/apache/incubator-devlake/plugins/feishu/models/migrationscripts/archived"
+	"gorm.io/gorm/clause"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type FeishuMeetingTopUserItem20220524Temp struct {
+	common.NoPKModel `json:"-"`
+	StartTime        time.Time `gorm:"primaryKey"`
+	Name             string    `json:"name" gorm:"primaryKey;type:varchar(255)"`
+	MeetingCount     string    `json:"meeting_count" gorm:"type:varchar(255)"`
+	MeetingDuration  string    `json:"meeting_duration" gorm:"type:varchar(255)"`
+	UserType         int64     `json:"user_type"`
+}
+
+func (FeishuMeetingTopUserItem20220524Temp) TableName() string {
+	return "_tool_feishu_meeting_top_user_items_tmp"
+}
+
+type FeishuMeetingTopUserItem20220524 struct {
+}
+
+func (FeishuMeetingTopUserItem20220524) TableName() string {
+	return "_tool_feishu_meeting_top_user_items"
+}
+
+type UpdateSchemas20220524 struct{}
+
+func (*UpdateSchemas20220524) Up(ctx context.Context, db *gorm.DB) error {
+	cursor, err := db.Model(archived.FeishuMeetingTopUserItem{}).Rows()
+	if err != nil {
+		return err
+	}
+	defer cursor.Close()
+	// 1. create a temporary table to store unique records
+	err = db.Migrator().CreateTable(FeishuMeetingTopUserItem20220524Temp{})
+	if err != nil {
+		return err
+	}
+	// 2. dedupe records and insert into the temporary table
+	for cursor.Next() {
+		inputRow := FeishuMeetingTopUserItem20220524Temp{}
+		err := db.ScanRows(cursor, &inputRow)
+		if err != nil {
+			return err
+		}
+		err = db.Clauses(clause.OnConflict{UpdateAll: true}).Create(inputRow).Error
+		if err != nil {
+			return err
+		}
+	}
+	// 3. drop old table
+	err = db.Migrator().DropTable(archived.FeishuMeetingTopUserItem{})
+	if err != nil {
+		return err
+	}
+	// 4. rename the temporary table to the old table
+	return db.Migrator().RenameTable(FeishuMeetingTopUserItem20220524Temp{}, FeishuMeetingTopUserItem20220524{})
+}
+
+func (*UpdateSchemas20220524) Version() uint64 {
+	return 20220524000001
+}
+
+func (*UpdateSchemas20220524) Name() string {
+	return "change primary column `id` to start_time+name"
+}

--- a/plugins/feishu/tasks/meeting_top_user_item_extractor.go
+++ b/plugins/feishu/tasks/meeting_top_user_item_extractor.go
@@ -27,8 +27,7 @@ import (
 var _ core.SubTaskEntryPoint = ExtractMeetingTopUserItem
 
 func ExtractMeetingTopUserItem(taskCtx core.SubTaskContext) error {
-
-	exetractor, err := helper.NewApiExtractor(helper.ApiExtractorArgs{
+	extractor, err := helper.NewApiExtractor(helper.ApiExtractorArgs{
 		RawDataSubTaskArgs: helper.RawDataSubTaskArgs{
 			Ctx: taskCtx,
 			Params: FeishuApiParams{
@@ -62,12 +61,12 @@ func ExtractMeetingTopUserItem(taskCtx core.SubTaskContext) error {
 		return err
 	}
 
-	return exetractor.Execute()
+	return extractor.Execute()
 }
 
 var ExtractMeetingTopUserItemMeta = core.SubTaskMeta{
 	Name:             "extractMeetingTopUserItem",
 	EntryPoint:       ExtractMeetingTopUserItem,
 	EnabledByDefault: true,
-	Description:      "Extrat raw top user meeting data into tool layer table feishu_meeting_top_user_item",
+	Description:      "Extract raw top user meeting data into tool layer table feishu_meeting_top_user_item",
 }

--- a/plugins/helper/batch_save.go
+++ b/plugins/helper/batch_save.go
@@ -44,7 +44,7 @@ func NewBatchSave(db *gorm.DB, slotType reflect.Type, size int) (*BatchSave, err
 	if slotType.Kind() != reflect.Ptr {
 		return nil, fmt.Errorf("slotType must be a pointer")
 	}
-	if !hasPrimaryKey(slotType, false) {
+	if !hasPrimaryKey(slotType, true) {
 		return nil, fmt.Errorf("no primary key")
 	}
 	return &BatchSave{
@@ -65,7 +65,7 @@ func (c *BatchSave) Add(slot interface{}) error {
 		return fmt.Errorf("slot is not a pointer")
 	}
 	// deduplication
-	key := getPrimaryKeyValue(slot, false)
+	key := getPrimaryKeyValue(slot, true)
 
 	if key != "" {
 		if index, ok := c.valueIndex[key]; !ok {

--- a/plugins/helper/batch_save_test.go
+++ b/plugins/helper/batch_save_test.go
@@ -85,7 +85,7 @@ func Test_getPrimaryKeyValue(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, getPrimaryKeyValue(tt.args.iface, true), "getPrimaryKeyValue(%v)", tt.args.iface)
+			assert.Equalf(t, tt.want, getPrimaryKeyValue(tt.args.iface), "getPrimaryKeyValue(%v)", tt.args.iface)
 		})
 	}
 }
@@ -131,7 +131,7 @@ func Test_hasPrimaryKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, hasPrimaryKey(reflect.TypeOf(tt.args.iface), true), "hasPrimaryKey(%v)", tt.args.iface)
+			assert.Equalf(t, tt.want, hasPrimaryKey(reflect.TypeOf(tt.args.iface)), "hasPrimaryKey(%v)", tt.args.iface)
 		})
 	}
 }

--- a/plugins/helper/batch_save_test.go
+++ b/plugins/helper/batch_save_test.go
@@ -85,7 +85,7 @@ func Test_getPrimaryKeyValue(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, getPrimaryKeyValue(tt.args.iface), "getPrimaryKeyValue(%v)", tt.args.iface)
+			assert.Equalf(t, tt.want, getPrimaryKeyValue(tt.args.iface, true), "getPrimaryKeyValue(%v)", tt.args.iface)
 		})
 	}
 }
@@ -131,7 +131,7 @@ func Test_hasPrimaryKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, hasPrimaryKey(reflect.TypeOf(tt.args.iface)), "hasPrimaryKey(%v)", tt.args.iface)
+			assert.Equalf(t, tt.want, hasPrimaryKey(reflect.TypeOf(tt.args.iface), true), "hasPrimaryKey(%v)", tt.args.iface)
 		})
 	}
 }

--- a/runner/directrun.go
+++ b/runner/directrun.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"github.com/apache/incubator-devlake/config"
 	"github.com/apache/incubator-devlake/logger"
+	"github.com/apache/incubator-devlake/migration"
 	"github.com/apache/incubator-devlake/plugins/core"
 	"github.com/spf13/cobra"
 	"os"
@@ -60,6 +61,16 @@ func DirectRun(cmd *cobra.Command, args []string, pluginTask core.PluginTask, op
 		}
 	}
 	err = core.RegisterPlugin(cmd.Use, pluginTask.(core.PluginMeta))
+	if err != nil {
+		panic(err)
+	}
+
+	// collect migration and run
+	migration.Init(db)
+	if migratable, ok := pluginTask.(core.Migratable); ok {
+		migration.Register(migratable.MigrationScripts(), cmd.Use)
+	}
+	err = migration.Execute(context.Background())
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
# Summary

copy migrate from `services/init.go` to `directrun.go` for migration in cli;

delete `id` in  feishu model and add new primaryKey

# Summary 2
I want to keep this PR small, but I got a error when fix feishu model because of time cannot use as primary key.

So Fix it in commit 2. 

![image](https://user-images.githubusercontent.com/3294100/170962048-c086c530-22de-49cd-893a-18e0b936dc3e.png)
StartTime is a struct so `isPrimaryKey` not run and StartTime cannot detect as primary key.
![origin_img_v2_2bb6a928-3b48-48c8-87c3-1b015f49678g](https://user-images.githubusercontent.com/3294100/170962102-567c3247-308b-457e-8f5c-bf27136aae0f.png)

I fix it like this: check isPrimaryKey before check struct; add need_recursion to avoid unuseful recursion

### Does this close any open issues?
close #2029
close #2014
close #2031

### Key Points
- [x] This is a breaking change
