### PR TITLE
Debug with delve / compile-script swallowing compilation error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ VERSION = $(TAG)@$(SHA)
 build-plugin:
 	@sh scripts/compile-plugins.sh
 
+build-plugin-debug:
+	@sh scripts/compile-plugins.sh -gcflags='all=-N -l'
+
 build-worker:
 	go build -ldflags "-X 'github.com/apache/incubator-devlake/version.Version=$(VERSION)'" -o bin/lake-worker ./worker/
 
@@ -41,6 +44,9 @@ worker:
 	go run worker/*.go
 
 dev: build-plugin run
+
+debug: build-plugin-debug
+	dlv debug main.go
 
 configure:
 	docker-compose up config-ui

--- a/scripts/compile-plugins.sh
+++ b/scripts/compile-plugins.sh
@@ -16,8 +16,17 @@
 # limitations under the License.
 #
 
-# If you want to use this, you need to run `PLUGIN=github make dev`
-# to compile all plugins `make dev`
+# compile all plugins and fire up api server:
+#   make dev
+#
+# compile specific plugin and fire up api server:
+#   PLUGIN=<PLUGIN_NAME> make dev
+#
+# compile all plugins and fire up api server in DEBUG MODE with `delve`:
+#   make debug
+#
+# compile specific plugin and fire up api server in DEBUG MODE with `delve`:
+#   PLUGIN=<PLUGIN_NAME> make dev
 
 set -e
 
@@ -36,9 +45,15 @@ else
 fi
 
 rm -rf $PLUGIN_OUTPUT_DIR/*
+
+PIDS=""
 for PLUG in $PLUGINS; do
     NAME=$(basename $PLUG)
     echo "Building plugin $NAME to bin/plugins/$NAME/$NAME.so"
     go build -buildmode=plugin "$@" -o $PLUGIN_OUTPUT_DIR/$NAME/$NAME.so $PLUG/*.go &
+    PIDS="$PIDS $!"
 done
-wait
+
+for PID in $PIDS; do
+    wait $PID
+done


### PR DESCRIPTION
# Summary

1. run `make debug` to fire up api server with `delve` for breakpoint debugging
2. fix `scripts/compile-plugins.sh` error swallowing, it keeps going even if the compilation failed

![image](https://user-images.githubusercontent.com/61080/175056288-de2b0099-2f71-4722-80d4-5c0a2935b160.png)
