### PR TITLE
refactor: rename tasks field from pipeline and move it to higher level

### DIFF
--- a/models/migrationscripts/register.go
+++ b/models/migrationscripts/register.go
@@ -25,7 +25,6 @@ func RegisterAll() {
 		new(initSchemas),
 		new(updateSchemas20220505), new(updateSchemas20220507), new(updateSchemas20220510),
 		new(updateSchemas20220513), new(updateSchemas20220524), new(updateSchemas20220526),
-		new(updateSchemas20220527),
-		new(updateSchemas20220528),
+		new(updateSchemas20220527), new(updateSchemas20220528), new(updateSchemas20220601),
 	}, "Framework")
 }

--- a/models/migrationscripts/updateSchemas20220601.go
+++ b/models/migrationscripts/updateSchemas20220601.go
@@ -15,20 +15,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package models
+package migrationscripts
 
 import (
+	"context"
 	"time"
 
 	"github.com/apache/incubator-devlake/models/common"
 	"gorm.io/datatypes"
-)
-
-const (
-	TASK_CREATED   = "TASK_CREATED"
-	TASK_RUNNING   = "TASK_RUNNING"
-	TASK_COMPLETED = "TASK_COMPLETED"
-	TASK_FAILED    = "TASK_FAILED"
+	"gorm.io/gorm"
 )
 
 type TaskProgressDetail struct {
@@ -40,7 +35,7 @@ type TaskProgressDetail struct {
 	SubTaskNumber    int    `json:"subTaskNumber"`
 }
 
-type Task struct {
+type Task20220601 struct {
 	common.Model
 	Plugin         string              `json:"plugin" gorm:"index"`
 	Subtasks       datatypes.JSON      `json:"subtasks"`
@@ -59,16 +54,26 @@ type Task struct {
 	SpentSeconds  int        `json:"spentSeconds"`
 }
 
-type NewTask struct {
-	// Plugin name
-	Plugin      string                 `json:"plugin" binding:"required"`
-	Subtasks    []string               `json:"subtasks"`
-	Options     map[string]interface{} `json:"options"`
-	PipelineId  uint64                 `json:"-"`
-	PipelineRow int                    `json:"-"`
-	PipelineCol int                    `json:"-"`
+func (Task20220601) TableName() string {
+	return "_devlake_tasks"
 }
 
-func (Task) TableName() string {
-	return "_devlake_tasks"
+type updateSchemas20220601 struct{}
+
+func (*updateSchemas20220601) Up(ctx context.Context, db *gorm.DB) error {
+
+	err := db.Migrator().AddColumn(Task20220601{}, "subtasks")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (*updateSchemas20220601) Version() uint64 {
+	return 20220601000005
+}
+
+func (*updateSchemas20220601) Name() string {
+	return "add column `subtasks` at _devlake_tasks"
 }

--- a/models/pipeline.go
+++ b/models/pipeline.go
@@ -27,18 +27,17 @@ import (
 
 type Pipeline struct {
 	common.Model
-	Name        string         `json:"name" gorm:"index"`
-	BlueprintId uint64         `json:"blueprintId"`
-	Tasks       datatypes.JSON `json:"tasks"`
-	TotalTasks  int            `json:"totalTasks"`
-	// Deprecated
-	FinishedTasks int        `json:"finishedTasks"`
-	BeganAt       *time.Time `json:"beganAt"`
-	FinishedAt    *time.Time `json:"finishedAt" gorm:"index"`
-	Status        string     `json:"status"`
-	Message       string     `json:"message"`
-	SpentSeconds  int        `json:"spentSeconds"`
-	Stage         int        `json:"stage"`
+	Name          string         `json:"name" gorm:"index"`
+	BlueprintId   uint64         `json:"blueprintId"`
+	Tasks         datatypes.JSON `json:"tasks"`
+	TotalTasks    int            `json:"totalTasks"`
+	FinishedTasks int            `json:"finishedTasks"`
+	BeganAt       *time.Time     `json:"beganAt"`
+	FinishedAt    *time.Time     `json:"finishedAt" gorm:"index"`
+	Status        string         `json:"status"`
+	Message       string         `json:"message"`
+	SpentSeconds  int            `json:"spentSeconds"`
+	Stage         int            `json:"stage"`
 }
 
 // We use a 2D array because the request body must be an array of a set of tasks

--- a/plugins/ae/ae.go
+++ b/plugins/ae/ae.go
@@ -108,7 +108,7 @@ func main() {
 	projectId := aeCmd.Flags().IntP("project-id", "p", 0, "ae project id")
 	_ = aeCmd.MarkFlagRequired("project-id")
 	aeCmd.Run = func(cmd *cobra.Command, args []string) {
-		runner.DirectRun(cmd, args, PluginEntry, map[string]interface{}{
+		runner.DirectRun(cmd, args, PluginEntry, []string{}, map[string]interface{}{
 			"projectId": *projectId,
 		})
 	}

--- a/plugins/dbt/dbt.go
+++ b/plugins/dbt/dbt.go
@@ -97,7 +97,7 @@ func main() {
 		for k, v := range projectVars {
 			projectVarsConvert[k] = v
 		}
-		runner.DirectRun(cmd, args, PluginEntry, map[string]interface{}{
+		runner.DirectRun(cmd, args, PluginEntry, []string{}, map[string]interface{}{
 			"projectPath":    *projectPath,
 			"projectName":    *projectName,
 			"projectTarget":  *projectTarget,

--- a/plugins/feishu/feishu.go
+++ b/plugins/feishu/feishu.go
@@ -88,7 +88,7 @@ func main() {
 	numOfDaysToCollect := feishuCmd.Flags().IntP("numOfDaysToCollect", "n", 8, "feishu collect days")
 	_ = feishuCmd.MarkFlagRequired("numOfDaysToCollect")
 	feishuCmd.Run = func(cmd *cobra.Command, args []string) {
-		runner.DirectRun(cmd, args, PluginEntry, map[string]interface{}{
+		runner.DirectRun(cmd, args, PluginEntry, []string{}, map[string]interface{}{
 			"numOfDaysToCollect": *numOfDaysToCollect,
 		})
 	}

--- a/plugins/github/github.go
+++ b/plugins/github/github.go
@@ -144,7 +144,7 @@ func main() {
 	_ = githubCmd.MarkFlagRequired("repo")
 
 	githubCmd.Run = func(cmd *cobra.Command, args []string) {
-		runner.DirectRun(cmd, args, PluginEntry, map[string]interface{}{
+		runner.DirectRun(cmd, args, PluginEntry, []string{}, map[string]interface{}{
 			"owner": *owner,
 			"repo":  *repo,
 		})

--- a/plugins/gitlab/gitlab.go
+++ b/plugins/gitlab/gitlab.go
@@ -33,7 +33,7 @@ func main() {
 
 	_ = gitlabCmd.MarkFlagRequired("project-id")
 	gitlabCmd.Run = func(cmd *cobra.Command, args []string) {
-		runner.DirectRun(cmd, args, PluginEntry, map[string]interface{}{
+		runner.DirectRun(cmd, args, PluginEntry, []string{}, map[string]interface{}{
 			"projectId": *projectId,
 		})
 	}

--- a/plugins/jenkins/jenkins.go
+++ b/plugins/jenkins/jenkins.go
@@ -102,7 +102,7 @@ var PluginEntry Jenkins //nolint
 func main() {
 	jenkinsCmd := &cobra.Command{Use: "jenkins"}
 	jenkinsCmd.Run = func(cmd *cobra.Command, args []string) {
-		runner.DirectRun(cmd, args, PluginEntry, map[string]interface{}{})
+		runner.DirectRun(cmd, args, PluginEntry, []string{}, map[string]interface{}{})
 	}
 	runner.RunCmd(jenkinsCmd)
 }

--- a/plugins/jira/jira.go
+++ b/plugins/jira/jira.go
@@ -217,7 +217,7 @@ func main() {
 	_ = cmd.MarkFlagRequired("connection")
 	_ = cmd.MarkFlagRequired("board")
 	cmd.Run = func(c *cobra.Command, args []string) {
-		runner.DirectRun(c, args, PluginEntry, map[string]interface{}{
+		runner.DirectRun(c, args, PluginEntry, []string{}, map[string]interface{}{
 			"connectionId": *connectionId,
 			"boardId":      *boardId,
 		})

--- a/plugins/refdiff/refdiff.go
+++ b/plugins/refdiff/refdiff.go
@@ -88,7 +88,7 @@ func main() {
 	_ = refdiffCmd.MarkFlagRequired("old-ref")
 
 	refdiffCmd.Run = func(cmd *cobra.Command, args []string) {
-		runner.DirectRun(cmd, args, PluginEntry, map[string]interface{}{
+		runner.DirectRun(cmd, args, PluginEntry, []string{}, map[string]interface{}{
 			"repoId": repoId,
 			"pairs": []map[string]string{
 				{

--- a/plugins/tapd/tapd.go
+++ b/plugins/tapd/tapd.go
@@ -202,7 +202,7 @@ func main() {
 		panic(err)
 	}
 	cmd.Run = func(c *cobra.Command, args []string) {
-		runner.DirectRun(c, args, PluginEntry, map[string]interface{}{
+		runner.DirectRun(c, args, PluginEntry, []string{}, map[string]interface{}{
 			"connectionId": *connectionId,
 			"workspaceId":  *workspaceId,
 			"companyId":    *companyId,

--- a/runner/directrun.go
+++ b/runner/directrun.go
@@ -29,7 +29,7 @@ import (
 )
 
 func RunCmd(cmd *cobra.Command) {
-	cmd.Flags().StringSliceP("tasks", "t", nil, "specify what tasks to run, --tasks=collectIssues,extractIssues")
+	cmd.Flags().StringSliceP("subtasks", "t", nil, "specify what tasks to run, --subtasks=collectIssues,extractIssues")
 	err := cmd.Execute()
 	if err != nil {
 		panic(err)
@@ -41,12 +41,12 @@ func RunCmd(cmd *cobra.Command) {
 // args: command line arguments
 // pluginTask: specific built-in plugin, for example: feishu, jira...
 // options: plugin config
-func DirectRun(cmd *cobra.Command, args []string, pluginTask core.PluginTask, options map[string]interface{}) {
-	tasks, err := cmd.Flags().GetStringSlice("tasks")
+func DirectRun(cmd *cobra.Command, args []string, pluginTask core.PluginTask, subtasks []string, options map[string]interface{}) {
+	tasks, err := cmd.Flags().GetStringSlice("subtasks")
 	if err != nil {
 		panic(err)
 	}
-	options["tasks"] = tasks
+	subtasks = tasks
 	cfg := config.GetConfig()
 	log := logger.Global.Nested(cmd.Use)
 	db, err := NewGormDb(cfg, log)
@@ -91,6 +91,7 @@ func DirectRun(cmd *cobra.Command, args []string, pluginTask core.PluginTask, op
 		db,
 		ctx,
 		cmd.Use,
+		subtasks,
 		options,
 		pluginTask,
 		nil,

--- a/services/task.go
+++ b/services/task.go
@@ -131,8 +131,14 @@ func CreateTask(newTask *models.NewTask) (*models.Task, error) {
 	if err != nil {
 		return nil, err
 	}
+	s, err := json.Marshal(newTask.Subtasks)
+	if err != nil {
+		return nil, err
+	}
+
 	task := models.Task{
 		Plugin:      newTask.Plugin,
+		Subtasks:    s,
 		Options:     b,
 		Status:      models.TASK_CREATED,
 		Message:     "",


### PR DESCRIPTION
# Summary
fix #1412: rename tasks field from pipeline and move it to higher level
1. tasks->subtasks
2. add subtasks field to higher level
3. add migration scripts

### Screenshots
![image](https://user-images.githubusercontent.com/101256042/171548256-07a90958-8430-4f3b-8512-8ece679e5492.png)

