### PR TITLE
Cherry pick pr 2119

### DIFF
--- a/plugins/gitlab/impl/impl.go
+++ b/plugins/gitlab/impl/impl.go
@@ -62,8 +62,6 @@ func (plugin Gitlab) SubTaskMetas() []core.SubTaskMeta {
 		tasks.ExtractApiMergeRequestsCommitsMeta,
 		tasks.CollectApiPipelinesMeta,
 		tasks.ExtractApiPipelinesMeta,
-		tasks.CollectApiChildrenOnPipelinesMeta,
-		tasks.ExtractApiChildrenOnPipelinesMeta,
 		tasks.EnrichMergeRequestsMeta,
 		tasks.ConvertProjectMeta,
 		tasks.ConvertIssuesMeta,

--- a/plugins/gitlab/tasks/pipeline_collector.go
+++ b/plugins/gitlab/tasks/pipeline_collector.go
@@ -23,20 +23,12 @@ import (
 )
 
 const RAW_PIPELINE_TABLE = "gitlab_api_pipeline"
-const RAW_CHILDREN_ON_PIPELINE_TABLE = "gitlab_api_children_on_pipeline"
 
 var CollectApiPipelinesMeta = core.SubTaskMeta{
 	Name:             "collectApiPipelines",
 	EntryPoint:       CollectApiPipelines,
 	EnabledByDefault: true,
 	Description:      "Collect pipeline data from gitlab api",
-}
-
-var CollectApiChildrenOnPipelinesMeta = core.SubTaskMeta{
-	Name:             "collectApiChildrenOnPipelines",
-	EntryPoint:       CollectApiChildrenOnPipelines,
-	EnabledByDefault: true,
-	Description:      "Collect pipline child data from gitlab api",
 }
 
 func CollectApiPipelines(taskCtx core.SubTaskContext) error {
@@ -50,31 +42,6 @@ func CollectApiPipelines(taskCtx core.SubTaskContext) error {
 		UrlTemplate:        "projects/{{ .Params.ProjectId }}/pipelines",
 		Query:              GetQuery,
 		ResponseParser:     GetRawMessageFromResponse,
-	})
-
-	if err != nil {
-		return err
-	}
-
-	return collector.Execute()
-}
-
-func CollectApiChildrenOnPipelines(taskCtx core.SubTaskContext) error {
-	rawDataSubTaskArgs, data := CreateRawDataSubTaskArgs(taskCtx, RAW_CHILDREN_ON_PIPELINE_TABLE)
-
-	iterator, err := GetPipelinesIterator(taskCtx)
-	if err != nil {
-		return err
-	}
-
-	collector, err := helper.NewApiCollector(helper.ApiCollectorArgs{
-		RawDataSubTaskArgs: *rawDataSubTaskArgs,
-		ApiClient:          data.ApiClient,
-		Incremental:        false,
-		Input:              iterator,
-		UrlTemplate:        "projects/{{ .Params.ProjectId }}/pipelines/{{ .Input.GitlabId }}",
-		Query:              GetQuery,
-		ResponseParser:     helper.GetRawMessageDirectFromResponse,
 	})
 
 	if err != nil {


### PR DESCRIPTION
# Summary

delete CollectChildrenPipeline and ExtractChildrenPipeline as the relevant api of gitlab have rate limit problem
And these two tasks only added `coverage` field to table._tool_gitlab_piplines. So we decide to delete them.

### Does this close any open issues?
Closes #2118 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
