### PR TITLE
fix: jira connections api should not depend on encKey

### DIFF
--- a/plugins/jira/api/connection.go
+++ b/plugins/jira/api/connection.go
@@ -128,7 +128,7 @@ func getJiraConnectionById(id uint64) (*models.JiraConnection, error) {
 	encKey := v.GetString(core.EncodeKeyEnvStr)
 	jiraConnection.BasicAuthEncoded, err = core.Decrypt(encKey, jiraConnection.BasicAuthEncoded)
 	if err != nil {
-		return nil, err
+		log.Error("failed to decrypt basic auth: %s", err)
 	}
 
 	return jiraConnection, nil
@@ -200,7 +200,7 @@ func refreshAndSaveJiraConnection(jiraConnection *models.JiraConnection, data ma
 
 	jiraConnection.BasicAuthEncoded, err = core.Decrypt(encKey, jiraConnection.BasicAuthEncoded)
 	if err != nil {
-		return err
+		log.Error("failed to decrypt basic auth: %s", err)
 	}
 	return nil
 }
@@ -316,7 +316,7 @@ func ListConnections(input *core.ApiResourceInput) (*core.ApiResourceOutput, err
 	for i := range jiraConnections {
 		jiraConnections[i].BasicAuthEncoded, err = core.Decrypt(encKey, jiraConnections[i].BasicAuthEncoded)
 		if err != nil {
-			return nil, err
+			log.Error("failed to decrypt basic auth: %s", err)
 		}
 	}
 	return &core.ApiResourceOutput{Body: jiraConnections}, nil

--- a/plugins/jira/api/init.go
+++ b/plugins/jira/api/init.go
@@ -25,8 +25,10 @@ import (
 
 var db *gorm.DB
 var cfg *viper.Viper
+var log core.Logger
 
 func Init(config *viper.Viper, logger core.Logger, database *gorm.DB) {
 	db = database
 	cfg = config
+	log = logger
 }


### PR DESCRIPTION
# Summary

This PR fixes #2032 by the following approach:
 for Jira connections endpoint, when `.env` got deleted and decryption failed, no more 400 bad requests, but with empty `basic auth`, so developer/user can still list out all Jira connections, and update their `basic auth` which will then be encrypted with the newly generated key. 

### Does this close any open issues?
  Fixes #2032

