### PR TITLE
fix: ignore collect pipeline 403 for CI/CD disable

### DIFF
--- a/plugins/gitlab/tasks/api_client.go
+++ b/plugins/gitlab/tasks/api_client.go
@@ -19,10 +19,11 @@ package tasks
 
 import (
 	"fmt"
-	"github.com/apache/incubator-devlake/plugins/gitlab/models"
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/apache/incubator-devlake/plugins/gitlab/models"
 
 	"github.com/apache/incubator-devlake/plugins/core"
 	"github.com/apache/incubator-devlake/plugins/helper"
@@ -71,4 +72,11 @@ func NewGitlabApiClient(taskCtx core.TaskContext, connection *models.GitlabConne
 		return nil, err
 	}
 	return asyncApiClient, nil
+}
+
+func ignoreHTTPStatus403(res *http.Response) error {
+	if res.StatusCode == http.StatusForbidden {
+		return helper.ErrIgnoreAndContinue
+	}
+	return nil
 }

--- a/plugins/gitlab/tasks/pipeline_collector.go
+++ b/plugins/gitlab/tasks/pipeline_collector.go
@@ -43,6 +43,7 @@ func CollectApiPipelines(taskCtx core.SubTaskContext) error {
 		UrlTemplate:        "projects/{{ .Params.ProjectId }}/pipelines",
 		Query:              GetQuery,
 		ResponseParser:     GetRawMessageFromResponse,
+		AfterResponse:      ignoreHTTPStatus403, // ignore 403 for CI/CD disable
 	})
 
 	if err != nil {


### PR DESCRIPTION
# Summary
Add ignoreHTTPStatus403 to ignore the http code 403
For collect pipeline with CI/CD disable.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Does this close any open issues?
close #2065 

### Screenshots
![image](https://user-images.githubusercontent.com/2921251/176665952-5f1ff4da-e5d1-4e85-94ae-7dc99b07ef98.png)

![image](https://user-images.githubusercontent.com/2921251/176666043-59c476fe-2e49-486c-8d2e-f2a673f3006e.png)
