### PR TITLE
feat: add `mode` to blueprint entity

### DIFF
--- a/api/blueprints/blueprints.go
+++ b/api/blueprints/blueprints.go
@@ -164,17 +164,13 @@ func Patch(c *gin.Context) {
 		shared.ApiOutputError(c, err, http.StatusBadRequest)
 		return
 	}
-	blueprint, err := services.GetBlueprint(id)
+	var body map[string]interface{}
+	err = c.ShouldBind(&body)
 	if err != nil {
 		shared.ApiOutputError(c, err, http.StatusBadRequest)
 		return
 	}
-	err = c.ShouldBind(blueprint)
-	if err != nil {
-		shared.ApiOutputError(c, err, http.StatusBadRequest)
-		return
-	}
-	err = services.UpdateBlueprint(blueprint)
+	blueprint, err := services.PatchBlueprint(id, body)
 	if err != nil {
 		shared.ApiOutputError(c, err, http.StatusBadRequest)
 		return

--- a/models/blueprint.go
+++ b/models/blueprint.go
@@ -22,9 +22,14 @@ import (
 	"gorm.io/datatypes"
 )
 
+const BLUEPRINT_CRON_MANUAL = "MANUAL"
+const BLUEPRINT_MODE_NORMAL = "NORMAL"
+const BLUEPRINT_MODE_ADVANCED = "ADVANCED"
+
 type Blueprint struct {
 	Name       string         `json:"name" validate:"required"`
-	Tasks      datatypes.JSON `json:"tasks" validate:"required"`
+	Mode       string         `json:"mode" gorm:"varchar(20)" validate:"required,oneof=NORMAL ADVANCED"`
+	Tasks      datatypes.JSON `json:"tasks"`
 	Enable     bool           `json:"enable"`
 	CronConfig string         `json:"cronConfig" validate:"required"`
 	common.Model

--- a/models/blueprint.go
+++ b/models/blueprint.go
@@ -22,7 +22,6 @@ import (
 	"gorm.io/datatypes"
 )
 
-const BLUEPRINT_CRON_MANUAL = "MANUAL"
 const BLUEPRINT_MODE_NORMAL = "NORMAL"
 const BLUEPRINT_MODE_ADVANCED = "ADVANCED"
 
@@ -31,7 +30,8 @@ type Blueprint struct {
 	Mode       string         `json:"mode" gorm:"varchar(20)" validate:"required,oneof=NORMAL ADVANCED"`
 	Tasks      datatypes.JSON `json:"tasks"`
 	Enable     bool           `json:"enable"`
-	CronConfig string         `json:"cronConfig" validate:"required"`
+	CronConfig string         `json:"cronConfig"`
+	IsManual   bool           `json:"isManual"`
 	common.Model
 }
 

--- a/models/migrationscripts/updateSchemas20220616.go
+++ b/models/migrationscripts/updateSchemas20220616.go
@@ -17,16 +17,34 @@ limitations under the License.
 
 package migrationscripts
 
-import "github.com/apache/incubator-devlake/migration"
+import (
+	"context"
 
-// RegisterAll register all the migration scripts of framework
-func All() []migration.Script {
-	return []migration.Script{
-		new(initSchemas),
-		new(updateSchemas20220505), new(updateSchemas20220507), new(updateSchemas20220510),
-		new(updateSchemas20220513), new(updateSchemas20220524), new(updateSchemas20220526),
-		new(updateSchemas20220527), new(updateSchemas20220528), new(updateSchemas20220601),
-		new(updateSchemas20220602), new(updateSchemas20220612), new(updateSchemas20220613),
-		new(updateSchemas20220614), new(updateSchemas2022061402), new(updateSchemas20220616),
+	"gorm.io/gorm"
+)
+
+type Blueprint20220616 struct {
+	Mode string `json:"mode" gorm:"varchar(20)" validate:"required,oneof=NORMAL ADVANCED"`
+}
+
+func (Blueprint20220616) TableName() string {
+	return "_devlake_blueprints"
+}
+
+type updateSchemas20220616 struct{}
+
+func (*updateSchemas20220616) Up(ctx context.Context, db *gorm.DB) error {
+	err := db.Migrator().AutoMigrate(&Blueprint20220616{})
+	if err != nil {
+		return err
 	}
+	return nil
+}
+
+func (*updateSchemas20220616) Version() uint64 {
+	return 20220616110537
+}
+
+func (*updateSchemas20220616) Name() string {
+	return "add mode field to blueprint"
 }

--- a/models/migrationscripts/updateSchemas20220616.go
+++ b/models/migrationscripts/updateSchemas20220616.go
@@ -24,7 +24,8 @@ import (
 )
 
 type Blueprint20220616 struct {
-	Mode string `json:"mode" gorm:"varchar(20)" validate:"required,oneof=NORMAL ADVANCED"`
+	Mode     string `json:"mode" gorm:"varchar(20)" validate:"required,oneof=NORMAL ADVANCED"`
+	IsManual bool   `json:"isManual"`
 }
 
 func (Blueprint20220616) TableName() string {

--- a/services/blueprint.go
+++ b/services/blueprint.go
@@ -91,6 +91,10 @@ func GetBlueprint(blueprintId uint64) (*models.Blueprint, error) {
 }
 
 func validateBlueprint(blueprint *models.Blueprint) error {
+	// TODO: implement NORMAL mode
+	if blueprint.Mode == models.BLUEPRINT_MODE_NORMAL {
+		return fmt.Errorf("NORMAL mode is yet to be implemented")
+	}
 	// validation
 	err := vld.Struct(blueprint)
 	if err != nil {

--- a/services/blueprint.go
+++ b/services/blueprint.go
@@ -100,11 +100,13 @@ func validateBlueprint(blueprint *models.Blueprint) error {
 	if err != nil {
 		return err
 	}
-	if blueprint.CronConfig != models.BLUEPRINT_CRON_MANUAL {
+	if blueprint.CronConfig != "" {
 		_, err = cron.ParseStandard(blueprint.CronConfig)
 		if err != nil {
 			return fmt.Errorf("invalid cronConfig: %w", err)
 		}
+	} else if blueprint.IsManual == false {
+		return fmt.Errorf("cronConfig is required for Automated blueprint")
 	}
 	if blueprint.Mode == models.BLUEPRINT_MODE_ADVANCED {
 		tasks := make([][]models.NewTask, 0)
@@ -170,7 +172,7 @@ func DeleteBlueprint(id uint64) error {
 func ReloadBlueprints(c *cron.Cron) error {
 	blueprints := make([]*models.Blueprint, 0)
 	err := db.Model(&models.Blueprint{}).
-		Where("enable = ? AND cron_config <> ?", true, models.BLUEPRINT_CRON_MANUAL).
+		Where("enable = ? AND is_manual = ?", true, false).
 		Find(&blueprints).Error
 	if err != nil {
 		panic(err)

--- a/services/blueprint.go
+++ b/services/blueprint.go
@@ -165,7 +165,9 @@ func DeleteBlueprint(id uint64) error {
 
 func ReloadBlueprints(c *cron.Cron) error {
 	blueprints := make([]*models.Blueprint, 0)
-	err := db.Model(&models.Blueprint{}).Where("enable = ?", true).Find(&blueprints).Error
+	err := db.Model(&models.Blueprint{}).
+		Where("enable = ? AND cron_config <> ?", true, models.BLUEPRINT_CRON_MANUAL).
+		Find(&blueprints).Error
 	if err != nil {
 		panic(err)
 	}
@@ -207,5 +209,6 @@ func ReloadBlueprints(c *cron.Cron) error {
 	if len(blueprints) > 0 {
 		c.Start()
 	}
+	log.Info("total %d blueprints were scheduled", len(blueprints))
 	return nil
 }

--- a/services/blueprint.go
+++ b/services/blueprint.go
@@ -25,6 +25,7 @@ import (
 	"github.com/apache/incubator-devlake/logger"
 	"github.com/apache/incubator-devlake/models"
 	"github.com/go-playground/validator/v10"
+	"github.com/mitchellh/mapstructure"
 	"github.com/robfig/cron/v3"
 	"gorm.io/gorm"
 )
@@ -89,86 +90,65 @@ func GetBlueprint(blueprintId uint64) (*models.Blueprint, error) {
 	return blueprint, nil
 }
 
-/*
-func ModifyBlueprint(newBlueprint *models.EditBlueprint) (*models.Blueprint, error) {
-	_, err := cron.ParseStandard(newBlueprint.CronConfig)
-	if err != nil {
-		return nil, fmt.Errorf("invalid cronConfig: %w", err)
-	}
-
-	blueprint := models.Blueprint{}
-	err = db.Model(&models.Blueprint{}).
-		Where("id = ?", newBlueprint.BlueprintId).Limit(1).Find(&blueprint).Error
-	if err != nil {
-		return nil, err
-	}
-	// update cronConfig
-	if newBlueprint.CronConfig != "" {
-		blueprint.CronConfig = newBlueprint.CronConfig
-	}
-	// update tasks
-	if newBlueprint.Tasks != nil {
-		blueprint.Tasks, err = json.Marshal(newBlueprint.Tasks)
-		if err != nil {
-			return nil, err
-		}
-	}
-	blueprint.Enable = newBlueprint.Enable
-
-	err = db.Model(&models.Blueprint{}).
-		Clauses(clause.OnConflict{UpdateAll: true}).Create(&blueprint).Error
-	if err != nil {
-		return nil, errors.InternalError
-	}
-	err = ReloadBlueprints(cronManager)
-	if err != nil {
-		return nil, errors.InternalError
-	}
-	return &blueprint, nil
-}
-*/
-
 func validateBlueprint(blueprint *models.Blueprint) error {
 	// validation
 	err := vld.Struct(blueprint)
 	if err != nil {
 		return err
 	}
-	_, err = cron.ParseStandard(blueprint.CronConfig)
-	if err != nil {
-		return fmt.Errorf("invalid cronConfig: %w", err)
+	if blueprint.CronConfig != models.BLUEPRINT_CRON_MANUAL {
+		_, err = cron.ParseStandard(blueprint.CronConfig)
+		if err != nil {
+			return fmt.Errorf("invalid cronConfig: %w", err)
+		}
 	}
-	tasks := make([][]models.NewTask, 0)
-	err = json.Unmarshal(blueprint.Tasks, &tasks)
-	if err != nil {
-		return fmt.Errorf("invalid tasks: %w", err)
-	}
-	// tasks should not be empty
-	if len(tasks) == 0 || len(tasks[0]) == 0 {
-		return fmt.Errorf("empty tasks")
+	if blueprint.Mode == models.BLUEPRINT_MODE_ADVANCED {
+		tasks := make([][]models.NewTask, 0)
+		err = json.Unmarshal(blueprint.Tasks, &tasks)
+		if err != nil {
+			return fmt.Errorf("invalid tasks: %w", err)
+		}
+		// tasks should not be empty
+		if len(tasks) == 0 || len(tasks[0]) == 0 {
+			return fmt.Errorf("empty tasks")
+		}
 	}
 	// TODO: validate each of every task object
 	return nil
 }
 
-func UpdateBlueprint(blueprint *models.Blueprint) error {
-	// validation
-	err := validateBlueprint(blueprint)
+func PatchBlueprint(id uint64, body map[string]interface{}) (*models.Blueprint, error) {
+	// load record from db
+	blueprint, err := GetBlueprint(id)
 	if err != nil {
-		return err
+		return nil, err
+	}
+	originMode := blueprint.Mode
+	err = mapstructure.Decode(body, blueprint)
+	if err != nil {
+		return nil, err
+	}
+	// make sure mode is not being update
+	if originMode != blueprint.Mode {
+		return nil, fmt.Errorf("mode is not updatable")
+	}
+	// validation
+	err = validateBlueprint(blueprint)
+	if err != nil {
+		return nil, err
 	}
 	// save
 	err = db.Save(blueprint).Error
 	if err != nil {
-		return errors.InternalError
+		return nil, errors.InternalError
 	}
 	// reload schedule
 	err = ReloadBlueprints(cronManager)
 	if err != nil {
-		return errors.InternalError
+		return nil, errors.InternalError
 	}
 	// done
-	return nil
+	return blueprint, nil
 }
 
 func DeleteBlueprint(id uint64) error {

--- a/services/init.go
+++ b/services/init.go
@@ -21,6 +21,7 @@ import (
 	"context"
 
 	"github.com/apache/incubator-devlake/models/migrationscripts"
+	"github.com/apache/incubator-devlake/plugins/core"
 
 	"time"
 
@@ -36,10 +37,12 @@ import (
 var cfg *viper.Viper
 var db *gorm.DB
 var cronManager *cron.Cron
+var log core.Logger
 
 func init() {
 	var err error
 	cfg = config.GetConfig()
+	log = logger.Global
 	db, err = runner.NewGormDb(cfg, logger.Global.Nested("db"))
 	location := cron.WithLocation(time.UTC)
 	cronManager = cron.New(location)


### PR DESCRIPTION
# Summary

Implement `mode` support for `blueprint`

1. added `mode` field to `blueprint`
2. `tasks` field is not required if `mode` == `NORMAL` because it would be generated by `settings` in the near future
3. added `isManual` to indicate if it is triggered by scheduler, `cronConfig` is required IFF `isManual == false`, but it gets validated if provided
4. `NORMAL` is not implemented yet

### Does this close any open issues?
Closes #1987 

### Screenshots
![image](https://user-images.githubusercontent.com/61080/174265332-fd46f3f1-183c-41c3-a411-2a7dc91d976a.png)
![image](https://user-images.githubusercontent.com/61080/174265378-dcd86d09-392b-4980-92f5-4094e74f133e.png)
![image](https://user-images.githubusercontent.com/61080/174265510-eb036c5c-d8d2-461b-93a4-ec64a5ae6127.png)
