### PR TITLE
feat: shorten the prefix of doc issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,7 +1,7 @@
 ---
 name: Documentation Issue
 about: Help improve our documentation
-title: '[Documentation][Module Name] Documentation title'
+title: '[Doc][Module Name] Documentation title'
 labels: type/docs
 assignees: ''
 


### PR DESCRIPTION
# Summary
The prefix of documentation-type issues is too long, so I changed it from [Documentation] to [Doc]

### Does this close any open issues?
No issue

### Screenshots
![image](https://user-images.githubusercontent.com/14050754/175021693-8134fed6-10b5-44ec-9e39-a787a548cc81.png)
