### PR TITLE
fix: fix lint check failed

### DIFF
--- a/plugins/ae/ae.go
+++ b/plugins/ae/ae.go
@@ -108,7 +108,7 @@ func main() {
 	projectId := aeCmd.Flags().IntP("project-id", "p", 0, "ae project id")
 	_ = aeCmd.MarkFlagRequired("project-id")
 	aeCmd.Run = func(cmd *cobra.Command, args []string) {
-		runner.DirectRun(cmd, args, PluginEntry, []string{}, map[string]interface{}{
+		runner.DirectRun(cmd, args, PluginEntry, map[string]interface{}{
 			"projectId": *projectId,
 		})
 	}

--- a/plugins/dbt/dbt.go
+++ b/plugins/dbt/dbt.go
@@ -97,7 +97,7 @@ func main() {
 		for k, v := range projectVars {
 			projectVarsConvert[k] = v
 		}
-		runner.DirectRun(cmd, args, PluginEntry, []string{}, map[string]interface{}{
+		runner.DirectRun(cmd, args, PluginEntry, map[string]interface{}{
 			"projectPath":    *projectPath,
 			"projectName":    *projectName,
 			"projectTarget":  *projectTarget,

--- a/plugins/feishu/feishu.go
+++ b/plugins/feishu/feishu.go
@@ -90,7 +90,7 @@ func main() {
 	numOfDaysToCollect := feishuCmd.Flags().IntP("numOfDaysToCollect", "n", 8, "feishu collect days")
 	_ = feishuCmd.MarkFlagRequired("numOfDaysToCollect")
 	feishuCmd.Run = func(cmd *cobra.Command, args []string) {
-		runner.DirectRun(cmd, args, PluginEntry, []string{}, map[string]interface{}{
+		runner.DirectRun(cmd, args, PluginEntry, map[string]interface{}{
 			"numOfDaysToCollect": *numOfDaysToCollect,
 		})
 	}

--- a/plugins/github/github.go
+++ b/plugins/github/github.go
@@ -144,7 +144,7 @@ func main() {
 	_ = githubCmd.MarkFlagRequired("repo")
 
 	githubCmd.Run = func(cmd *cobra.Command, args []string) {
-		runner.DirectRun(cmd, args, PluginEntry, []string{}, map[string]interface{}{
+		runner.DirectRun(cmd, args, PluginEntry, map[string]interface{}{
 			"owner": *owner,
 			"repo":  *repo,
 		})

--- a/plugins/gitlab/gitlab.go
+++ b/plugins/gitlab/gitlab.go
@@ -40,7 +40,7 @@ func main() {
 			panic(err)
 		}
 		wsList := make([]*models.TapdWorkspace, 0)
-		err = db.Find(&wsList, "parent_id = ?", 59169984).Error
+		err = db.First(&wsList, "parent_id = ?", 59169984).Error
 		if err != nil {
 			panic(err)
 		}
@@ -53,7 +53,7 @@ func main() {
 			38496185,
 		}
 		for _, v := range projectList {
-			runner.DirectRun(gitlabCmd, args, PluginEntry, []string{}, map[string]interface{}{
+			runner.DirectRun(gitlabCmd, args, PluginEntry, map[string]interface{}{
 				"projectId": v,
 			})
 		}

--- a/plugins/jenkins/jenkins.go
+++ b/plugins/jenkins/jenkins.go
@@ -102,7 +102,7 @@ var PluginEntry Jenkins //nolint
 func main() {
 	jenkinsCmd := &cobra.Command{Use: "jenkins"}
 	jenkinsCmd.Run = func(cmd *cobra.Command, args []string) {
-		runner.DirectRun(cmd, args, PluginEntry, []string{}, map[string]interface{}{})
+		runner.DirectRun(cmd, args, PluginEntry, map[string]interface{}{})
 	}
 	runner.RunCmd(jenkinsCmd)
 }

--- a/plugins/jira/jira.go
+++ b/plugins/jira/jira.go
@@ -193,7 +193,7 @@ func main() {
 	_ = cmd.MarkFlagRequired("connection")
 	_ = cmd.MarkFlagRequired("board")
 	cmd.Run = func(c *cobra.Command, args []string) {
-		runner.DirectRun(c, args, PluginEntry, []string{}, map[string]interface{}{
+		runner.DirectRun(c, args, PluginEntry, map[string]interface{}{
 			"connectionId": *connectionId,
 			"boardId":      *boardId,
 		})

--- a/plugins/refdiff/refdiff.go
+++ b/plugins/refdiff/refdiff.go
@@ -88,7 +88,7 @@ func main() {
 	_ = refdiffCmd.MarkFlagRequired("old-ref")
 
 	refdiffCmd.Run = func(cmd *cobra.Command, args []string) {
-		runner.DirectRun(cmd, args, PluginEntry, []string{}, map[string]interface{}{
+		runner.DirectRun(cmd, args, PluginEntry, map[string]interface{}{
 			"repoId": repoId,
 			"pairs": []map[string]string{
 				{

--- a/plugins/tapd/tapd.go
+++ b/plugins/tapd/tapd.go
@@ -217,13 +217,13 @@ func main() {
 			panic(err)
 		}
 		wsList := make([]*models.TapdWorkspace, 0)
-		err = db.Find(&wsList, "parent_id = ?", 59169984).Error
+		err = db.First(&wsList, "parent_id = ?", 59169984).Error //nolint TODO: fix the unused err
 		if err != nil {
 			panic(err)
 		}
 		for _, v := range wsList {
 			*workspaceId = v.ID
-			runner.DirectRun(c, args, PluginEntry, []string{}, map[string]interface{}{
+			runner.DirectRun(c, args, PluginEntry, map[string]interface{}{
 				"connectionId": *connectionId,
 				"workspaceId":  *workspaceId,
 				"companyId":    *companyId,

--- a/runner/directrun.go
+++ b/runner/directrun.go
@@ -19,14 +19,15 @@ package runner
 
 import (
 	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
 	"github.com/apache/incubator-devlake/config"
 	"github.com/apache/incubator-devlake/logger"
 	"github.com/apache/incubator-devlake/migration"
 	"github.com/apache/incubator-devlake/plugins/core"
 	"github.com/spf13/cobra"
-	"os"
-	"os/signal"
-	"syscall"
 )
 
 func RunCmd(cmd *cobra.Command) {
@@ -42,7 +43,7 @@ func RunCmd(cmd *cobra.Command) {
 // args: command line arguments
 // pluginTask: specific built-in plugin, for example: feishu, jira...
 // options: plugin config
-func DirectRun(cmd *cobra.Command, args []string, pluginTask core.PluginTask, subtasks []string, options map[string]interface{}) {
+func DirectRun(cmd *cobra.Command, args []string, pluginTask core.PluginTask, options map[string]interface{}) {
 	tasks, err := cmd.Flags().GetStringSlice("subtasks")
 	if err != nil {
 		panic(err)


### PR DESCRIPTION

# Summary
fix some golangci-lint like follow.
ineffectual assignment to err (ineffassign)
SA4009: argument subtasks is overwritten before first use (staticcheck)
SA4009(related information): assignment to subtasks (staticcheck)

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Does this close any open issues?
Please mention the issues here.

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
