### PR TITLE
feat: blueprint normal mode framework-side

### DIFF
--- a/impl/dalgorm/dalgorm.go
+++ b/impl/dalgorm/dalgorm.go
@@ -109,7 +109,11 @@ func (d *Dalgorm) All(dst interface{}, clauses ...dal.Clause) error {
 
 // First loads first matched row from database to `dst`, error will be returned if no records were found
 func (d *Dalgorm) First(dst interface{}, clauses ...dal.Clause) error {
-	return buildTx(d.db, clauses).First(dst).Error
+	err := buildTx(d.db, clauses).First(dst).Error
+	if err == gorm.ErrRecordNotFound {
+		return dal.ErrRecordNotFound
+	}
+	return err
 }
 
 // Count total records

--- a/models/blueprint.go
+++ b/models/blueprint.go
@@ -18,6 +18,8 @@ limitations under the License.
 package models
 
 import (
+	"encoding/json"
+
 	"github.com/apache/incubator-devlake/models/common"
 	"gorm.io/datatypes"
 )
@@ -28,13 +30,19 @@ const BLUEPRINT_MODE_ADVANCED = "ADVANCED"
 type Blueprint struct {
 	Name       string         `json:"name" validate:"required"`
 	Mode       string         `json:"mode" gorm:"varchar(20)" validate:"required,oneof=NORMAL ADVANCED"`
-	Tasks      datatypes.JSON `json:"tasks"`
+	Plan       datatypes.JSON `json:"plan"`
 	Enable     bool           `json:"enable"`
 	CronConfig string         `json:"cronConfig"`
 	IsManual   bool           `json:"isManual"`
+	Settings   datatypes.JSON `json:"settings"`
 	common.Model
 }
 
 func (Blueprint) TableName() string {
 	return "_devlake_blueprints"
+}
+
+type BlueprintSettings struct {
+	Version     string          `json:"version" validate:"required,semver,oneof=1.0.0"`
+	Connections json.RawMessage `json:"connections" validate:"required"`
 }

--- a/models/migrationscripts/220622-blueprint-normal-mode.go
+++ b/models/migrationscripts/220622-blueprint-normal-mode.go
@@ -1,0 +1,69 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"context"
+
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+// model blueprint
+type blueprintNormalMode_Blueprint struct {
+	Settings datatypes.JSON `json:"settings"`
+}
+
+func (blueprintNormalMode_Blueprint) TableName() string {
+	return "_devlake_blueprints"
+}
+
+// model pipeline
+type blueprintNormalMode_Pipeline struct {
+}
+
+func (blueprintNormalMode_Pipeline) TableName() string {
+	return "_devlake_pipelines"
+}
+
+// migration script
+type blueprintNormalMode struct{}
+
+func (*blueprintNormalMode) Up(ctx context.Context, db *gorm.DB) error {
+	err := db.Migrator().AutoMigrate(&blueprintNormalMode_Blueprint{})
+	if err != nil {
+		return err
+	}
+	err = db.Migrator().RenameColumn(&blueprintNormalMode_Blueprint{}, "tasks", "plan")
+	if err != nil {
+		return err
+	}
+	err = db.Migrator().RenameColumn(&blueprintNormalMode_Pipeline{}, "tasks", "plan")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (*blueprintNormalMode) Version() uint64 {
+	return 20220622110537
+}
+
+func (*blueprintNormalMode) Name() string {
+	return "blueprint normal mode support"
+}

--- a/models/migrationscripts/register.go
+++ b/models/migrationscripts/register.go
@@ -28,5 +28,6 @@ func All() []migration.Script {
 		new(updateSchemas20220527), new(updateSchemas20220528), new(updateSchemas20220601),
 		new(updateSchemas20220602), new(updateSchemas20220612), new(updateSchemas20220613),
 		new(updateSchemas20220614), new(updateSchemas2022061402), new(updateSchemas20220616),
+		new(blueprintNormalMode),
 	}
 }

--- a/models/pipeline.go
+++ b/models/pipeline.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/apache/incubator-devlake/models/common"
+	"github.com/apache/incubator-devlake/plugins/core"
 
 	"gorm.io/datatypes"
 )
