### PR TITLE
fix: add mount localtime while deploy with helm

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -48,10 +48,11 @@ jobs:
         run: |
           export NODE_IP=$(kubectl get nodes --namespace default -o jsonpath="{.items[0].status.addresses[0].address}")
           echo Node IP: ${NODE_IP}
-          helm install --wait --timeout 600s deploy-test deployment/helm \
+          helm install --wait --timeout 300s deploy-test deployment/helm \
             --set service.uiPort=30000 \
             --set service.grafanaPort=30001 \
-            --set service.grafanaEndpoint=http://${NODE_IP}:30001
+            --set service.grafanaEndpoint=http://${NODE_IP}:30001 \
+            --set option.localtime=""
           kubectl get pods -o wide
           kubectl get services -o wide
 
@@ -83,7 +84,9 @@ jobs:
         if: ${{ always() }}
         run: |
           for pod in $(kubectl get pods -o jsonpath='{.items[*].metadata.name}') ; do
+            echo describe for $pod
+            kubectl describe pod $pod
             echo logs for $pod
-            kubectl logs $pod
+            kubectl logs $pod || echo ""
           done
 

--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -109,3 +109,5 @@ Some useful parameters for the chart, you could also check them in values.yaml
 | service.ingress.tlsSecretName  | The secret name for tls's certificate, required when https enabled  | ""  |
 | service.ingress.httpPort  | The http port for ingress  | 80  |
 | service.ingress.httpsPort  | The https port for ingress  | 443  |
+| option.localtime  | The hostpath for mount as /etc/localtime | /etc/localtime  |
+

--- a/deployment/helm/templates/deployments.yaml
+++ b/deployment/helm/templates/deployments.yaml
@@ -61,6 +61,11 @@ spec:
             - mountPath: /etc/grafana/grafana.ini
               name: {{ include "devlake.fullname" . }}-grafana-config
               subPath: grafana.ini
+            {{- if ne .Values.option.localtime "" }}
+            - name: {{ include "devlake.fullname" . }}-grafana-localtime
+              mountPath: /etc/localtime
+              readOnly: true
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "devlake.fullname" . }}-config
@@ -78,6 +83,12 @@ spec:
             defaultMode: 420
             name: {{ include "devlake.fullname" . }}-grafana-config
           name: {{ include "devlake.fullname" . }}-grafana-config
+        {{- if ne .Values.option.localtime "" }}
+        - name: {{ include "devlake.fullname" . }}-grafana-localtime
+          hostPath:
+            path: {{ .Values.option.localtime }}
+            type: File
+        {{- end }}
 
 ---
 # devlake-ui
@@ -117,3 +128,16 @@ spec:
             #   value: "admin"
             # - name: ADMIN_PASS
             #   value: "admin"
+          volumeMounts:
+            {{- if ne .Values.option.localtime "" }}
+            - name: {{ include "devlake.fullname" . }}-ui-localtime
+              mountPath: /etc/localtime
+              readOnly: true
+            {{- end }}
+      volumes:
+        {{- if ne .Values.option.localtime "" }}
+        - name: {{ include "devlake.fullname" . }}-ui-localtime
+          hostPath:
+            path: {{ .Values.option.localtime }}
+            type: File
+        {{- end }}

--- a/deployment/helm/templates/statefulsets.yaml
+++ b/deployment/helm/templates/statefulsets.yaml
@@ -68,6 +68,12 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/mysql
               name: {{ include "devlake.fullname" . }}-mysql-data
+          volumeMounts:
+            {{- if ne .Values.option.localtime "" }}
+            - name: {{ include "devlake.fullname" . }}-mysql-localtime
+              mountPath: /etc/localtime
+              readOnly: true
+            {{- end }}
       {{- with .Values.mysql.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -80,6 +86,13 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+        {{- if ne .Values.option.localtime "" }}
+        - name: {{ include "devlake.fullname" . }}-mysql-localtime
+          hostPath:
+            path: {{ .Values.option.localtime }}
+            type: File
+        {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: {{ include "devlake.fullname" . }}-mysql-data
@@ -148,6 +161,18 @@ spec:
           volumeMounts:
             - mountPath: /app/config
               name: {{ include "devlake.fullname" . }}-lake-config
+            {{- if ne .Values.option.localtime "" }}
+            - name: {{ include "devlake.fullname" . }}-lake-localtime
+              mountPath: /etc/localtime
+              readOnly: true
+            {{- end }}
+      volumes:
+        {{- if ne .Values.option.localtime "" }}
+        - name: {{ include "devlake.fullname" . }}-lake-localtime
+          hostPath:
+            path: {{ .Values.option.localtime }}
+            type: File
+        {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: {{ include "devlake.fullname" . }}-lake-config

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -150,3 +150,9 @@ ingress:
   httpPort: 80
   # ingress https port
   httpsPort: 443
+
+
+option:
+  # localtime zone info from host path.
+  localtime: /etc/localtime
+


### PR DESCRIPTION
# Summary
Add mount entry for localtime while deploy with helm chart.


### Does this close any open issues?
Closes #2278 

### Screenshots
```
[root@nuc incubator-devlake]# kubectl exec devlake0-lake-0 -- date
Tue Jun 21 18:18:36 CST 2022
[root@nuc incubator-devlake]#
```
With this patch, the container uses the same time zone as the node.


### Other Information
N/A
