### PR TITLE
Kw 220718 config-ui fixes

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -67,8 +67,9 @@ func CreateApiService() {
 		shared.ApiOutputError(
 			ctx,
 			fmt.Errorf("Database migration is required for Apache DevLake to function properly, it might cause the "+
-				"collected data gets wiped out for consistency. Please send a request to `/proceed-migrations` "+
-				"if it is ok, or you may downgrade back to the older version you previous used"),
+				"collected data gets wiped out for consistency. \nPlease send a request to `/proceed-db-migration` "+
+				"(or `/api/proceed-db-migration` from config-ui)if it is ok, or you may downgrade back to the older "+
+				"version you previous used."),
 			http.StatusPreconditionRequired,
 		)
 		ctx.Abort()

--- a/config-ui/src/components/blueprints/BlueprintsGrid.jsx
+++ b/config-ui/src/components/blueprints/BlueprintsGrid.jsx
@@ -241,7 +241,7 @@ const BlueprintsGrid = (props) => {
                       </label>
                     </div>
                     <div>
-                      {dayjs(getNextRunDate(b.cronConfig)).format('L LTS')}
+                      {b.isManual ? "Manual" : dayjs(getNextRunDate(b.cronConfig)).format('L LTS')}
                     </div>
                     {/* <div>
                       <span style={{ color: b.enable ? Colors.GREEN5 : Colors.GRAY3, position: 'absolute', bottom: '4px' }}>

--- a/config-ui/src/hooks/useBlueprintManager.jsx
+++ b/config-ui/src/hooks/useBlueprintManager.jsx
@@ -58,10 +58,19 @@ function useBlueprintManager (blueprintName = `BLUEPRINT WEEKLY ${Date.now()}`, 
   const [deleteComplete, setDeleteComplete] = useState(false)
 
   const parseCronExpression = useCallback((expression, utc = true, additionalOptions = {}) => {
+    if (expression.toLowerCase() === "manual") {
+      return {
+        next: () => "manual",
+        prev: () => "manual",
+      }
+    }
     return parser.parseExpression(expression, { utc, ...additionalOptions })
   }, [])
 
   const detectCronInterval = useCallback((cronConfig) => {
+    if (cronConfig === "manual") {
+      return "Manual"
+    }
     return cronPresets.find(p => p.cronConfig === cronConfig)
       ? cronPresets.find(p => p.cronConfig === cronConfig).label
       : 'Custom'

--- a/config-ui/src/utils/request.js
+++ b/config-ui/src/utils/request.js
@@ -24,7 +24,12 @@ let warned428 = false
 const handleErrorResponse = (e) => {
   let errorResponse = { success: false, message: e.message, data: null, status: 504 }
   if (e.response) {
-    errorResponse = { ...errorResponse, data: e.response ? e.response.data : null, message: e.response?.data?.message, status: e.response ? e.response.status : 504 }
+    errorResponse = {
+      ...errorResponse,
+      data: e.response ? e.response.data : null,
+      message: e.response?.data?.message,
+      status: e.response ? e.response.status : 504,
+    }
   }
   if (!warned428 && e.response?.status === 428) {
     warned428 = true

--- a/config-ui/src/utils/request.js
+++ b/config-ui/src/utils/request.js
@@ -16,13 +16,19 @@
  *
  */
 import axios from 'axios'
+import { ToastNotification } from '@/components/Toast'
 
 const headers = {}
+let warned428 = false
 
 const handleErrorResponse = (e) => {
   let errorResponse = { success: false, message: e.message, data: null, status: 504 }
   if (e.response) {
     errorResponse = { ...errorResponse, data: e.response ? e.response.data : null, message: e.response?.data?.message, status: e.response ? e.response.status : 504 }
+  }
+  if (!warned428 && e.response?.status === 428) {
+    warned428 = true
+    ToastNotification.show({ message: e.response.data.message, intent: 'danger', icon: 'error', timeout: -1 })
   }
   return errorResponse
 }


### PR DESCRIPTION
# Summary

- [fix: notify user for 428 error (db migration confirmation)](https://github.com/apache/incubator-devlake/pull/2521/commits/1ad8b98877b934a3aa633a90bb41ce5005c9d8ea)
- [fix: unable to save Manual blueprint](https://github.com/apache/incubator-devlake/pull/2521/commits/1054d4d78fbef5d884b16e49dfa3f1ff953cc17b)
- [fix: liniting](https://github.com/apache/incubator-devlake/pull/2521/commits/b0523a07f6e59af63998e0f6ac986d87108c51b2)
- [fix: blueprints page failed if there were Manual items](https://github.com/apache/incubator-devlake/pull/2521/commits/90fb37c55ab32bb854506b25b175b38c48d26911)

![image](https://user-images.githubusercontent.com/61080/179470529-2abaffd0-fa24-4392-98e1-b114de22db0c.png)

![image](https://user-images.githubusercontent.com/61080/179476906-80b87cec-98c7-4c8e-a27d-6a1c41def4eb.png)



