### PR TITLE
Add TagsPattern for use Pattern in refdiff

### DIFF
--- a/plugins/refdiff/README.md
+++ b/plugins/refdiff/README.md
@@ -85,7 +85,7 @@ and if you want to perform certain subtasks.
 ]
 ```
 Or you can use tagsPattern to match the tags you want
-And you can use tagOrder (support `alphabetically` and `reverse alphabetically`) to set the order rule with tagLimit to limit the count of matching.
+And you can use tagOrder (support `alphabetically`,`reverse alphabetically`,`semver`,`reverse semver`) to set the order rule with tagLimit to limit the count of matching.
 This is support to calculateCommitsDiff and calculateIssuesDiff
 ```json
 [
@@ -100,7 +100,7 @@ This is support to calculateCommitsDiff and calculateIssuesDiff
         "repoId": "github:GithubRepo:384111310",
         "tagsPattern":".*\\.11\\..*",
         "tagLimit":3,
-        "tagOrder":"reverse alphabetically",
+        "tagOrder":"reverse semver",
       }
     }
   ]

--- a/plugins/refdiff/README.md
+++ b/plugins/refdiff/README.md
@@ -1,10 +1,4 @@
 # RefDiff
-
-
-| [English](README.md) | [中文](README-zh-CN.md) |
-| --- | --- |
-
-
 ## Summary
 
 For development workload analysis, we often need to know how many commits have been created between 2 releases. This plugin offers the ability to calculate the commits of difference between 2 Ref(branch/tag), and the result will be stored back into database for further analysis.
@@ -85,6 +79,28 @@ and if you want to perform certain subtasks.
             "oldRef": "refs/tags/0.4.0"
           }
         ]
