### PR TITLE
fix: minor fix for golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ lint:
 	golangci-lint run
 
 fmt:
-	find -name \*.go | xargs gofmt -w -l
+	find . -name \*.go | xargs gofmt -s -w -l
 
 clean:
 	@rm -rf bin

--- a/plugins/jira/models/migrationscripts/updateSchemas20220601.go
+++ b/plugins/jira/models/migrationscripts/updateSchemas20220601.go
@@ -62,7 +62,7 @@ func (*UpdateSchemas20220601) Up(ctx context.Context, db *gorm.DB) error {
 		if err != nil {
 			return err
 		}
-		for i, _ := range connections {
+		for i := range connections {
 			err = helper.DecryptConnection(connections[i])
 			if err != nil {
 				return err


### PR DESCRIPTION
- fix `make fmt` under macos
- add gofmt `-s` options for aligning golang-ci's

Signed-off-by: Ji Bin <matrixji@live.com>

# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Does this close any open issues?
Not. Related: #2099 

### Screenshots
N/A

### Other Information
N/A
