### PR TITLE
Db Migration confirmation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ swag:
 	swag init --parseDependency --parseInternal -o ./api/docs -g ./api/api.go -g plugins/*/api/*.go
 	echo "visit the swagger document on http://localhost:8080/swagger/index.html"
 
-dev: build-plugin swag run
+dev: build-plugin run
 
 debug: build-plugin-debug
 	dlv debug main.go

--- a/main.go
+++ b/main.go
@@ -21,7 +21,6 @@ import (
 	"github.com/apache/incubator-devlake/api"
 	"github.com/apache/incubator-devlake/config"
 	"github.com/apache/incubator-devlake/plugins/core"
-	"github.com/apache/incubator-devlake/services"
 	_ "github.com/apache/incubator-devlake/version"
 )
 
@@ -37,6 +36,5 @@ func main() {
 			panic(err)
 		}
 	}
-	services.Init()
 	api.CreateApiService()
 }

--- a/services/init.go
+++ b/services/init.go
@@ -40,7 +40,7 @@ var cronManager *cron.Cron
 var log core.Logger
 var migrationRequireConfirmation bool
 
-// Init FIXME ...
+// Init the services module
 func Init() {
 	var err error
 	cfg = config.GetConfig()
@@ -63,7 +63,8 @@ func Init() {
 	if err != nil {
 		panic(err)
 	}
-	if !migration.NeedConfirmation() {
+	forceMigration := cfg.GetBool("FORCE_MIGRATION")
+	if !migration.NeedConfirmation() || forceMigration {
 		err = ExecuteMigration()
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
# Summary

1. All APIs stop working and a 428 error would be returned if there were pending migrations
2. Users must request `GET /proceed-db-migration` endpoint to apply the migration, or revert the image tags to use the existing version.
3. No confirmation is needed if "FORCE_MIGRATION=true" is found in `.env` or Environment Variable

### Does this close any open issues?
Close #2440


### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
