### PR TITLE
fix(tapd): ignore err if it's record not found

### DIFF
--- a/plugins/tapd/impl/impl.go
+++ b/plugins/tapd/impl/impl.go
@@ -19,7 +19,7 @@ package impl
 
 import (
 	"fmt"
-	"github.com/apache/incubator-devlake/plugins/core/dal"
+	"github.com/apache/incubator-devlake/plugins/helper"
 	"time"
 
 	"github.com/apache/incubator-devlake/migration"
@@ -115,23 +115,24 @@ func (plugin Tapd) SubTaskMetas() []core.SubTaskMeta {
 }
 
 func (plugin Tapd) PrepareTaskData(taskCtx core.TaskContext, options map[string]interface{}) (interface{}, error) {
-	db := taskCtx.GetDal()
 	var op tasks.TapdOptions
 	err := mapstructure.Decode(options, &op)
 	if err != nil {
 		return nil, err
 	}
 	if op.ConnectionId == 0 {
-		return nil, fmt.Errorf("ConnectionId is required for Tapd execution")
+		return nil, fmt.Errorf("connectionId is invalid")
 	}
 	connection := &models.TapdConnection{}
-	clauses := []dal.Clause{
-		dal.Where("connection_id = ?", op.ConnectionId),
-	}
-	err = db.First(connection, clauses...)
+	connectionHelper := helper.NewConnectionHelper(
+		taskCtx,
+		nil,
+	)
+	err = connectionHelper.FirstById(connection, op.ConnectionId)
 	if err != nil {
 		return nil, err
 	}
+
 	var since time.Time
 	if op.Since != "" {
 		since, err = time.Parse("2006-01-02T15:04:05Z", op.Since)

--- a/plugins/tapd/tasks/bug_changelog_collector.go
+++ b/plugins/tapd/tasks/bug_changelog_collector.go
@@ -46,7 +46,7 @@ func CollectBugChangelogs(taskCtx core.SubTaskContext) error {
 			dal.Orderby("created DESC"),
 		}
 		err := db.First(&latestUpdated, clauses...)
-		if err != nil {
+		if err != nil && err.Error() != "record not found" {
 			return fmt.Errorf("failed to get latest tapd changelog record: %w", err)
 		}
 		if latestUpdated.Id > 0 {

--- a/plugins/tapd/tasks/bug_collector.go
+++ b/plugins/tapd/tasks/bug_collector.go
@@ -47,7 +47,7 @@ func CollectBugs(taskCtx core.SubTaskContext) error {
 			dal.Orderby("modified DESC"),
 		}
 		err := db.First(&latestUpdated, clauses...)
-		if err != nil {
+		if err != nil && err.Error() != "record not found" {
 			return fmt.Errorf("failed to get latest tapd changelog record: %w", err)
 		}
 		if latestUpdated.Id > 0 {

--- a/plugins/tapd/tasks/bug_commit_collector.go
+++ b/plugins/tapd/tasks/bug_commit_collector.go
@@ -54,7 +54,7 @@ func CollectBugCommits(taskCtx core.SubTaskContext) error {
 			dal.Orderby("created DESC"),
 		}
 		err := db.First(&latestUpdated, clauses...)
-		if err != nil {
+		if err != nil && err.Error() != "record not found" {
 			return fmt.Errorf("failed to get latest tapd changelog record: %w", err)
 		}
 		if latestUpdated.Id > 0 {

--- a/plugins/tapd/tasks/iteration_collector.go
+++ b/plugins/tapd/tasks/iteration_collector.go
@@ -48,7 +48,7 @@ func CollectIterations(taskCtx core.SubTaskContext) error {
 			dal.Orderby("created DESC"),
 		}
 		err := db.First(&latestUpdated, clauses...)
-		if err != nil {
+		if err != nil && err.Error() != "record not found" {
 			return fmt.Errorf("failed to get latest tapd changelog record: %w", err)
 		}
 		if latestUpdated.Id > 0 {

--- a/plugins/tapd/tasks/story_changelog_collector.go
+++ b/plugins/tapd/tasks/story_changelog_collector.go
@@ -46,7 +46,7 @@ func CollectStoryChangelogs(taskCtx core.SubTaskContext) error {
 			dal.Orderby("created DESC"),
 		}
 		err := db.First(&latestUpdated, clauses...)
-		if err != nil {
+		if err != nil && err.Error() != "record not found" {
 			return fmt.Errorf("failed to get latest tapd changelog record: %w", err)
 		}
 		if latestUpdated.Id > 0 {

--- a/plugins/tapd/tasks/story_collector.go
+++ b/plugins/tapd/tasks/story_collector.go
@@ -46,7 +46,7 @@ func CollectStorys(taskCtx core.SubTaskContext) error {
 			dal.Orderby("modified DESC"),
 		}
 		err := db.First(&latestUpdated, clauses...)
-		if err != nil {
+		if err != nil && err.Error() != "record not found" {
 			return fmt.Errorf("failed to get latest tapd changelog record: %w", err)
 		}
 		if latestUpdated.Id > 0 {

--- a/plugins/tapd/tasks/story_commit_collector.go
+++ b/plugins/tapd/tasks/story_commit_collector.go
@@ -54,7 +54,7 @@ func CollectStoryCommits(taskCtx core.SubTaskContext) error {
 			dal.Orderby("created DESC"),
 		}
 		err := db.First(&latestUpdated, clauses...)
-		if err != nil {
+		if err != nil && err.Error() != "record not found" {
 			return fmt.Errorf("failed to get latest tapd changelog record: %w", err)
 		}
 		if latestUpdated.Id > 0 {

--- a/plugins/tapd/tasks/task_changelog_collector.go
+++ b/plugins/tapd/tasks/task_changelog_collector.go
@@ -46,7 +46,7 @@ func CollectTaskChangelogs(taskCtx core.SubTaskContext) error {
 			dal.Orderby("created DESC"),
 		}
 		err := db.First(&latestUpdated, clauses...)
-		if err != nil {
+		if err != nil && err.Error() != "record not found" {
 			return fmt.Errorf("failed to get latest tapd changelog record: %w", err)
 		}
 		if latestUpdated.Id > 0 {

--- a/plugins/tapd/tasks/task_collector.go
+++ b/plugins/tapd/tasks/task_collector.go
@@ -48,7 +48,7 @@ func CollectTasks(taskCtx core.SubTaskContext) error {
 			dal.Orderby("modified DESC"),
 		}
 		err := db.First(&latestUpdated, clauses...)
-		if err != nil {
+		if err != nil && err.Error() != "record not found" {
 			return fmt.Errorf("failed to get latest tapd changelog record: %w", err)
 		}
 		if latestUpdated.Id > 0 {

--- a/plugins/tapd/tasks/task_commit_collector.go
+++ b/plugins/tapd/tasks/task_commit_collector.go
@@ -54,7 +54,7 @@ func CollectTaskCommits(taskCtx core.SubTaskContext) error {
 			dal.Orderby("created DESC"),
 		}
 		err := db.First(&latestUpdated, clauses...)
-		if err != nil {
+		if err != nil && err.Error() != "record not found" {
 			return fmt.Errorf("failed to get latest tapd changelog record: %w", err)
 		}
 		if latestUpdated.Id > 0 {

--- a/plugins/tapd/tasks/worklog_collector.go
+++ b/plugins/tapd/tasks/worklog_collector.go
@@ -46,7 +46,7 @@ func CollectWorklogs(taskCtx core.SubTaskContext) error {
 			dal.Orderby("created DESC"),
 		}
 		err := db.First(&latestUpdated, clauses...)
-		if err != nil {
+		if err != nil && err.Error() != "record not found" {
 			return fmt.Errorf("failed to get latest tapd changelog record: %w", err)
 		}
 		if latestUpdated.Id > 0 {


### PR DESCRIPTION
# Summary

ignore err if it's `record not found` when fetch latestUpdate from db in `Collector`

### Does this close any open issues?
relate to #2282 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
