### PR TITLE
fix(ci): remove add tar in github action and modify lake-builder image

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -24,10 +24,8 @@ jobs:
           MYSQL_USER: merico
           MYSQL_PASSWORD: merico
           MYSQL_ROOT_PASSWORD: root
-    container: mericodev/lake-builder:0.0.4
+    container: mericodev/lake-builder:0.0.5
     steps:
-      - run: |
-          apk add --no-cache tar
       - uses: actions/checkout@v3
       - name: Cache test-e2e
         id: cache-test-e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,8 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     container:
-      image: mericodev/lake-builder:0.0.4
+      image: mericodev/lake-builder:0.0.5
     steps:
-    - run: |
-        apk add --no-cache tar
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Setup Golang env

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM mericodev/lake-builder:0.0.4 as builder
+FROM mericodev/lake-builder:0.0.5 as builder
 
 # docker build --build-arg GOPROXY=https://goproxy.io,direct -t mericodev/lake .
 ARG GOPROXY=
@@ -36,7 +36,6 @@ RUN apk add --update --no-cache python3-dev && ln -sf python3 /usr/bin/python
 RUN python3 -m ensurepip
 RUN pip3 install --no-cache --upgrade pip setuptools
 RUN pip3 install dbt-mysql
-RUN apk add --no-cache tar
 
 EXPOSE 8080
 

--- a/devops/lake-builder/Dockerfile
+++ b/devops/lake-builder/Dockerfile
@@ -14,10 +14,11 @@
 # limitations under the License.
 #
 
-# current tag: mericodev/lake-builder:0.0.4
+# current tag: mericodev/lake-builder:0.0.5
 FROM golang:1.17-alpine3.15 as builder
 #RUN set -eux && sed -i 's/dl-cdn.alpinelinux.org/mirrors.ustc.edu.cn/g' /etc/apk/repositories
 RUN apk update
 RUN apk upgrade
 #RUN apk add --update gcc=130.2.1_pre1-r3 g++=10.2.1_pre1-r3
 RUN apk add --no-cache tzdata libgit2-dev gcc g++ make
+RUN apk add --no-cache tar


### PR DESCRIPTION
# Summary

Previously, we don't have tar in our base image lake-builder, so we have to run `add no cache tar` during github action workflow.
In this pr, we removed all `add no cache tar` in *.yml and add it to base image dockerfile

### Does this close any open issues?
closes #2102

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
