### PR TITLE
save github connection in db and support create multi connection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,25 +78,10 @@ FEISHU_ENDPOINT=https://open.feishu.cn/open-apis/vc/v1/
 # GitHub configuration #
 ########################
 
-GITHUB_ENDPOINT=https://api.github.com/
-GITHUB_AUTH=
-GITHUB_PROXY=
-GITHUB_API_REQUESTS_PER_HOUR=
-# GITHUB_PR_TYPE=type/(.*)$ the program will extract the value in (), in this example, you will get "refactor" from "type/refactor"
-GITHUB_PR_TYPE='type/(.*)$'
-# GITHUB_PR_COMPONENT=component/(.*)$ the program will extract the value in (), in this example, you will get "plugins" from "component/plugins"
-GITHUB_PR_COMPONENT='component/(.*)$'
-# GITHUB_ISSUE_SEVERITY=severity/(.*)$ the program will extract the value in (), in this example, you will get "refactor" from "type/refactor"
-GITHUB_ISSUE_SEVERITY='severity/(.*)$'
-# GITHUB_ISSUE_COMPONENT=component/(.*)$ the program will extract the value in (), in this example, you will get "refactor" from "type/refactor"
-GITHUB_ISSUE_COMPONENT='component/(.*)$'
-GITHUB_ISSUE_PRIORITY='^(highest|high|medium|low)$'
-GITHUB_ISSUE_TYPE_BUG='^(bug|failure|error)$'
-GITHUB_ISSUE_TYPE_REQUIREMENT='^(feat|feature|proposal|requirement)$'
-GITHUB_ISSUE_TYPE_INCIDENT=
-# GITHUB_PR_BODY_CLOSE_PATTERN='(?mi)(fix|close|resolve|fixes|closes|resolves|fixed|closed|resolved)[\s]*.*(((and )?(#|https:\/\/github.com\/%s\/%s\/issues\/)\d+[ ]*)+)'
+# GitHub configuration has been migrated into DB #
+# FIXME It's very special because no defined in config, so it will be deleted in next PR
 GITHUB_PR_BODY_CLOSE_PATTERN='(?mi)(fix|close|resolve|fixes|closes|resolves|fixed|closed|resolved)[\s]*.*(((and )?(#|https:\/\/github.com\/%s\/%s\/issues\/)\d+[ ]*)+)'
-# GITHUB_PR_TITLE_PATTERN='.*\(#(\d+)\)'
+# FIXME this config use in refdiff
 GITHUB_PR_TITLE_PATTERN='.*\(#(\d+)\)'
 
 ##########################

--- a/config-ui/src/data/Providers.js
+++ b/config-ui/src/data/Providers.js
@@ -63,7 +63,7 @@ const ProviderConnectionLimits = {
   gitlab: 1,
   jenkins: 1,
   // jira: null, // (Multi-connection, no-limit)
-  github: 1
+  // github: null
 }
 
 // NOTE: Not all fields may be referenced/displayed for a provider,

