### PR TITLE
fix: gitlab blueprint generator

### DIFF
--- a/plugins/gitlab/api/blueprint.go
+++ b/plugins/gitlab/api/blueprint.go
@@ -86,7 +86,7 @@ func MakePipelinePlan(subtaskMetas []core.SubTaskMeta, connectionId uint64, scop
 			stage = core.PipelineStage{}
 		}
 		stage = append(stage, &core.PipelineTask{
-			Plugin:   "github",
+			Plugin:   "gitlab",
 			Subtasks: subtasks,
 			Options:  options,
 		})

--- a/plugins/gitlab/tasks/commit_collector.go
+++ b/plugins/gitlab/tasks/commit_collector.go
@@ -27,7 +27,7 @@ const RAW_COMMIT_TABLE = "gitlab_api_commit"
 var CollectApiCommitsMeta = core.SubTaskMeta{
 	Name:             "collectApiCommits",
 	EntryPoint:       CollectApiCommits,
-	EnabledByDefault: true,
+	EnabledByDefault: false,
 	Description:      "Collect commit data from gitlab api",
 	DomainTypes:      []string{core.DOMAIN_TYPE_CODE},
 }

--- a/plugins/gitlab/tasks/commit_convertor.go
+++ b/plugins/gitlab/tasks/commit_convertor.go
@@ -32,7 +32,7 @@ import (
 var ConvertCommitsMeta = core.SubTaskMeta{
 	Name:             "convertApiCommits",
 	EntryPoint:       ConvertApiCommits,
-	EnabledByDefault: true,
+	EnabledByDefault: false,
 	Description:      "Update domain layer commit according to GitlabCommit",
 	DomainTypes:      []string{core.DOMAIN_TYPE_CODE},
 }

--- a/plugins/gitlab/tasks/commit_extractor.go
+++ b/plugins/gitlab/tasks/commit_extractor.go
@@ -28,7 +28,7 @@ import (
 var ExtractApiCommitsMeta = core.SubTaskMeta{
 	Name:             "extractApiCommits",
 	EntryPoint:       ExtractApiCommits,
-	EnabledByDefault: true,
+	EnabledByDefault: false,
 	Description:      "Extract raw commit data into tool layer table GitlabCommit,GitlabAccount and GitlabProjectCommit",
 	DomainTypes:      []string{core.DOMAIN_TYPE_CODE},
 }


### PR DESCRIPTION
# Summary

1. fix typo in the plugin name
2. collect/extract/convert commits should be disabled by default.