@@ -29,7 +30,7 @@ type Pipeline struct {
 	common.Model
 	Name          string         `json:"name" gorm:"index"`
 	BlueprintId   uint64         `json:"blueprintId"`
-	Tasks         datatypes.JSON `json:"tasks"`
+	Plan          datatypes.JSON `json:"plan"`
 	TotalTasks    int            `json:"totalTasks"`
 	FinishedTasks int            `json:"finishedTasks"`
 	BeganAt       *time.Time     `json:"beganAt"`
@@ -43,8 +44,8 @@ type Pipeline struct {
 // We use a 2D array because the request body must be an array of a set of tasks
 // to be executed concurrently, while each set is to be executed sequentially.
 type NewPipeline struct {
-	Name        string       `json:"name"`
-	Tasks       [][]*NewTask `json:"tasks"`
+	Name        string            `json:"name"`
+	Plan        core.PipelinePlan `json:"plan"`
 	BlueprintId uint64
 }
 

--- a/models/task.go
+++ b/models/task.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/apache/incubator-devlake/models/common"
+	"github.com/apache/incubator-devlake/plugins/core"
 	"gorm.io/datatypes"
 )
 
@@ -61,12 +62,10 @@ type Task struct {
 
 type NewTask struct {
 	// Plugin name
-	Plugin      string                 `json:"plugin" binding:"required"`
-	Subtasks    []string               `json:"subtasks"`
-	Options     map[string]interface{} `json:"options"`
-	PipelineId  uint64                 `json:"-"`
-	PipelineRow int                    `json:"-"`
-	PipelineCol int                    `json:"-"`
+	*core.PipelineTask
+	PipelineId  uint64 `json:"-"`
+	PipelineRow int    `json:"-"`
+	PipelineCol int    `json:"-"`
 }
 
 func (Task) TableName() string {

--- a/plugins/core/dal/dal.go
+++ b/plugins/core/dal/dal.go
@@ -19,6 +19,7 @@ package dal
 
 import (
 	"database/sql"
+	"errors"
 )
 
 type Clause struct {
@@ -129,3 +130,5 @@ const HavingClause string = "Having"
 func Having(clause string, params ...interface{}) Clause {
 	return Clause{Type: HavingClause, Data: DalClause{clause, params}}
 }
+
+var ErrRecordNotFound = errors.New("record not found")

--- a/plugins/core/plugin_blueprint.go
+++ b/plugins/core/plugin_blueprint.go
@@ -1,0 +1,57 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import "encoding/json"
+
+// PluginBlueprint is used to support Blueprint Normal model
+type PluginBlueprintV100 interface {
+	// MakePipelinePlan generates `pipeline.tasks` based on `version` and `scope`
+	//
+	// `version` semver from `blueprint.settings.version`
+	// `scope` arbitrary json.RawMessage, depends on `version`, for v0.0.1, it is an Array of Objects
+	MakePipelinePlan(connectionId uint64, scope []*BlueprintScopeV100) (PipelinePlan, error)
+}
+
+// BlueprintConnectionV100 is the connection definition for protocol v1.0.0
+type BlueprintConnectionV100 struct {
+	Plugin       string                `json:"plugin" validate:"required"`
+	ConnectionId uint64                `json:"connectionId" validate:"required"`
+	Scope        []*BlueprintScopeV100 `json:"scope" validate:"required"`
+}
+
+// BlueprintScopeV100 is the scope definition for protocol v1.0.0
+type BlueprintScopeV100 struct {
+	Entities       []string        `json:"entities"`
+	Options        json.RawMessage `json:"options"`
+	Transformation json.RawMessage `json:"transformation"`
+}
+
+// PipelineTask represents a smallest unit of execution inside a PipelinePlan
+type PipelineTask struct {
+	// Plugin name
+	Plugin   string                 `json:"plugin" binding:"required"`
+	Subtasks []string               `json:"subtasks"`
+	Options  map[string]interface{} `json:"options"`
+}
+
+// PipelineStage consist of multiple PipelineTasks, they will be executed in parallel
+type PipelineStage []*PipelineTask
+
+// PipelinePlan consist of multiple PipelineStages, they will be executed in sequential order
+type PipelinePlan []PipelineStage

--- a/plugins/core/plugin_task.go
+++ b/plugins/core/plugin_task.go
@@ -80,6 +80,18 @@ type SubTask interface {
 // All subtasks from plugins should comply to this prototype, so they could be orchestrated by framework
 type SubTaskEntryPoint func(c SubTaskContext) error
 
+const DOMAIN_TYPE_CODE = "CODE"
+const DOMAIN_TYPE_TICKET = "TICKET"
+const DOMAIN_TYPE_CICD = "CICD"
+const DOMAIN_TYPE_CROSS = "CROSS"
+
+var DOMAIN_TYPES = []string{
+	DOMAIN_TYPE_CODE,
+	DOMAIN_TYPE_TICKET,
+	DOMAIN_TYPE_CICD,
+	DOMAIN_TYPE_CROSS,
+}
+
 // Meta data of a subtask
 type SubTaskMeta struct {
 	Name       string
@@ -88,6 +100,7 @@ type SubTaskMeta struct {
 	Required         bool
 	EnabledByDefault bool
 	Description      string
+	DomainTypes      []string
 }
 
 // Implement this interface to let framework run tasks for you

--- a/services/blueprint_test.go
+++ b/services/blueprint_test.go
@@ -1,0 +1,94 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"testing"
+
+	"github.com/apache/incubator-devlake/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergePipelineTasks(t *testing.T) {
+	plan1 := models.PipelinePlan{
+		[]*models.NewTask{
+			{Plugin: "github"},
+			{Plugin: "gitlab"},
+		},
+		[]*models.NewTask{
+			{Plugin: "gitextractor1"},
+			{Plugin: "gitextractor2"},
+		},
+	}
+
+	plan2 := models.PipelinePlan{
+		[]*models.NewTask{
+			{Plugin: "jira"},
+		},
+	}
+
+	plan3 := models.PipelinePlan{
+		[]*models.NewTask{
+			{Plugin: "jenkins"},
+		},
+		[]*models.NewTask{
+			{Plugin: "jenkins"},
+		},
+		[]*models.NewTask{
+			{Plugin: "jenkins"},
+		},
+	}
+
+	assert.Equal(t, plan1, MergePipelinePlans(plan1))
+	assert.Equal(t, plan2, MergePipelinePlans(plan2))
+	assert.Equal(
+		t,
+		models.PipelinePlan{
+			[]*models.NewTask{
+				{Plugin: "github"},
+				{Plugin: "gitlab"},
+				{Plugin: "jira"},
+			},
+			[]*models.NewTask{
+				{Plugin: "gitextractor1"},
+				{Plugin: "gitextractor2"},
+			},
+		},
+		MergePipelinePlans(plan1, plan2),
+	)
+	assert.Equal(
+		t,
+		models.PipelinePlan{
+			[]*models.NewTask{
+				{Plugin: "github"},
+				{Plugin: "gitlab"},
+				{Plugin: "jira"},
+				{Plugin: "jenkins"},
+			},
+			[]*models.NewTask{
+				{Plugin: "gitextractor1"},
+				{Plugin: "gitextractor2"},
+				{Plugin: "jenkins"},
+			},
+			[]*models.NewTask{
+				{Plugin: "jenkins"},
+			},
+		},
+		MergePipelinePlans(plan1, plan2, plan3),
+	)
+}

--- a/services/blueprint_test.go
+++ b/services/blueprint_test.go
@@ -20,36 +20,36 @@ package services
 import (
 	"testing"
 
-	"github.com/apache/incubator-devlake/models"
+	"github.com/apache/incubator-devlake/plugins/core"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestMergePipelineTasks(t *testing.T) {
-	plan1 := models.PipelinePlan{
-		[]*models.NewTask{
+	plan1 := core.PipelinePlan{
+		{
 			{Plugin: "github"},
 			{Plugin: "gitlab"},
 		},
-		[]*models.NewTask{
+		{
 			{Plugin: "gitextractor1"},
 			{Plugin: "gitextractor2"},
 		},
 	}
 
-	plan2 := models.PipelinePlan{
-		[]*models.NewTask{
+	plan2 := core.PipelinePlan{
+		{
 			{Plugin: "jira"},
 		},
 	}
 
-	plan3 := models.PipelinePlan{
-		[]*models.NewTask{
+	plan3 := core.PipelinePlan{
+		{
 			{Plugin: "jenkins"},
 		},
-		[]*models.NewTask{
+		{
 			{Plugin: "jenkins"},
 		},
-		[]*models.NewTask{
+		{
 			{Plugin: "jenkins"},
 		},
 	}
@@ -58,13 +58,13 @@ func TestMergePipelineTasks(t *testing.T) {
 	assert.Equal(t, plan2, MergePipelinePlans(plan2))
 	assert.Equal(
 		t,
-		models.PipelinePlan{
-			[]*models.NewTask{
+		core.PipelinePlan{
+			{
 				{Plugin: "github"},
 				{Plugin: "gitlab"},
 				{Plugin: "jira"},
 			},
-			[]*models.NewTask{
+			{
 				{Plugin: "gitextractor1"},
 				{Plugin: "gitextractor2"},
 			},
@@ -73,19 +73,19 @@ func TestMergePipelineTasks(t *testing.T) {
 	)
 	assert.Equal(
 		t,
-		models.PipelinePlan{
-			[]*models.NewTask{
+		core.PipelinePlan{
+			{
 				{Plugin: "github"},
 				{Plugin: "gitlab"},
 				{Plugin: "jira"},
 				{Plugin: "jenkins"},
 			},
-			[]*models.NewTask{
+			{
 				{Plugin: "gitextractor1"},
 				{Plugin: "gitextractor2"},
 				{Plugin: "jenkins"},
 			},
-			[]*models.NewTask{
+			{
 				{Plugin: "jenkins"},
 			},
 		},

--- a/services/pipeline.go
+++ b/services/pipeline.go
@@ -99,12 +99,15 @@ func CreatePipeline(newPipeline *models.NewPipeline) (*models.Pipeline, error) {
 	}
 
 	// create tasks accordingly
-	for i := range newPipeline.Tasks {
-		for j := range newPipeline.Tasks[i] {
-			newTask := newPipeline.Tasks[i][j]
-			newTask.PipelineId = pipeline.ID
-			newTask.PipelineRow = i + 1
-			newTask.PipelineCol = j + 1
+	for i := range newPipeline.Plan {
+		for j := range newPipeline.Plan[i] {
+			pipelineTask := newPipeline.Plan[i][j]
+			newTask := &models.NewTask{
+				PipelineTask: pipelineTask,
+				PipelineId:   pipeline.ID,
+				PipelineRow:  i + 1,
+				PipelineCol:  j + 1,
+			}
 			_, err := CreateTask(newTask)
 			if err != nil {
 				pipelineLog.Error("create task for pipeline failed: %w", err)
@@ -123,13 +126,13 @@ func CreatePipeline(newPipeline *models.NewPipeline) (*models.Pipeline, error) {
 	}
 
 	// update tasks state
-	pipeline.Tasks, err = json.Marshal(newPipeline.Tasks)
+	pipeline.Plan, err = json.Marshal(newPipeline.Plan)
 	if err != nil {
 		return nil, err
 	}
 	err = db.Model(pipeline).Updates(map[string]interface{}{
 		"total_tasks": pipeline.TotalTasks,
-		"tasks":       pipeline.Tasks,
+		"plan":        pipeline.Plan,
 	}).Error
 	if err != nil {
 		pipelineLog.Error("update pipline state failed: %w", err)

--- a/test/api/task/task_test.go
+++ b/test/api/task/task_test.go
@@ -53,7 +53,7 @@ func TestNewTask(t *testing.T) {
 	api.RegisterRouter(r)
 
 	w := httptest.NewRecorder()
-	params := strings.NewReader(`{"name": "hello", "tasks": [[{ "plugin": "jira", "options": { "host": "www.jira.com" } }]]}`)
+	params := strings.NewReader(`{"name": "hello", "plan": [[{ "plugin": "jira", "options": { "host": "www.jira.com" } }]]}`)
 	req, _ := http.NewRequest("POST", "/pipelines", params)
 	r.ServeHTTP(w, req)
 

--- a/test/api/task/task_test.go
+++ b/test/api/task/task_test.go
@@ -68,7 +68,7 @@ func TestNewTask(t *testing.T) {
 	assert.Equal(t, pipeline.Name, "hello")
 
 	var tasks [][]*models.NewTask
-	err = json.Unmarshal(pipeline.Tasks, &tasks)
+	err = json.Unmarshal(pipeline.Plan, &tasks)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
# Summary

1. `blueprint.tasks` and `pipeline.tasks` were renamed to `plan`
2. `dal.First` would return `dal.ErrRecordNotFound` instead of `gorm.ErrRecordNotFound`
3. migration script is written in a novel convention for better readability, feel free to argue
4. define `Blueprint` protocol `1.0.0` including `interface` and `struct` they should adopt, so the framework and plugin can generate Pipeline.Plan based on it
5. define `DOMAIN_TYPES` (aka, `entities` from config-ui), the naming is open for discussion.
6. blueprint would call plugin to generate Plans, and then merge them into one unified Plan

**This is framework implementation, which would require plugin support to produce a meaningful result.**


### Does this close any open issues?
Part of #1982 

