### PR TITLE
fix: update GitHub basic metrics dashboard

### DIFF
--- a/grafana/dashboards/GithubBasicMetrics.json
+++ b/grafana/dashboards/GithubBasicMetrics.json
@@ -15,8 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 10,
-  "iteration": 1655905249031,
+  "id": 15,
+  "iteration": 1658252639998,
   "links": [],
   "panels": [
     {
@@ -683,7 +683,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "-- Get the queue time of all backlog bugs\nwith _outstanding_issues as(\n  select \n    b.name as repo_name,\n    i.number as issue_key,\n    i.title,\n    i.created_date,\n    (TIMESTAMPDIFF(MINUTE, i.created_date,NOW()))/1440 as queue_time_in_days,\n    concat(b.url,'/',i.number) as url\n  from \n    issues i\n    left join board_issues bi on i.id = bi.issue_id\n    left join boards b on bi.board_id = b.id\n  where\n    b.id in ($repo_id)\n    and $__timeFilter(i.created_date)\n    and i.status != 'DONE'\n)\n\nselect title, queue_time_in_days from _outstanding_issues\norder by 2 desc",
+          "rawSql": "-- Get the queue time of all outstanding bugs\nwith _outstanding_issues as(\n  select \n    b.name as repo_name,\n    i.number as issue_key,\n    i.title,\n    i.created_date,\n    (TIMESTAMPDIFF(MINUTE, i.created_date,NOW()))/1440 as queue_time_in_days,\n    concat(b.url,'/',i.number) as url\n  from \n    issues i\n    left join board_issues bi on i.id = bi.issue_id\n    left join boards b on bi.board_id = b.id\n  where\n    b.id in ($repo_id)\n    and $__timeFilter(i.created_date)\n    and i.status != 'DONE'\n)\n\nselect title, queue_time_in_days from _outstanding_issues\norder by 2 desc",
           "refId": "A",
           "select": [
             [
@@ -850,7 +850,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "-- Get the queue time of all backlog bugs\nselect \n  b.name as repo_name,\n  i.number as issue_key,\n  i.title,\n  i.created_date,\n  (TIMESTAMPDIFF(MINUTE, i.created_date,NOW()))/1440 as queue_time_in_days,\n  concat(b.url,'/',i.number) as url\nfrom \n  issues i\n  left join board_issues bi on i.id = bi.issue_id\n  left join boards b on bi.board_id = b.id\nwhere\n  b.id in ($repo_id)\n  and $__timeFilter(i.created_date)\n  and i.status != 'DONE'\norder by queue_time_in_days desc",
+          "rawSql": "-- Get the queue time of all outstanding bugs\nselect \n  b.name as repo_name,\n  i.number as issue_key,\n  i.title,\n  i.created_date,\n  (TIMESTAMPDIFF(MINUTE, i.created_date,NOW()))/1440 as queue_time_in_days,\n  concat(b.url,'/',i.number) as url\nfrom \n  issues i\n  left join board_issues bi on i.id = bi.issue_id\n  left join boards b on bi.board_id = b.id\nwhere\n  b.id in ($repo_id)\n  and $__timeFilter(i.created_date)\n  and i.status != 'DONE'\norder by queue_time_in_days desc",
           "refId": "A",
           "select": [
             [
@@ -1953,6 +1953,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "Github_Basic_Metrics",
-  "uid": "KXWvOFQnz",
-  "version": 13
+  "uid": "wHB2Ahg4z",
+  "version": 4
 }


### PR DESCRIPTION
# Summary
1. remove panel "1.3 - Mean New Issue Count and Standard Deviation".
2. update "2.4 Mean Issue Lead Time in Days [Issues Created in Each Month]" to "Issues Closed in Each Month". If not, `issue lead time` will always get lower when time goes by.
3. update wordings.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Does this close any open issues?
No

### Screenshots
![image](https://user-images.githubusercontent.com/14050754/179817598-41e89b13-8b65-4263-8097-104634bd62e4.png)

### Other Information
Any other information that is important to this PR.
