### PR TITLE
fix: add release to apiclient

### DIFF
--- a/plugins/helper/api_async_client.go
+++ b/plugins/helper/api_async_client.go
@@ -207,16 +207,24 @@ func (apiClient *ApiAsyncClient) WaitAsync() error {
 	return apiClient.scheduler.Wait()
 }
 
+// HasError to return if the scheduler has Error
 func (apiClient *ApiAsyncClient) HasError() bool {
 	return apiClient.scheduler.HasError()
 }
 
+// NextTick to return the NextTick of scheduler
 func (apiClient *ApiAsyncClient) NextTick(task func() error) {
 	apiClient.scheduler.NextTick(task)
 }
 
+// GetNumOfWorkers to return the Workers count if scheduler.
 func (apiClient *ApiAsyncClient) GetNumOfWorkers() int {
 	return apiClient.numOfWorkers
+}
+
+// Release will release the ApiAsyncClient with scheduler
+func (apiClient *ApiAsyncClient) Release() {
+	apiClient.scheduler.Release()
 }
 
 type RateLimitedApiClient interface {
@@ -226,6 +234,7 @@ type RateLimitedApiClient interface {
 	NextTick(task func() error)
 	GetNumOfWorkers() int
 	SetAfterFunction(callback common.ApiClientAfterResponse)
+	Release()
 }
 
 var _ RateLimitedApiClient = (*ApiAsyncClient)(nil)

--- a/plugins/helper/api_collector.go
+++ b/plugins/helper/api_collector.go
@@ -147,8 +147,12 @@ func (collector *ApiCollector) Execute() error {
 	collector.args.Ctx.SetProgress(0, -1)
 	if collector.args.Input != nil {
 		iterator := collector.args.Input
-		apiClient := collector.args.ApiClient
 		defer iterator.Close()
+		apiClient := collector.args.ApiClient
+		if apiClient == nil {
+			return fmt.Errorf("api_collector can not Execute with nil apiClient")
+		}
+		defer apiClient.Release()
 		for iterator.HasNext() && !apiClient.HasError() {
 			input, err := iterator.Fetch()
 			if err != nil {

--- a/plugins/helper/api_collector_test.go
+++ b/plugins/helper/api_collector_test.go
@@ -76,6 +76,7 @@ func TestFetchPageUndetermined(t *testing.T) {
 	params := struct {
 		Name string
 	}{Name: "testparams"}
+	mockApi.On("Release").Return()
 
 	collector, err := NewApiCollector(ApiCollectorArgs{
 		RawDataSubTaskArgs: RawDataSubTaskArgs{


### PR DESCRIPTION
# Summary

Add Release() for RateLimitedApiClient and ApiAsyncClient.
Add defer Release() call at Execute of api_collector.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Does this close any open issues?
close #1772 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
