### PR TITLE
feat(github): modify test conn

### DIFF
--- a/plugins/gitee/api/init.go
+++ b/plugins/gitee/api/init.go
@@ -19,14 +19,11 @@ package api
 
 import (
 	"github.com/apache/incubator-devlake/plugins/core"
-	"github.com/apache/incubator-devlake/plugins/github/models"
 	"github.com/apache/incubator-devlake/plugins/helper"
 	"github.com/go-playground/validator/v10"
 	"github.com/spf13/viper"
 	"gorm.io/gorm"
 )
-
-type ApiUserPublicEmailResponse []models.PublicEmail
 
 var vld *validator.Validate
 var connectionHelper *helper.ConnectionApiHelper

--- a/plugins/github/api/connection.go
+++ b/plugins/github/api/connection.go
@@ -20,7 +20,6 @@ package api
 import (
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/apache/incubator-devlake/plugins/github/models"
@@ -33,6 +32,21 @@ import (
 
 /*
 POST /plugins/github/test
+REQUEST BODY:
+{
+	"endpoint": "https://api.github.com/",
+	"token": "github api access token"
+}
+RESPONSE BODY:
+Success:
+{
+	"login": "xxx"
+}
+Failure:
+{
+	"success": false,
+	"message": "invalid token"
+}
 */
 func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
 	// process input
@@ -45,62 +59,34 @@ func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, erro
 	if err != nil {
 		return nil, err
 	}
-	tokens := strings.Split(params.Token, ",")
-
 	// verify multiple token in parallel
 	// PLEASE NOTE: This works because GitHub API Client rotates tokens on each request
-	results := make(chan error)
-	for i := 0; i < len(tokens); i++ {
-		token := tokens[i]
-		j := i + 1
-		go func() {
-			apiClient, err := helper.NewApiClient(
-				params.Endpoint,
-				map[string]string{
-					"Authorization": fmt.Sprintf("Bearer %s", token),
-				},
-				3*time.Second,
-				params.Proxy,
-				nil,
-			)
-			if err != nil {
-				results <- fmt.Errorf("verify token failed for #%v %s %w", j, token, err)
-				return
-			}
-			res, err := apiClient.Get("user/public_emails", nil, nil)
-			if err != nil {
-				results <- fmt.Errorf("verify token failed for #%v %s %w", j, token, err)
-				return
-			}
-			githubApiResponse := &ApiUserPublicEmailResponse{}
-			err = helper.UnmarshalResponse(res, githubApiResponse)
-			if err != nil {
-				results <- fmt.Errorf("verify token failed for #%v %s %w", j, token, err)
-			} else {
-				results <- nil
-			}
-		}()
+	apiClient, err := helper.NewApiClient(
+		params.Endpoint,
+		map[string]string{
+			"Authorization": fmt.Sprintf("Bearer %s", params.Token),
+		},
+		3*time.Second,
+		params.Proxy,
+		nil,
+	)
+	if err != nil {
+		return nil, err
 	}
-
-	// collect verification results
-	msgs := make([]string, 0)
-	i := 0
-	for err := range results {
-		if err != nil {
-			msgs = append(msgs, err.Error())
-		}
-		i++
-		if i == len(tokens) {
-			close(results)
-		}
+	res, err := apiClient.Get("user", nil, nil)
+	if err != nil {
+		return nil, err
 	}
-
-	if len(msgs) > 0 {
-		return nil, fmt.Errorf(strings.Join(msgs, "\n"))
+	githubApiResponse := &models.GithubUserOfToken{}
+	err = helper.UnmarshalResponse(res, githubApiResponse)
+	if err != nil {
+		return nil, err
+	} else if githubApiResponse.Login == "" {
+		return nil, fmt.Errorf("invalid token")
 	}
 
 	// output
-	return nil, nil
+	return &core.ApiResourceOutput{Body: githubApiResponse, Status: http.StatusOK}, nil
 }
 
 /*

--- a/plugins/github/api/init.go
+++ b/plugins/github/api/init.go
@@ -19,14 +19,11 @@ package api
 
 import (
 	"github.com/apache/incubator-devlake/plugins/core"
-	"github.com/apache/incubator-devlake/plugins/github/models"
 	"github.com/apache/incubator-devlake/plugins/helper"
 	"github.com/go-playground/validator/v10"
 	"github.com/spf13/viper"
 	"gorm.io/gorm"
 )
-
-type ApiUserPublicEmailResponse []models.PublicEmail
 
 var vld *validator.Validate
 var connectionHelper *helper.ConnectionApiHelper

--- a/plugins/github/models/connection.go
+++ b/plugins/github/models/connection.go
@@ -17,7 +17,9 @@ limitations under the License.
 
 package models
 
-import "github.com/apache/incubator-devlake/plugins/helper"
+import (
+	"github.com/apache/incubator-devlake/plugins/helper"
+)
 
 type TestConnectionRequest struct {
 	Endpoint string `json:"endpoint" validate:"required,url"`
@@ -46,11 +48,7 @@ func (GithubConnection) TableName() string {
 	return "_tool_github_connections"
 }
 
-// Using Public Email because it requires authentication, and it is public information anyway.
-// We're not using email information for anything here.
-type PublicEmail struct {
-	Email      string
-	Primary    bool
-	Verified   bool
-	Visibility string
+// Using GithubUserOfToken because it requires authentication, and it is public information anyway.
+type GithubUserOfToken struct {
+	Login string `json:"login"`
 }


### PR DESCRIPTION
# Summary

Modify github test connection,
before: config-ui send a request which contains a list of tokens, and backend will check one by one and return the index if one of tokens failed
now: config-ui will only send one token per time.

```json
POST /plugins/github/test
REQUEST BODY:
{
	"endpoint": "https://api.github.com/",
	"token": "github api access token"
}
RESPONSE BODY:
- Success:
{
	"login": "xxx"
}
- Failure:
{
	"success": false,
	"message": "invalid token"
}
```



### Does this close any open issues?
relate to #2423

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
