### PR TITLE
Run config-ui nginx container as non-root

### DIFF
--- a/config-ui/Dockerfile
+++ b/config-ui/Dockerfile
@@ -31,7 +31,8 @@ RUN npm ci
 COPY . /home/node/code
 RUN npm run build-production
 
-FROM nginx:latest
+FROM nginxinc/nginx-unprivileged:1.21
+USER 0
 #ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait /wait
 #RUN chmod +x /wait
 RUN rm /etc/nginx/conf.d/default.conf
@@ -43,4 +44,5 @@ EXPOSE 80 443
 RUN apt update && apt install -y apache2-utils
 COPY ./nginx.sh /usr/bin/nginx.sh
 RUN chmod +x /usr/bin/nginx.sh
+USER 101
 CMD nginx.sh


### PR DESCRIPTION
config-ui nginx was running as root, which is not a best practice, as an attacker can potentially become root in a given kubernetes node using some security breach. This commit switches to use an unprivileged nginx container, which runs as nginx user. In addition, it fixes the tag of the image to inherit from, as using latest is also not a good practice, as it can lead to introduce breaking changes if the parent image moves the latest tag to a new image with said breaking changes.

# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Does this close any open issues?
No

### Screenshots
We have it running with those changes in our Kubernetes cluster with no issues. Notice the custom securityContext configuration that we set states to not run the containers as root:

![image](https://user-images.githubusercontent.com/16705936/174236662-1942420b-a932-435f-a31a-533ec3ec10bc.png)

### Other Information
N/A