### PR TITLE
fix bug report template label setting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -18,7 +18,7 @@
 name: Bug report
 title: "[Bug] [Module Name] Bug title "
 description: Problems and issues with code of Apache DevLake
-labels: [ "bug", "Waiting for reply" ]
+labels: type/bug
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
# Summary

Recently recreated "bug report" doesn't come with `type/bug` label
![image](https://user-images.githubusercontent.com/61080/174028326-d77802d7-61ec-404a-b2ed-9974aae3f7b0.png)

This PR aim to fix the problem
