### PR TITLE
fix: api_collector is missing the value of the input parameter

### DIFF
--- a/plugins/helper/api_collector.go
+++ b/plugins/helper/api_collector.go
@@ -195,7 +195,8 @@ func (collector *ApiCollector) fetchPagesDetermined(reqData *RequestData) {
 						Skip: collector.args.PageSize * (page - 1),
 						Size: collector.args.PageSize,
 					},
-					Input: reqData.Input,
+					Input:     reqData.Input,
+					InputJSON: reqData.InputJSON,
 				}
 				collector.fetchAsync(reqDataTemp, nil)
 			}
@@ -232,7 +233,8 @@ func (collector *ApiCollector) fetchPagesUndetermined(reqData *RequestData) {
 				Size: collector.args.PageSize,
 				Skip: collector.args.PageSize * (i),
 			},
-			Input: reqData.Input,
+			Input:     reqData.Input,
+			InputJSON: reqData.InputJSON,
 		}
 		var collect func() error
 		collect = func() error {


### PR DESCRIPTION
# Summary
I think it is missing the InputJson. so `Input:  reqData.InputJSON` is NULL

![image](https://user-images.githubusercontent.com/101256042/172986321-a2d1341c-9a54-4493-b84b-fb5bea1c3867.png)

![image](https://user-images.githubusercontent.com/101256042/172986540-1a084f79-0b58-4f8a-957a-49ca1f2e3647.png)


### Does this close any open issues?
fix: #2153 
fix: #2140

### Screenshots
![image](https://user-images.githubusercontent.com/101256042/172986176-add6ae95-679f-4bfb-acde-830fe11575ca.png)

### Other Information
Any other information that is important to this PR.
