### PR TITLE
fix: gitextractor does not collect remote branch

### DIFF
--- a/plugins/gitextractor/parser/libgit2.go
+++ b/plugins/gitextractor/parser/libgit2.go
@@ -112,7 +112,7 @@ func (l *LibGit2) run(repo *git.Repository, repoId string) error {
 		default:
 			break
 		}
-		if branch.IsBranch() {
+		if branch.IsBranch() || branch.IsRemote() {
 			name, err1 := branch.Name()
 			if err1 != nil {
 				return err1


### PR DESCRIPTION
# Summary

fix #2186 [Bug] [gitextractor] gitextractor does not collect remote branches.

The method `func (v *Reference) IsBranch() bool` would return `true` only if the branch is a local one. To fix it, we brought in another method `func (v *Reference) IsRemote() bool`, as the name indicated, it tells us whether the branch is remote

### Does this close any open issues?
close #2186 

### Screenshots
![image](https://user-images.githubusercontent.com/8455907/173523450-298aee56-5693-4a42-a654-95b3ea2ab97c.png)
### Other Information
Any other information that is important to this PR.
