### PR TITLE
fix(jenkins): copy inputjson

### DIFF
--- a/plugins/jenkins/tasks/build_extractor.go
+++ b/plugins/jenkins/tasks/build_extractor.go
@@ -85,7 +85,9 @@ func ExtractApiBuilds(taskCtx core.SubTaskContext) error {
 					}
 				}
 			} else if vcs == "svn" {
-				build.CommitSha = strconv.Itoa(body.ChangeSet.Revisions[0].Revision)
+				if len(body.ChangeSet.Revisions) > 0 {
+					build.CommitSha = strconv.Itoa(body.ChangeSet.Revisions[0].Revision)
+				}
 			}
 
 			results = append(results, build)

--- a/plugins/jenkins/tasks/job_collector.go
+++ b/plugins/jenkins/tasks/job_collector.go
@@ -59,6 +59,7 @@ func CollectApiJobs(taskCtx core.SubTaskContext) error {
 		ApiClient:   data.ApiClient,
 		PageSize:    100,
 		Incremental: incremental,
+		Concurrency: 1,
 
 		UrlTemplate: "api/json",
 		Query: func(reqData *helper.RequestData) (url.Values, error) {


### PR DESCRIPTION
closes #2158

### ⚠️ &nbsp;&nbsp;Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [ ] I have read through the [Contributing](https://devlake.apache.org/community/) Documentation & [PR Template](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] This PR is using a `label` (bug, feature etc.)
- [ ] My code is has necessary documentation (if appropriate)
- [ ] I have added any relevant tests
- [ ] This section (**⚠️ &nbsp;&nbsp;Pre Checklist**) will be removed when submitting PR

# Summary

In api_collector, when we copy reqData, we forgot to copy inputJson. 
In Jenkins jobs collector, we should set the concurrency to 1. If the concurrency is larger than 1, it might go to fetch data which jenkins does not have, then it will report 500.

### Does this close any open issues?
closes #2158

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
