### PR TITLE
fix: ignore http status code 404

### DIFF
--- a/plugins/helper/api_async_client.go
+++ b/plugins/helper/api_async_client.go
@@ -225,7 +225,7 @@ type RateLimitedApiClient interface {
 	HasError() bool
 	NextTick(task func() error)
 	GetNumOfWorkers() int
-	SetAfterFunction(callback ApiClientAfterResponse)
+	SetAfterFunction(callback common.ApiClientAfterResponse)
 }
 
 var _ RateLimitedApiClient = (*ApiAsyncClient)(nil)

--- a/plugins/helper/api_async_client.go
+++ b/plugins/helper/api_async_client.go
@@ -154,6 +154,11 @@ func (apiClient *ApiAsyncClient) DoAsync(
 				res.Body = io.NopCloser(bytes.NewBuffer(body))
 			}
 		}
+		if err == ErrIgnoreAndContinue {
+			// make sure defer func got be executed
+			err = nil
+			return nil
+		}
 
 		// check
 		needRetry := false
@@ -220,6 +225,7 @@ type RateLimitedApiClient interface {
 	HasError() bool
 	NextTick(task func() error)
 	GetNumOfWorkers() int
+	SetAfterFunction(callback ApiClientAfterResponse)
 }
 
 var _ RateLimitedApiClient = (*ApiAsyncClient)(nil)

--- a/plugins/helper/api_client.go
+++ b/plugins/helper/api_client.go
@@ -33,11 +33,11 @@ import (
 	"unicode/utf8"
 
 	"github.com/apache/incubator-devlake/plugins/core"
+	"github.com/apache/incubator-devlake/plugins/helper/common"
 	"github.com/apache/incubator-devlake/utils"
 )
 
 type ApiClientBeforeRequest func(req *http.Request) error
-type ApiClientAfterResponse func(res *http.Response) error
 
 var ErrIgnoreAndContinue = errors.New("ignore and continue")
 
@@ -47,7 +47,7 @@ type ApiClient struct {
 	endpoint      string
 	headers       map[string]string
 	beforeRequest ApiClientBeforeRequest
-	afterReponse  ApiClientAfterResponse
+	afterReponse  common.ApiClientAfterResponse
 	ctx           context.Context
 	logger        core.Logger
 }
@@ -127,7 +127,7 @@ func (apiClient *ApiClient) SetBeforeFunction(callback ApiClientBeforeRequest) {
 	apiClient.beforeRequest = callback
 }
 