--- a/config-ui/src/data/integrations.jsx
+++ b/config-ui/src/data/integrations.jsx
@@ -91,7 +91,7 @@ const integrationsData = [
     id: Providers.GITHUB,
     type: ProviderTypes.INTEGRATION,
     enabled: true,
-    multiConnection: false,
+    multiConnection: true,
     name: ProviderLabels.GITHUB,
     icon: <GitHubProvider className='providerIconSvg' width='30' height='30' style={{ float: 'left', marginTop: '5px' }} />,
     iconDashboard: <GitHubProvider className='providerIconSvg' width='48' height='48' />,

--- a/config-ui/src/hooks/useConnectionManager.jsx
+++ b/config-ui/src/hooks/useConnectionManager.jsx
@@ -128,7 +128,7 @@ function useConnectionManager ({
         connectionPayload = { name: name, endpoint: endpointUrl, username: username, password: password, proxy: proxy, ...connectionPayload }
         break
       case Providers.GITHUB:
-        connectionPayload = { name: name, endpoint: endpointUrl, auth: token, proxy: proxy, ...connectionPayload }
+        connectionPayload = { name: name, endpoint: endpointUrl, token, proxy: proxy, ...connectionPayload }
         break
       case Providers.JENKINS:
         // eslint-disable-next-line max-len
@@ -329,7 +329,7 @@ function useConnectionManager ({
         endpoint: c.Endpoint || c.endpoint,
         username: c.username,
         password: c.password,
-        auth: c.basicAuthEncoded || c.auth,
+        auth: c.basicAuthEncoded || c.token,
         proxy: c.Proxy || c.Proxy
       }
       const onSuccess = (res) => {
@@ -380,7 +380,7 @@ function useConnectionManager ({
           setProxy(activeConnection.Proxy || activeConnection.proxy)
           break
         case Providers.GITHUB:
-          setToken(activeConnection.basicAuthEncoded || activeConnection.auth)
+          setToken(activeConnection.basicAuthEncoded || activeConnection.token)
           setProxy(activeConnection.Proxy || activeConnection.proxy)
           break
         case Providers.JIRA:

--- a/config-ui/src/hooks/useSettingsManager.jsx
+++ b/config-ui/src/hooks/useSettingsManager.jsx
@@ -49,7 +49,7 @@ function useSettingsManager ({
           ...connectionPayload,
           name: connection.name,
           endpoint: connection.endpoint,
-          auth: connection.auth,
+          auth: connection.token,
           proxy: connection.proxy || connection.Proxy
         }
         break

--- a/config-ui/src/pages/configure/connections/AddConnection.jsx
+++ b/config-ui/src/pages/configure/connections/AddConnection.jsx
@@ -45,7 +45,8 @@ export default function AddConnection () {
   const [activeProvider, setActiveProvider] = useState(integrationsData.find(p => p.id === providerId))
 
   const {
-    testConnection, saveConnection,
+    testConnection,
+    saveConnection,
     errors,
     isSaving,
     isTesting,
@@ -101,15 +102,13 @@ export default function AddConnection () {
     if (activeProvider && activeProvider.id) {
       fetchAllConnections()
       switch (activeProvider.id) {
-        case Providers.GITHUB:
-          setName(ProviderLabels.GITHUB)
-          break
         case Providers.GITLAB:
           setName(ProviderLabels.GITLAB)
           break
         case Providers.JENKINS:
           setName(ProviderLabels.JENKINS)
           break
+        case Providers.GITHUB:
         case Providers.JIRA:
         default:
           setName('')

--- a/config-ui/src/pages/configure/connections/ConnectionForm.jsx
+++ b/config-ui/src/pages/configure/connections/ConnectionForm.jsx
@@ -159,7 +159,7 @@ export default function ConnectionForm (props) {
                 backgroundColor: '#f0f0f0'
               }}
             >
-              <p className='warning-message' intent={Intent.WARNING}>
+              <p className='warning-message'>
                 <Icon icon='warning-sign' size='16' color={Colors.GRAY1} style={{ marginRight: '5px' }} />
                 <strong>CONNECTION SOURCES LIMITED</strong><br />
                 You may only add <Tag intent={Intent.PRIMARY}>{sourceLimits[activeProvider.id]}</Tag> instance(s) at this time,
@@ -181,7 +181,7 @@ export default function ConnectionForm (props) {
               border: showLimitWarning ? 'inherit' : 0
             }}
           >
-            <p className='warning-message' intent={Intent.WARNING}>
+            <p className='warning-message'>
               <Icon icon='error' size='16' color={Colors.RED4} style={{ marginRight: '5px' }} />
               <strong>UNABLE TO SAVE CONNECTION ({name !== '' ? name : 'BLANK'})</strong><br />
             </p>
@@ -197,7 +197,7 @@ export default function ConnectionForm (props) {
         <div className='formContainer'>
           <FormGroup
             disabled={isTesting || isSaving || isLocked}
-            readOnly={[Providers.GITHUB, Providers.GITLAB, Providers.JENKINS].includes(activeProvider.id)}
+            readOnly={[Providers.GITLAB, Providers.JENKINS].includes(activeProvider.id)}
             label=''
             inline={true}
             labelFor='connection-name'
@@ -216,14 +216,14 @@ export default function ConnectionForm (props) {
               id='connection-name'
               inputRef={connectionNameRef}
               disabled={isTesting || isSaving || isLocked}
-              readOnly={[Providers.GITHUB, Providers.GITLAB, Providers.JENKINS].includes(activeProvider.id)}
+              readOnly={[Providers.GITLAB, Providers.JENKINS].includes(activeProvider.id)}
               placeholder={placeholders ? placeholders.name : 'Enter Instance Name'}
               value={name}
               onChange={(e) => onNameChange(e.target.value)}
               // className={`input connection-name-input ${fieldHasError('Connection') ? 'invalid-field' : ''}`}
               // className='input connection-name-input'
               className={`input connection-name-input ${stateErrored === 'connection-name' ? 'invalid-field' : ''}`}
-              leftIcon={[Providers.GITHUB, Providers.GITLAB, Providers.JENKINS].includes(activeProvider.id) ? 'lock' : null}
+              leftIcon={[Providers.GITLAB, Providers.JENKINS].includes(activeProvider.id) ? 'lock' : null}
               inline={true}
               rightElement={(
                 <InputValidationError

--- a/config-ui/src/pages/configure/integration/manage.jsx
+++ b/config-ui/src/pages/configure/integration/manage.jsx
@@ -278,7 +278,7 @@ export default function ManageIntegration () {
                             // eslint-disable-next-line max-len
                             className={getTestedConnection(connection) && getTestedConnection(connection).status !== 1 ? 'connection-offline' : 'connection-online'}
                           >
-                            {activeProvider.id === Providers.JIRA && (
+                            {!sourceLimits[activeProvider.id] && (
                               <td
                                 style={{ cursor: 'pointer' }}
                                 className='cell-name'

--- a/config-ui/src/pages/configure/integration/manage.jsx
+++ b/config-ui/src/pages/configure/integration/manage.jsx
@@ -264,7 +264,7 @@ export default function ManageIntegration () {
                     <table className='bp3-html-table bp3-html-table-bordered connections-table' style={{ width: '100%' }}>
                       <thead>
                         <tr>
-                          {activeProvider.id === Providers.JIRA && (<th>ID</th>)}
+                          {!sourceLimits[activeProvider.id] && (<th>ID</th>)}
                           <th>Connection Name</th>
                           <th>Endpoint</th>
                           <th>Status</th>

--- a/plugins/github/api/init.go
+++ b/plugins/github/api/init.go
@@ -1,0 +1,42 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"github.com/apache/incubator-devlake/plugins/core"
+	"github.com/apache/incubator-devlake/plugins/github/models"
+	"github.com/apache/incubator-devlake/plugins/helper"
+	"github.com/go-playground/validator/v10"
+	"github.com/spf13/viper"
+	"gorm.io/gorm"
+)
+
+type ApiUserPublicEmailResponse []models.PublicEmail
+
+var vld *validator.Validate
+var connectionHelper *helper.ConnectionApiHelper
+var basicRes core.BasicRes
+
+func Init(config *viper.Viper, logger core.Logger, database *gorm.DB) {
+	basicRes = helper.NewDefaultBasicRes(config, logger, database)
+	vld = validator.New()
+	connectionHelper = helper.NewConnectionHelper(
+		basicRes,
+		vld,
+	)
+}

--- a/plugins/github/models/connection.go
+++ b/plugins/github/models/connection.go
@@ -28,7 +28,6 @@ type TestConnectionRequest struct {
 type GithubConnection struct {
 	helper.RestConnection `mapstructure:",squash"`
 	helper.AccessToken    `mapstructure:",squash"`
-	Config                `mapstructure:",squash"`
 }
 
 type Config struct {

--- a/plugins/github/models/connection.go
+++ b/plugins/github/models/connection.go
@@ -27,7 +27,7 @@ type TestConnectionRequest struct {
 
 type GithubConnection struct {
 	helper.RestConnection `mapstructure:",squash"`
-	Auth                  string `mapstructure:"auth" validate:"required" json:"auth"`
+	helper.AccessToken    `mapstructure:",squash"`
 	Config                `mapstructure:",squash"`
 }
 

--- a/plugins/github/models/connection.go
+++ b/plugins/github/models/connection.go
@@ -17,31 +17,33 @@ limitations under the License.
 
 package models
 
-type GithubConnection struct {
-	Endpoint string `mapstructure:"endpoint" validate:"required" env:"GITHUB_ENDPOINT" json:"endpoint"`
-	Auth     string `mapstructure:"auth" validate:"required" env:"GITHUB_AUTH" json:"auth"`
-	Proxy    string `mapstructure:"proxy" env:"GITHUB_PROXY" json:"proxy"`
+import "github.com/apache/incubator-devlake/plugins/helper"
 
-	Config `mapstructure:",squash"`
+type TestConnectionRequest struct {
+	Endpoint string `json:"endpoint" validate:"required,url"`
+	Auth     string `json:"auth" validate:"required"`
+	Proxy    string `json:"proxy"`
+}
+
+type GithubConnection struct {
+	helper.RestConnection `mapstructure:",squash"`
+	Auth                  string `mapstructure:"auth" validate:"required" json:"auth"`
+	Config                `mapstructure:",squash"`
 }
 
 type Config struct {
-	PrType               string `mapstructure:"prType" env:"GITHUB_PR_TYPE" json:"prType"`
-	PrComponent          string `mapstructure:"prComponent" env:"GITHUB_PR_COMPONENT" json:"prComponent"`
-	IssueSeverity        string `mapstructure:"issueSeverity" env:"GITHUB_ISSUE_SEVERITY" json:"issueSeverity"`
-	IssuePriority        string `mapstructure:"issuePriority" env:"GITHUB_ISSUE_PRIORITY" json:"issuePriority"`
-	IssueComponent       string `mapstructure:"issueComponent" env:"GITHUB_ISSUE_COMPONENT" json:"issueComponent"`
-	IssueTypeBug         string `mapstructure:"issueTypeBug" env:"GITHUB_ISSUE_TYPE_BUG" json:"issueTypeBug"`
-	IssueTypeIncident    string `mapstructure:"issueTypeIncident" env:"GITHUB_ISSUE_TYPE_INCIDENT" json:"issueTypeIncident"`
-	IssueTypeRequirement string `mapstructure:"issueTypeRequirement" env:"GITHUB_ISSUE_TYPE_REQUIREMENT" json:"issueTypeRequirement"`
+	PrType               string `mapstructure:"prType" json:"prType"`
+	PrComponent          string `mapstructure:"prComponent" json:"prComponent"`
+	IssueSeverity        string `mapstructure:"issueSeverity" json:"issueSeverity"`
+	IssuePriority        string `mapstructure:"issuePriority" json:"issuePriority"`
+	IssueComponent       string `mapstructure:"issueComponent" json:"issueComponent"`
+	IssueTypeBug         string `mapstructure:"issueTypeBug" json:"issueTypeBug"`
+	IssueTypeIncident    string `mapstructure:"issueTypeIncident" json:"issueTypeIncident"`
+	IssueTypeRequirement string `mapstructure:"issueTypeRequirement" json:"issueTypeRequirement"`
 }
 
-// This object conforms to what the frontend currently expects.
-type GithubResponse struct {
-	Name string `json:"name"`
-	ID   int    `json:"id"`
-
-	GithubConnection
+func (GithubConnection) TableName() string {
+	return "_tool_github_connections"
 }
 
 // Using Public Email because it requires authentication, and it is public information anyway.
@@ -51,10 +53,4 @@ type PublicEmail struct {
 	Primary    bool
 	Verified   bool
 	Visibility string
-}
-
-type TestConnectionRequest struct {
-	Endpoint string `json:"endpoint" validate:"required,url"`
-	Auth     string `json:"auth" validate:"required"`
-	Proxy    string `json:"proxy"`
 }

--- a/plugins/github/models/migrationscripts/updateSchemas20220608.go
+++ b/plugins/github/models/migrationscripts/updateSchemas20220608.go
@@ -28,10 +28,10 @@ import (
 type GithubConnection20220608 struct {
 	archived.Model
 	Name      string `gorm:"type:varchar(100);uniqueIndex" json:"name" validate:"required"`
-	Endpoint  string `mapstructure:"endpoint" env:"GITHUB_ENDPOINT" validate:"required" json:"endpoint"`
-	Proxy     string `mapstructure:"proxy" env:"GITHUB_PROXY" json:"proxy"`
-	RateLimit int    `comment:"api request rate limit per hour" json:"rateLimit"`
-	Auth      string `mapstructure:"auth" validate:"required" env:"GITHUB_AUTH" json:"auth"`
+	Endpoint  string `mapstructure:"endpoint" env:"GITHUB_ENDPOINT" validate:"required"`
+	Proxy     string `mapstructure:"proxy" env:"GITHUB_PROXY"`
+	RateLimit int    `comment:"api request rate limit per hour"`
+	Token     string `mapstructure:"token" validate:"required" env:"GITHUB_AUTH"`
 
 	Config20220608 `mapstructure:",squash"`
 }
@@ -66,7 +66,7 @@ func (*UpdateSchemas20220608) Up(ctx context.Context, db *gorm.DB) error {
 		return err
 	}
 	// update from .env and save to db
-	if connection.Endpoint != `` && connection.Auth != `` {
+	if connection.Endpoint != `` && connection.Token != `` {
 		db.Create(connection)
 	}
 	return nil

--- a/plugins/github/models/migrationscripts/updateSchemas20220608.go
+++ b/plugins/github/models/migrationscripts/updateSchemas20220608.go
@@ -1,0 +1,81 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"context"
+	"github.com/apache/incubator-devlake/config"
+	"github.com/apache/incubator-devlake/models/migrationscripts/archived"
+	"github.com/apache/incubator-devlake/plugins/helper"
+	"gorm.io/gorm"
+)
+
+type GithubConnection20220608 struct {
+	archived.Model
+	Name      string `gorm:"type:varchar(100);uniqueIndex" json:"name" validate:"required"`
+	Endpoint  string `mapstructure:"endpoint" env:"GITHUB_ENDPOINT" validate:"required" json:"endpoint"`
+	Proxy     string `mapstructure:"proxy" env:"GITHUB_PROXY" json:"proxy"`
+	RateLimit int    `comment:"api request rate limit per hour" json:"rateLimit"`
+	Auth      string `mapstructure:"auth" validate:"required" env:"GITHUB_AUTH" json:"auth"`
+
+	Config20220608 `mapstructure:",squash"`
+}
+
+type Config20220608 struct {
+	PrType               string `mapstructure:"prType" env:"GITHUB_PR_TYPE" json:"prType"`
+	PrComponent          string `mapstructure:"prComponent" env:"GITHUB_PR_COMPONENT" json:"prComponent"`
+	IssueSeverity        string `mapstructure:"issueSeverity" env:"GITHUB_ISSUE_SEVERITY" json:"issueSeverity"`
+	IssuePriority        string `mapstructure:"issuePriority" env:"GITHUB_ISSUE_PRIORITY" json:"issuePriority"`
+	IssueComponent       string `mapstructure:"issueComponent" env:"GITHUB_ISSUE_COMPONENT" json:"issueComponent"`
+	IssueTypeBug         string `mapstructure:"issueTypeBug" env:"GITHUB_ISSUE_TYPE_BUG" json:"issueTypeBug"`
+	IssueTypeIncident    string `mapstructure:"issueTypeIncident" env:"GITHUB_ISSUE_TYPE_INCIDENT" json:"issueTypeIncident"`
+	IssueTypeRequirement string `mapstructure:"issueTypeRequirement" env:"GITHUB_ISSUE_TYPE_REQUIREMENT" json:"issueTypeRequirement"`
+}
+
+func (GithubConnection20220608) TableName() string {
+	return "_tool_github_connections"
+}
+
+type UpdateSchemas20220608 struct{}
+
+func (*UpdateSchemas20220608) Up(ctx context.Context, db *gorm.DB) error {
+	err := db.Migrator().CreateTable(GithubConnection20220608{})
+	if err != nil {
+		return err
+	}
+	v := config.GetConfig()
+	connection := &GithubConnection20220608{}
+	err = helper.EncodeStruct(v, connection, "env")
+	connection.Name = `GitHub`
+	if err != nil {
+		return err
+	}
+	// update from .env and save to db
+	if connection.Endpoint != `` && connection.Auth != `` {
+		db.Create(connection)
+	}
+	return nil
+}
+
+func (*UpdateSchemas20220608) Version() uint64 {
+	return 20220608000003
+}
+
+func (*UpdateSchemas20220608) Name() string {
+	return "Add connection for github"
+}

--- a/plugins/github/tasks/api_client.go
+++ b/plugins/github/tasks/api_client.go
@@ -31,7 +31,7 @@ import (
 
 func CreateApiClient(taskCtx core.TaskContext, connection *models.GithubConnection) (*helper.ApiAsyncClient, error) {
 	// load configuration
-	tokens := strings.Split(connection.Auth, ",")
+	tokens := strings.Split(connection.Token, ",")
 	tokenIndex := 0
 	// create synchronize api client so we can calculate api rate limit dynamically
 	apiClient, err := helper.NewApiClient(connection.Endpoint, nil, 0, connection.Proxy, taskCtx.GetContext())

--- a/plugins/github/tasks/issue_extractor.go
+++ b/plugins/github/tasks/issue_extractor.go
@@ -72,44 +72,26 @@ func ExtractApiIssues(taskCtx core.SubTaskContext) error {
 	var issueTypeRequirementRegex *regexp.Regexp
 	var issueTypeIncidentRegex *regexp.Regexp
 	var issueSeverity = config.IssueSeverity
-	if issueSeverity == "" {
-		issueSeverity = taskCtx.GetConfig("GITHUB_ISSUE_SEVERITY")
-	}
-	var issueComponent = config.IssueComponent
-	if issueComponent == "" {
-		issueComponent = taskCtx.GetConfig("GITHUB_ISSUE_COMPONENT")
-	}
-	var issuePriority = config.IssuePriority
-	if issuePriority == "" {
-		issuePriority = taskCtx.GetConfig("GITHUB_ISSUE_PRIORITY")
-	}
-	var issueTypeBug = config.IssueTypeBug
-	if issueTypeBug == "" {
-		issueTypeBug = taskCtx.GetConfig("GITHUB_ISSUE_TYPE_BUG")
-	}
-	var issueTypeRequirement = config.IssueTypeRequirement
-	if issueTypeRequirement == "" {
-		issueTypeRequirement = taskCtx.GetConfig("GITHUB_ISSUE_TYPE_REQUIREMENT")
-	}
-	var issueTypeIncident = config.IssueTypeIncident
-	if issueTypeIncident == "" {
-		issueTypeIncident = taskCtx.GetConfig("GITHUB_ISSUE_TYPE_INCIDENT")
-	}
 	if len(issueSeverity) > 0 {
 		issueSeverityRegex = regexp.MustCompile(issueSeverity)
 	}
+	var issueComponent = config.IssueComponent
 	if len(issueComponent) > 0 {
 		issueComponentRegex = regexp.MustCompile(issueComponent)
 	}
+	var issuePriority = config.IssuePriority
 	if len(issuePriority) > 0 {
 		issuePriorityRegex = regexp.MustCompile(issuePriority)
 	}
+	var issueTypeBug = config.IssueTypeBug
 	if len(issueTypeBug) > 0 {
 		issueTypeBugRegex = regexp.MustCompile(issueTypeBug)
 	}
+	var issueTypeRequirement = config.IssueTypeRequirement
 	if len(issueTypeRequirement) > 0 {
 		issueTypeRequirementRegex = regexp.MustCompile(issueTypeRequirement)
 	}
+	var issueTypeIncident = config.IssueTypeIncident
 	if len(issueTypeIncident) > 0 {
 		issueTypeIncidentRegex = regexp.MustCompile(issueTypeIncident)
 	}

--- a/plugins/github/tasks/pr_extractor.go
+++ b/plugins/github/tasks/pr_extractor.go
@@ -72,16 +72,10 @@ func ExtractApiPullRequests(taskCtx core.SubTaskContext) error {
 	var labelTypeRegex *regexp.Regexp
 	var labelComponentRegex *regexp.Regexp
 	var prType = config.PrType
-	if prType == "" {
-		prType = taskCtx.GetConfig("GITHUB_PR_TYPE")
-	}
-	var prComponent = config.PrComponent
-	if prComponent == "" {
-		prComponent = taskCtx.GetConfig("GITHUB_PR_COMPONENT")
-	}
 	if len(prType) > 0 {
 		labelTypeRegex = regexp.MustCompile(prType)
 	}
+	var prComponent = config.PrComponent
 	if len(prComponent) > 0 {
 		labelComponentRegex = regexp.MustCompile(prComponent)
 	}

--- a/plugins/helper/connection.go
+++ b/plugins/helper/connection.go
@@ -53,7 +53,7 @@ type RestConnection struct {
 	BaseConnection `mapstructure:",squash"`
 	Endpoint       string `mapstructure:"endpoint" validate:"required" json:"endpoint"`
 	Proxy          string `mapstructure:"proxy" json:"proxy"`
-	RateLimit      int    `comment:"api request rate limt per hour" json:"rateLimit"`
+	RateLimit      int    `comment:"api request rate limit per hour" json:"rateLimit"`
 }
 
 type ConnectionApiHelper struct {

--- a/plugins/icla/plugin_main.go
+++ b/plugins/icla/plugin_main.go
@@ -89,15 +89,8 @@ func (plugin Icla) ApiResources() map[string]map[string]core.ApiResourceHandler 
 // standalone mode for debugging
 func main() {
 	cmd := &cobra.Command{Use: "icla"}
-
-	// TODO add your cmd flag if necessary
-	// yourFlag := cmd.Flags().IntP("yourFlag", "y", 8, "TODO add description here")
-	// _ = cmd.MarkFlagRequired("yourFlag")
-
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		runner.DirectRun(cmd, args, PluginEntry, map[string]interface{}{
-			// TODO add more custom params here
-		})
+		runner.DirectRun(cmd, args, PluginEntry, map[string]interface{}{})
 	}
 	runner.RunCmd(cmd)
 }


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

Save GitHub connection in DB and support creating multi-connection.

It's the first PR for #1980. Only can collect data by the connection named `GitHub` or fail.

### Does this close any open issues?
#1980

### Screenshots
![image](https://user-images.githubusercontent.com/3294100/172664252-a3e86739-7c47-4414-a651-cdef53834ec9.png)

### Changes in API
1. Github Connections now support POST/DELETE API like Jira Plugin.
2. Github Connections now replace all column `auth` with `token`.
3. Now support save multi connections.
4. delete the below columns in all GitHub Plugin Api.
```
PrType
PrComponent
IssueSeverity
IssuePriority
IssueComponent
IssueTypeBug
IssueTypeIncident
IssueTypeRequirement
```