+      }
+    }
+  ]
+]
+```
+Or you can use tagsPattern to match the tags you want
+And you can use tagOrder (support `alphabetically` and `reverse alphabetically`) to set the order rule with tagLimit to limit the count of matching.
+This is support to calculateCommitsDiff and calculateIssuesDiff
+```json
+[
+  [
+    {
+      "plugin": "refdiff",
+      "subtasks": [
+        "calculateCommitsDiff",
+        "calculateIssuesDiff",
+      ],
+      "options": {
+        "repoId": "github:GithubRepo:384111310",
+        "tagsPattern":".*\\.11\\..*",
+        "tagLimit":3,
+        "tagOrder":"reverse alphabetically",
       }
     }
   ]

--- a/plugins/refdiff/refdiff.go
+++ b/plugins/refdiff/refdiff.go
@@ -94,7 +94,10 @@ func main() {
 	//_ = refdiffCmd.MarkFlagRequired("old-ref")
 
 	refdiffCmd.Run = func(cmd *cobra.Command, args []string) {
-		tl, _ := strconv.Atoi(*tagsLimit)
+		tl, err := strconv.Atoi(*tagsLimit)
+		if err != nil {
+			panic(err)
+		}
 		pairs := make([]map[string]string, 0, 1)
 		if *newRef == "" && *oldRef == "" {
 			if *tagsPattern == "" {

--- a/plugins/refdiff/refdiff.go
+++ b/plugins/refdiff/refdiff.go
@@ -64,6 +64,16 @@ func (plugin RefDiff) PrepareTaskData(taskCtx core.TaskContext, options map[stri
 		return nil, err
 	}
 
+	db := taskCtx.GetDb()
+	tagsPattern := op.TagsPattern
+	tagsLimit := op.TagsLimit
+	tagsOrder := op.TagsOrder
+
+	op.TagsRefs, err = tasks.CaculateTagPattern(db, tagsPattern, tagsLimit, tagsOrder)
+	if err != nil {
+		return nil, err
+	}
+
 	return &tasks.RefdiffTaskData{
 		Options: &op,
 	}, nil

--- a/plugins/refdiff/refdiff.go
+++ b/plugins/refdiff/refdiff.go
@@ -18,8 +18,6 @@ limitations under the License.
 package main
 
 import (
-	"strconv"
-
 	"github.com/apache/incubator-devlake/plugins/refdiff/tasks"
 	"github.com/apache/incubator-devlake/runner"
 	"github.com/mitchellh/mapstructure"
@@ -96,7 +94,7 @@ func main() {
 	oldRef := refdiffCmd.Flags().StringP("old-ref", "o", "", "old ref")
 
 	tagsPattern := refdiffCmd.Flags().StringP("tags-pattern", "p", "", "tags pattern")
-	tagsLimit := refdiffCmd.Flags().StringP("tags-limit", "l", "", "tags limit")
+	tagsLimit := refdiffCmd.Flags().IntP("tags-limit", "l", 2, "tags limit")
 	tagsOrder := refdiffCmd.Flags().StringP("tags-order", "d", "", "tags order")
 
 	_ = refdiffCmd.MarkFlagRequired("repo-id")
@@ -104,10 +102,6 @@ func main() {
 	//_ = refdiffCmd.MarkFlagRequired("old-ref")
 
 	refdiffCmd.Run = func(cmd *cobra.Command, args []string) {
-		tl, err := strconv.Atoi(*tagsLimit)
-		if err != nil {
-			panic(err)
-		}
 		pairs := make([]map[string]string, 0, 1)
 		if *newRef == "" && *oldRef == "" {
 			if *tagsPattern == "" {
@@ -124,7 +118,7 @@ func main() {
 			"repoId":      repoId,
 			"pairs":       pairs,
 			"tagsPattern": *tagsPattern,
-			"tagsLimit":   tl,
+			"tagsLimit":   *tagsLimit,
 			"tagsOrder":   *tagsOrder,
 		})
 	}

--- a/plugins/refdiff/refdiff.go
+++ b/plugins/refdiff/refdiff.go
@@ -62,12 +62,16 @@ func (plugin RefDiff) PrepareTaskData(taskCtx core.TaskContext, options map[stri
 		return nil, err
 	}
 
-	db := taskCtx.GetDb()
+	db := taskCtx.GetDal()
 	tagsPattern := op.TagsPattern
 	tagsLimit := op.TagsLimit
 	tagsOrder := op.TagsOrder
 
-	op.TagsRefs, err = tasks.CaculateTagPattern(db, tagsPattern, tagsLimit, tagsOrder)
+	rs, err := tasks.CaculateTagPattern(db, tagsPattern, tagsLimit, tagsOrder)
+	if err != nil {
+		return nil, err
+	}
+	op.AllPairs, err = tasks.CalculateCommitPairs(db, op.RepoId, op.Pairs, rs)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/refdiff/tasks/ref_commit_diff_calculator.go
+++ b/plugins/refdiff/tasks/ref_commit_diff_calculator.go
@@ -32,19 +32,11 @@ func CalculateCommitsPairs(taskCtx core.SubTaskContext) (RefCommitPairs, error) 
 	data := taskCtx.GetData().(*RefdiffTaskData)
 	repoId := data.Options.RepoId
 	pairs := data.Options.Pairs
-	tagsLimit := data.Options.TagsLimit
+	rs := data.Options.TagsRefs
 	db := taskCtx.GetDb()
 
-	rs, err := CaculateTagPattern(taskCtx)
-	if err != nil {
-		return RefCommitPairs{}, err
-	}
-	if tagsLimit > rs.Len() {
-		tagsLimit = rs.Len()
-	}
-
-	commitPairs := make(RefCommitPairs, 0, tagsLimit+len(pairs))
-	for i := 1; i < tagsLimit; i++ {
+	commitPairs := make(RefCommitPairs, 0, len(rs)+len(pairs))
+	for i := 1; i < len(rs); i++ {
 		commitPairs = append(commitPairs, [4]string{rs[i-1].CommitSha, rs[i].CommitSha, rs[i-1].Name, rs[i].Name})
 	}
 

--- a/plugins/refdiff/tasks/ref_commit_diff_calculator.go
+++ b/plugins/refdiff/tasks/ref_commit_diff_calculator.go
@@ -27,6 +27,7 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+// Calculate the commits pairs both from Options.Pairs and TagPattern
 func CalculateCommitsPairs(taskCtx core.SubTaskContext) ([][4]string, error) {
 	data := taskCtx.GetData().(*RefdiffTaskData)
 	repoId := data.Options.RepoId

--- a/plugins/refdiff/tasks/ref_commit_diff_calculator.go
+++ b/plugins/refdiff/tasks/ref_commit_diff_calculator.go
@@ -28,7 +28,7 @@ import (
 )
 
 // Calculate the commits pairs both from Options.Pairs and TagPattern
-func CalculateCommitsPairs(taskCtx core.SubTaskContext) ([][4]string, error) {
+func CalculateCommitsPairs(taskCtx core.SubTaskContext) (RefCommitPairs, error) {
 	data := taskCtx.GetData().(*RefdiffTaskData)
 	repoId := data.Options.RepoId
 	pairs := data.Options.Pairs
@@ -37,13 +37,13 @@ func CalculateCommitsPairs(taskCtx core.SubTaskContext) ([][4]string, error) {
 
 	rs, err := CaculateTagPattern(taskCtx)
 	if err != nil {
-		return [][4]string{}, err
+		return RefCommitPairs{}, err
 	}
 	if tagsLimit > rs.Len() {
 		tagsLimit = rs.Len()
 	}
 
-	commitPairs := make([][4]string, 0, tagsLimit+len(pairs))
+	commitPairs := make(RefCommitPairs, 0, tagsLimit+len(pairs))
 	for i := 1; i < tagsLimit; i++ {
 		commitPairs = append(commitPairs, [4]string{rs[i-1].CommitSha, rs[i].CommitSha, rs[i-1].Name, rs[i].Name})
 	}
@@ -67,14 +67,14 @@ func CalculateCommitsPairs(taskCtx core.SubTaskContext) ([][4]string, error) {
 		// get new ref's commit sha
 		newCommit, err := ref2sha(refPair.NewRef)
 		if err != nil {
-			return [][4]string{}, fmt.Errorf("failed to load commit sha for NewRef on pair #%d: %w", i, err)
+			return RefCommitPairs{}, fmt.Errorf("failed to load commit sha for NewRef on pair #%d: %w", i, err)
 		}
 		// get old ref's commit sha
 		oldCommit, err := ref2sha(refPair.OldRef)
 		if err != nil {
-			return [][4]string{}, fmt.Errorf("failed to load commit sha for OleRef on pair #%d: %w", i, err)
+			return RefCommitPairs{}, fmt.Errorf("failed to load commit sha for OleRef on pair #%d: %w", i, err)
 		}
-		commitPairs = append(commitPairs, [4]string{newCommit, oldCommit, refPair.NewRef, refPair.OldRef})
+		commitPairs = append(commitPairs, RefCommitPair{newCommit, oldCommit, refPair.NewRef, refPair.OldRef})
 	}
 
 	return commitPairs, nil

--- a/plugins/refdiff/tasks/ref_issue_diff_calculator.go
+++ b/plugins/refdiff/tasks/ref_issue_diff_calculator.go
@@ -31,18 +31,10 @@ func CaculatePairList(taskCtx core.SubTaskContext) (RefPairLists, error) {
 	data := taskCtx.GetData().(*RefdiffTaskData)
 	repoId := data.Options.RepoId
 	pairs := data.Options.Pairs
-	tagsLimit := data.Options.TagsLimit
+	rs := data.Options.TagsRefs
 
-	rs, err := CaculateTagPattern(taskCtx)
-	if err != nil {
-		return RefPairLists{}, err
-	}
-	if tagsLimit > rs.Len() {
-		tagsLimit = rs.Len()
-	}
-
-	pairList := make(RefPairLists, 0, tagsLimit+len(pairs))
-	for i := 1; i < tagsLimit; i++ {
+	pairList := make(RefPairLists, 0, len(rs)+len(pairs))
+	for i := 1; i < len(rs); i++ {
 		pairList = append(pairList, RefPairList{fmt.Sprintf("%s:%s", repoId, rs[i-1].Id), fmt.Sprintf("%s:%s", repoId, rs[i].Id)})
 	}
 

--- a/plugins/refdiff/tasks/ref_issue_diff_calculator.go
+++ b/plugins/refdiff/tasks/ref_issue_diff_calculator.go
@@ -26,20 +26,16 @@ import (
 	"github.com/apache/incubator-devlake/plugins/helper"
 )
 
-// Calculate the pair list both from Options.Pairs and TagPattern
+// CaculatePairList Calculate the pair list both from Options.Pairs and TagPattern
 func CaculatePairList(taskCtx core.SubTaskContext) (RefPairLists, error) {
 	data := taskCtx.GetData().(*RefdiffTaskData)
 	repoId := data.Options.RepoId
-	pairs := data.Options.Pairs
-	rs := data.Options.TagsRefs
+	pairs := data.Options.AllPairs
 
-	pairList := make(RefPairLists, 0, len(rs)+len(pairs))
-	for i := 1; i < len(rs); i++ {
-		pairList = append(pairList, RefPairList{fmt.Sprintf("%s:%s", repoId, rs[i-1].Id), fmt.Sprintf("%s:%s", repoId, rs[i].Id)})
-	}
+	pairList := make(RefPairLists, 0, len(pairs))
 
 	for _, pair := range pairs {
-		pairList = append(pairList, RefPairList{fmt.Sprintf("%s:%s", repoId, pair.NewRef), fmt.Sprintf("%s:%s", repoId, pair.OldRef)})
+		pairList = append(pairList, RefPairList{fmt.Sprintf("%s:%s", repoId, pair[2]), fmt.Sprintf("%s:%s", repoId, pair[3])})
 	}
 
 	return pairList, nil

--- a/plugins/refdiff/tasks/ref_issue_diff_calculator.go
+++ b/plugins/refdiff/tasks/ref_issue_diff_calculator.go
@@ -27,7 +27,7 @@ import (
 )
 
 // Calculate the pair list both from Options.Pairs and TagPattern
-func CaculatePairList(taskCtx core.SubTaskContext) ([][2]string, error) {
+func CaculatePairList(taskCtx core.SubTaskContext) (RefPairLists, error) {
 	data := taskCtx.GetData().(*RefdiffTaskData)
 	repoId := data.Options.RepoId
 	pairs := data.Options.Pairs
@@ -35,19 +35,19 @@ func CaculatePairList(taskCtx core.SubTaskContext) ([][2]string, error) {
 
 	rs, err := CaculateTagPattern(taskCtx)
 	if err != nil {
-		return [][2]string{}, err
+		return RefPairLists{}, err
 	}
 	if tagsLimit > rs.Len() {
 		tagsLimit = rs.Len()
 	}
 
-	pairList := make([][2]string, 0, tagsLimit+len(pairs))
+	pairList := make(RefPairLists, 0, tagsLimit+len(pairs))
 	for i := 1; i < tagsLimit; i++ {
-		pairList = append(pairList, [2]string{fmt.Sprintf("%s:%s", repoId, rs[i-1].Id), fmt.Sprintf("%s:%s", repoId, rs[i].Id)})
+		pairList = append(pairList, RefPairList{fmt.Sprintf("%s:%s", repoId, rs[i-1].Id), fmt.Sprintf("%s:%s", repoId, rs[i].Id)})
 	}
 
 	for _, pair := range pairs {
-		pairList = append(pairList, [2]string{fmt.Sprintf("%s:%s", repoId, pair.NewRef), fmt.Sprintf("%s:%s", repoId, pair.OldRef)})
+		pairList = append(pairList, RefPairList{fmt.Sprintf("%s:%s", repoId, pair.NewRef), fmt.Sprintf("%s:%s", repoId, pair.OldRef)})
 	}
 
 	return pairList, nil

--- a/plugins/refdiff/tasks/ref_issue_diff_calculator.go
+++ b/plugins/refdiff/tasks/ref_issue_diff_calculator.go
@@ -26,6 +26,7 @@ import (
 	"github.com/apache/incubator-devlake/plugins/helper"
 )
 
+// Calculate the pair list both from Options.Pairs and TagPattern
 func CaculatePairList(taskCtx core.SubTaskContext) ([][2]string, error) {
 	data := taskCtx.GetData().(*RefdiffTaskData)
 	repoId := data.Options.RepoId

--- a/plugins/refdiff/tasks/refdiff_task_data.go
+++ b/plugins/refdiff/tasks/refdiff_task_data.go
@@ -18,13 +18,23 @@ limitations under the License.
 package tasks
 
 import (
+	"fmt"
+	"regexp"
+	"sort"
 	"time"
+
+	"github.com/apache/incubator-devlake/models/domainlayer/code"
+	"github.com/apache/incubator-devlake/plugins/core"
 )
 
 type RefdiffOptions struct {
 	RepoId string
 	Tasks  []string `json:"tasks,omitempty"`
 	Pairs  []RefPair
+
+	TagsPattern string
+	TagsLimit   int
+	TagsOrder   string
 }
 
 type RefdiffTaskData struct {
@@ -35,4 +45,78 @@ type RefdiffTaskData struct {
 type RefPair struct {
 	NewRef string
 	OldRef string
+}
+
+type Refs []code.Ref
+type RefsAlphabetically Refs
+type RefsReverseAlphabetically Refs
+
+func (rs Refs) Len() int {
+	return len(rs)
+}
+
+func (rs RefsAlphabetically) Len() int {
+	return len(rs)
+}
+
+func (rs RefsAlphabetically) Less(i, j int) bool {
+	return rs[i].Id < rs[j].Id
+}
+
+func (rs RefsAlphabetically) Swap(i, j int) {
+	rs[i], rs[j] = rs[j], rs[i]
+}
+
+func (rs RefsReverseAlphabetically) Len() int {
+	return len(rs)
+}
+
+func (rs RefsReverseAlphabetically) Less(i, j int) bool {
+	return rs[i].Id > rs[j].Id
+}
+
+func (rs RefsReverseAlphabetically) Swap(i, j int) {
+	rs[i], rs[j] = rs[j], rs[i]
+}
+
+func CaculateTagPattern(taskCtx core.SubTaskContext) (Refs, error) {
+	rs := Refs{}
+	data := taskCtx.GetData().(*RefdiffTaskData)
+	tagsPattern := data.Options.TagsPattern
+	tagsOrder := data.Options.TagsOrder
+	db := taskCtx.GetDb()
+
+	// caculate Pattern part
+	if data.Options.TagsPattern == "" || data.Options.TagsLimit <= 1 {
+		return rs, nil
+	}
+	rows, err := db.Model(&code.Ref{}).Order("created_date desc").Rows()
+	if err != nil {
+		return rs, err
+	}
+	defer rows.Next()
+	r, err := regexp.Compile(tagsPattern)
+	if err != nil {
+		return rs, fmt.Errorf("unable to parse: %s\r\n%s", tagsPattern, err.Error())
+	}
+	for rows.Next() {
+		var ref code.Ref
+		err = db.ScanRows(rows, &ref)
+		if err != nil {
+			return rs, err
+		}
+
+		if ok := r.Match([]byte(ref.Id)); ok {
+			rs = append(rs, ref)
+		}
+	}
+	switch tagsOrder {
+	case "alphabetically":
+		sort.Sort(RefsAlphabetically(rs))
+	case "reverse alphabetically":
+		sort.Sort(RefsReverseAlphabetically(rs))
+	default:
+		break
+	}
+	return rs, nil
 }

--- a/plugins/refdiff/tasks/refdiff_task_data.go
+++ b/plugins/refdiff/tasks/refdiff_task_data.go
@@ -32,9 +32,9 @@ type RefdiffOptions struct {
 	Tasks  []string `json:"tasks,omitempty"`
 	Pairs  []RefPair
 
-	TagsPattern string
-	TagsLimit   int
-	TagsOrder   string
+	TagsPattern string // The Pattern to match from all tags
+	TagsLimit   int    // How many tags be matched should be used.
+	TagsOrder   string // The Rule to Order the tag list
 }
 
 type RefdiffTaskData struct {
@@ -79,6 +79,7 @@ func (rs RefsReverseAlphabetically) Swap(i, j int) {
 	rs[i], rs[j] = rs[j], rs[i]
 }
 
+// Calculate the TagPattern order by tagsOrder and return the Refs
 func CaculateTagPattern(taskCtx core.SubTaskContext) (Refs, error) {
 	rs := Refs{}
 	data := taskCtx.GetData().(*RefdiffTaskData)

--- a/plugins/refdiff/tasks/refdiff_task_data.go
+++ b/plugins/refdiff/tasks/refdiff_task_data.go
@@ -46,6 +46,10 @@ type RefPair struct {
 	NewRef string
 	OldRef string
 }
+type RefCommitPair [4]string
+type RefPairList [2]string
+type RefCommitPairs []RefCommitPair
+type RefPairLists []RefPairList
 
 type Refs []code.Ref
 type RefsAlphabetically Refs


### PR DESCRIPTION
# Summary
Add TagsPattern to set Pattern for refdiff
Add TagsLimit to limit the count of TagsPattern matching.
Add TagsOrder to set the order rule for  list of TagsPattern  matching.
Add surpport of DirctRun for new param. 
Optimize partial logs
The TagsPattern support CalculateIssuesDiff and CalculateCommitsDiff.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Does this close any open issues?
close #1983 

### Screenshots
![image](https://user-images.githubusercontent.com/2921251/172193821-afae87a3-cf89-49d4-b67e-d930a3bf127c.png)
![image](https://user-images.githubusercontent.com/2921251/172193936-68db23e8-56ab-4297-83eb-414df4f8acf0.png)

![image](https://user-images.githubusercontent.com/2921251/172194173-bf5ccf03-322d-418f-b8c7-2356a7b6e2d0.png)
![image](https://user-images.githubusercontent.com/2921251/172194234-ec4dc412-0125-41c8-a19b-4d2f45661eec.png)

### Other Information
Any other information that is important to this PR.