-func (apiClient *ApiClient) SetAfterFunction(callback ApiClientAfterResponse) {
+func (apiClient *ApiClient) SetAfterFunction(callback common.ApiClientAfterResponse) {
 	apiClient.afterReponse = callback
 }
 

--- a/plugins/helper/api_client.go
+++ b/plugins/helper/api_client.go
@@ -37,8 +37,6 @@ import (
 	"github.com/apache/incubator-devlake/utils"
 )
 
-type ApiClientBeforeRequest func(req *http.Request) error
-
 var ErrIgnoreAndContinue = errors.New("ignore and continue")
 
 // ApiClient is designed for simple api requests
@@ -46,7 +44,7 @@ type ApiClient struct {
 	client        *http.Client
 	endpoint      string
 	headers       map[string]string
-	beforeRequest ApiClientBeforeRequest
+	beforeRequest common.ApiClientBeforeRequest
 	afterReponse  common.ApiClientAfterResponse
 	ctx           context.Context
 	logger        core.Logger
@@ -123,7 +121,7 @@ func (apiClient *ApiClient) GetHeaders() map[string]string {
 	return apiClient.headers
 }
 
-func (apiClient *ApiClient) SetBeforeFunction(callback ApiClientBeforeRequest) {
+func (apiClient *ApiClient) SetBeforeFunction(callback common.ApiClientBeforeRequest) {
 	apiClient.beforeRequest = callback
 }
 

--- a/plugins/helper/api_client.go
+++ b/plugins/helper/api_client.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -37,6 +38,8 @@ import (
 
 type ApiClientBeforeRequest func(req *http.Request) error
 type ApiClientAfterResponse func(res *http.Response) error
+
+var ErrIgnoreAndContinue = errors.New("ignore and continue")
 
 // ApiClient is designed for simple api requests
 type ApiClient struct {
@@ -220,6 +223,9 @@ func (apiClient *ApiClient) Do(
 	// after receive
 	if apiClient.afterReponse != nil {
 		err = apiClient.afterReponse(res)
+		if err == ErrIgnoreAndContinue {
+			return res, err
+		}
 		if err != nil {
 			res.Body.Close()
 			return nil, err

--- a/plugins/helper/api_collector.go
+++ b/plugins/helper/api_collector.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/apache/incubator-devlake/plugins/core"
 	"github.com/apache/incubator-devlake/plugins/core/dal"
+	"github.com/apache/incubator-devlake/plugins/helper/common"
 )
 
 // Pager contains pagination information for a api request
@@ -73,7 +74,7 @@ type ApiCollectorArgs struct {
 	// NORMALLY, DO NOT SPECIFY THIS PARAMETER, unless you know what it means
 	Concurrency    int
 	ResponseParser func(res *http.Response) ([]json.RawMessage, error)
-	AfterResponse  ApiClientAfterResponse
+	AfterResponse  common.ApiClientAfterResponse
 }
 
 type ApiCollector struct {
@@ -285,7 +286,7 @@ func (collector *ApiCollector) generateUrl(pager *Pager, input interface{}) (str
 	return buf.String(), nil
 }
 
-func (collector *ApiCollector) SetAfterResponse(f ApiClientAfterResponse) {
+func (collector *ApiCollector) SetAfterResponse(f common.ApiClientAfterResponse) {
 	collector.args.ApiClient.SetAfterFunction(f)
 }
 

--- a/plugins/helper/api_collector.go
+++ b/plugins/helper/api_collector.go
@@ -73,6 +73,7 @@ type ApiCollectorArgs struct {
 	// NORMALLY, DO NOT SPECIFY THIS PARAMETER, unless you know what it means
 	Concurrency    int
 	ResponseParser func(res *http.Response) ([]json.RawMessage, error)
+	AfterResponse  ApiClientAfterResponse
 }
 
 type ApiCollector struct {
@@ -104,11 +105,22 @@ func NewApiCollector(args ApiCollectorArgs) (*ApiCollector, error) {
 	if args.ResponseParser == nil {
 		return nil, fmt.Errorf("ResponseParser is required")
 	}
-	return &ApiCollector{
+	apicllector := &ApiCollector{
 		RawDataSubTask: rawDataSubTask,
 		args:           &args,
 		urlTemplate:    tpl,
-	}, nil
+	}
+	if args.AfterResponse != nil {
+		apicllector.SetAfterResponse(args.AfterResponse)
+	} else {
+		apicllector.SetAfterResponse(func(res *http.Response) error {
+			if res.StatusCode == http.StatusUnauthorized {
+				return fmt.Errorf("authentication failed, please check your AccessToken")
+			}
+			return nil
+		})
+	}
+	return apicllector, nil
 }
 
 // Start collection
@@ -271,6 +283,10 @@ func (collector *ApiCollector) generateUrl(pager *Pager, input interface{}) (str
 		return "", err
 	}
 	return buf.String(), nil
+}
+
+func (collector *ApiCollector) SetAfterResponse(f ApiClientAfterResponse) {
+	collector.args.ApiClient.SetAfterFunction(f)
 }
 
 func (collector *ApiCollector) fetchAsync(reqData *RequestData, handler func(int, []byte, *http.Response) error) {

--- a/plugins/helper/api_collector_test.go
+++ b/plugins/helper/api_collector_test.go
@@ -72,7 +72,7 @@ func TestFetchPageUndetermined(t *testing.T) {
 	}).Twice()
 	mockApi.On("HasError").Return(false)
 	mockApi.On("WaitAsync").Return(nil)
-
+	mockApi.On("SetAfterFunction", mock.Anything).Return()
 	params := struct {
 		Name string
 	}{Name: "testparams"}

--- a/plugins/helper/common/callbacks.go
+++ b/plugins/helper/common/callbacks.go
@@ -20,3 +20,4 @@ package common
 import "net/http"
 
 type ApiAsyncCallback func(*http.Response) error
+type ApiClientAfterResponse func(res *http.Response) error

--- a/plugins/helper/common/hooks.go
+++ b/plugins/helper/common/hooks.go
@@ -20,4 +20,6 @@ package common
 import "net/http"
 
 type ApiAsyncCallback func(*http.Response) error
+
+type ApiClientBeforeRequest func(req *http.Request) error
 type ApiClientAfterResponse func(res *http.Response) error

--- a/plugins/jira/jira.go
+++ b/plugins/jira/jira.go
@@ -168,6 +168,7 @@ func (plugin Jira) MigrationScripts() []migration.Script {
 		new(migrationscripts.UpdateSchemas20220527),
 		new(migrationscripts.UpdateSchemas20220601),
 		new(migrationscripts.UpdateSchemas20220614),
+		new(migrationscripts.UpdateSchemas20220615),
 		new(migrationscripts.UpdateSchemas20220616),
 	}
 }

--- a/plugins/jira/tasks/api_client.go
+++ b/plugins/jira/tasks/api_client.go
@@ -79,3 +79,13 @@ func GetJiraServerInfo(client *helper.ApiAsyncClient) (*models.JiraServerInfo, i
 	}
 	return serverInfo, res.StatusCode, nil
 }
+
+func ignoreHTTPStatus404(res *http.Response) error {
+	if res.StatusCode == http.StatusUnauthorized {
+		return fmt.Errorf("authentication failed, please check your AccessToken")
+	}
+	if res.StatusCode == http.StatusNotFound {
+		return helper.ErrIgnoreAndContinue
+	}
+	return nil
+}

--- a/plugins/jira/tasks/changelog_collector.go
+++ b/plugins/jira/tasks/changelog_collector.go
@@ -111,6 +111,7 @@ func CollectChangelogs(taskCtx core.SubTaskContext) error {
 			}
 			return data.Values, nil
 		},
+		AfterResponse: ignoreHTTPStatus404,
 	})
 
 	if err != nil {

--- a/plugins/jira/tasks/remotelink_collector.go
+++ b/plugins/jira/tasks/remotelink_collector.go
@@ -94,6 +94,7 @@ func CollectRemotelinks(taskCtx core.SubTaskContext) error {
 			}
 			return result, nil
 		},
+		AfterResponse: ignoreHTTPStatus404,
 	})
 	if err != nil {
 		return err

--- a/plugins/jira/tasks/worklog_collector.go
+++ b/plugins/jira/tasks/worklog_collector.go
@@ -19,6 +19,7 @@ package tasks
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"reflect"
 
@@ -89,6 +90,15 @@ func CollectWorklogs(taskCtx core.SubTaskContext) error {
 				return nil, err
 			}
 			return data.Worklogs, nil
+		},
+		AfterResponse: func(res *http.Response) error {
+			if res.StatusCode == http.StatusUnauthorized {
+				return fmt.Errorf("authentication failed, please check your AccessToken")
+			}
+			if res.StatusCode == http.StatusNotFound {
+				return helper.ErrIgnoreAndContinue
+			}
+			return nil
 		},
 	})
 	if err != nil {

--- a/plugins/jira/tasks/worklog_collector.go
+++ b/plugins/jira/tasks/worklog_collector.go
@@ -19,7 +19,6 @@ package tasks
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"reflect"
 
@@ -91,15 +90,7 @@ func CollectWorklogs(taskCtx core.SubTaskContext) error {
 			}
 			return data.Worklogs, nil
 		},
-		AfterResponse: func(res *http.Response) error {
-			if res.StatusCode == http.StatusUnauthorized {
-				return fmt.Errorf("authentication failed, please check your AccessToken")
-			}
-			if res.StatusCode == http.StatusNotFound {
-				return helper.ErrIgnoreAndContinue
-			}
-			return nil
-		},
+		AfterResponse: ignoreHTTPStatus404,
 	})
 	if err != nil {
 		logger.Error("collect board error:", err)


### PR DESCRIPTION

# Summary

fix #2226 
Adding an function type attribute `AfterResponse` to `helper.ApiCollectorArgs`. This function would check all the HTTP responses, if the status code is 404, it returns a predefined error `helper.ErrIgnoreAndContinue`. The rest part of the `collector` will ignore this error and skip to the next HTTP request.

### Does this close any open issues?
close #2226 

