### PR TITLE
fix: fix start_at/end_at display bug

### DIFF
--- a/config-ui/src/pages/blueprints/blueprint-detail.jsx
+++ b/config-ui/src/pages/blueprints/blueprint-detail.jsx
@@ -664,15 +664,12 @@ const BlueprintDetail = (props) => {
         status: p.status,
         statusLabel: TaskStatusLabels[p.status],
         statusIcon: getTaskStatusIcon(p.status),
-        startedAt: dayjs(p.beganAt).format('L LTS'),
-        completedAt:
-          p.status === 'TASK_RUNNING'
-            ? ' - '
-            : dayjs(p.finishedAt || p.updatedAt).format('L LTS'),
+        startedAt: p.beganAt ? dayjs(p.beganAt).format('L LTS') : '-',
+        completedAt: p.finishedAt ? dayjs(p.updatedAt).format('L LTS') : ' - ',
         duration:
-          p.status === 'TASK_RUNNING'
-            ? dayjs(p.beganAt).toNow(true)
-            : dayjs(p.beganAt).from(p.finishedAt || p.updatedAt, true),
+          p.beganAt && p.finishedAt
+            ? dayjs(p.beganAt).from(p.finishedAt, true)
+            : (p.beganAt ? dayjs(p.beganAt).toNow(true) : ' - '),
       }))
     )
   }, [blueprintPipelines])


### PR DESCRIPTION
# Summary

1. fix start_at/end_at display bug
![image](https://user-images.githubusercontent.com/3294100/179496890-a16332a6-3a09-437e-a2ef-3a6b8cddb9ae.png)
![image](https://user-images.githubusercontent.com/3294100/179496902-8b0ca638-125b-4121-8600-28d80c2243e6.png)
now start_at/end_at can display correctly when one of them or both of them are null