### PR TITLE
ci: fix commit message linter

### DIFF
--- a/.github/workflows/commit-msg.yml
+++ b/.github/workflows/commit-msg.yml
@@ -14,4 +14,9 @@ jobs:
         with:
           path: lint-commit-message
           key: ${{ runner.os }}-lint-commit-message
-      - uses: wagoid/commitlint-github-action@v4
+      #- uses: wagoid/commitlint-github-action@v4
+      - name: Lint commit message
+        run: |
+          ! git log --oneline ${{ github.event.pull_request.base.sha }}... \
+            | grep -vP '^\w{8} Merge ' \
+            | grep -vP '^\w{8} (feat|fix|build|chore|docs|style|refactor|perf|test|ci)(\(\w+\))?: \w'


### PR DESCRIPTION
# Summary

commit message linter has broken for a while, it is time to bring it back.
