### PR TITLE
Fix work_scheduler wouldn't halt on error

### DIFF
--- a/helpers/unithelper/dummy_logger.go
+++ b/helpers/unithelper/dummy_logger.go
@@ -31,5 +31,6 @@ func DummyLogger() *mocks.Logger {
 	logger.On("Info", mock.Anything, mock.Anything).Maybe()
 	logger.On("Warn", mock.Anything, mock.Anything).Maybe()
 	logger.On("Error", mock.Anything, mock.Anything).Maybe()
+	logger.On("Nested", mock.Anything).Return(logger).Maybe()
 	return logger
 }

--- a/plugins/helper/api_async_client.go
+++ b/plugins/helper/api_async_client.go
@@ -41,7 +41,6 @@ type ApiAsyncClient struct {
 	*ApiClient
 	maxRetry     int
 	scheduler    *WorkerScheduler
-	hasError     bool
 	numOfWorkers int
 }
 
@@ -111,7 +110,6 @@ func CreateAsyncApiClient(
 		apiClient,
 		retry,
 		scheduler,
-		false,
 		numOfWorkers,
 	}, nil
 }
@@ -178,7 +176,7 @@ func (apiClient *ApiAsyncClient) DoAsync(
 		}
 
 		if err != nil {
-			apiClient.hasError = true
+			apiClient.logger.Error("retry exceeded times: %d, err: %s", retry, err.Error())
 			return err
 		}
 
@@ -205,7 +203,7 @@ func (apiClient *ApiAsyncClient) WaitAsync() error {
 }
 
 func (apiClient *ApiAsyncClient) HasError() bool {
-	return apiClient.hasError
+	return apiClient.scheduler.HasError()
 }
 
 func (apiClient *ApiAsyncClient) NextTick(task func() error) {

--- a/runner/loader.go
+++ b/runner/loader.go
@@ -36,7 +36,7 @@ func LoadPlugins(pluginsDir string, config *viper.Viper, logger core.Logger, db 
 			return err
 		}
 		fileName := d.Name()
-		if strings.HasSuffix(fileName, ".so") {
+		if strings.HasSuffix(fileName, ".so") && fileName != ".so" {
 			pluginName := fileName[0 : len(d.Name())-3]
 			plug, loadErr := plugin.Open(path)
 			if loadErr != nil {


### PR DESCRIPTION
# Summary

The `gatherError` didn't work as expected, it failed to collect the error
This work scheduler is too abstract, in order to low down the complexity, I decided to remove the `callframes` information for now, feel free to discuss if you think it is neccessary.

### Does this close any open issues?
Fixes #2167 

### Screenshots
This screenshot shows that errors now can be collected, and task stop after a while

![image](https://user-images.githubusercontent.com/61080/173185927-65eb65f7-238b-4efe-aa63-14cbcf672f45.png)

