### PR TITLE
chore: create alpine-dbt-mysql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,15 +27,7 @@ ENV GOBIN=/app/bin
 
 RUN make clean && make all
 
-FROM --platform=linux/amd64 alpine:3.15
-RUN apk add --no-cache musl-dev libgit2-dev libffi-dev \
-    && apk add --no-cache gcc
-
-ENV PYTHONUNBUFFERED=1
-RUN apk add --update --no-cache python3-dev && ln -sf python3 /usr/bin/python
-RUN python3 -m ensurepip
-RUN pip3 install --no-cache --upgrade pip setuptools
-RUN pip3 install dbt-mysql
+FROM --platform=linux/amd64 mericodev/alpine-dbt-mysql:0.0.1
 
 EXPOSE 8080
 

--- a/devops/alpine-dbt-mysql/Dockerfile
+++ b/devops/alpine-dbt-mysql/Dockerfile
@@ -1,0 +1,10 @@
+FROM --platform=linux/amd64 alpine:3.15
+RUN apk add --no-cache musl-dev libgit2-dev libffi-dev \
+    && apk add --no-cache gcc
+
+ENV PYTHONUNBUFFERED=1
+RUN apk add --update --no-cache python3-dev && ln -sf python3 /usr/bin/python
+RUN python3 -m ensurepip
+RUN pip3 install --no-cache --upgrade pip setuptools
+RUN pip3 install dbt-mysql
+RUN apk add --no-cache tar

--- a/devops/alpine-dbt-mysql/Dockerfile
+++ b/devops/alpine-dbt-mysql/Dockerfile
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# current tag: mericodev/alpine-dbt-mysql:0.0.1
 FROM --platform=linux/amd64 alpine:3.15
 RUN apk add --no-cache musl-dev libgit2-dev libffi-dev \
     && apk add --no-cache gcc

--- a/devops/alpine-dbt-mysql/README.md
+++ b/devops/alpine-dbt-mysql/README.md
@@ -1,0 +1,11 @@
+# alpine-dbt-mysql
+alpine linux image with dbt-mysql installed
+
+https://hub.docker.com/r/mericodev/alpine-dbt-mysql
+
+## release
+```shell
+export VERSION=0.0.1
+docker build -t mericodev/alpine-dbt-mysql:$VERSION .
+docker push mericodev/alpine-dbt-mysql:$VERSION
+```

--- a/devops/lake-builder/Dockerfile
+++ b/devops/lake-builder/Dockerfile
@@ -20,5 +20,4 @@ FROM golang:1.17-alpine3.15 as builder
 RUN apk update
 RUN apk upgrade
 #RUN apk add --update gcc=130.2.1_pre1-r3 g++=10.2.1_pre1-r3
-RUN apk add --no-cache tzdata libgit2-dev gcc g++ make
-RUN apk add --no-cache tar
+RUN apk add --no-cache tzdata libgit2-dev gcc g++ make tar


### PR DESCRIPTION
# Summary
preinstall python and dbt-mysql in mericodev/alpine-dbt-mysql image.
to prevent install it every time we release lake

### Does this close any open issues?
fix #1692

### Screenshots
Include any relevant screenshots here.

### Other Information
Before merge this PR, we should push image `mericodev/alpine-dbt-mysql` to docker hub.
