### PR TITLE
fix: when clicking the dashboard button on the config-ui page, a username/password error

### DIFF
--- a/config-ui/nginx.conf
+++ b/config-ui/nginx.conf
@@ -20,11 +20,11 @@ ${SERVER_CONF}
   }
 
   location /grafana/ {
-    auth_basic off;
     resolver ${DNS} valid=${DNS_VALID};
     resolver_timeout 3s;
     set $target "${GRAFANA_ENDPOINT}";
     rewrite /grafana/(.*) /$1  break;
+    proxy_set_header Authorization "";
     proxy_send_timeout 10s;
     proxy_read_timeout 10s;
     proxy_pass http://$target;


### PR DESCRIPTION
Signed-off-by: KeHaoKH <hao.ke@merico.dev>

# Summary
when clicking the dashboard button on the config-ui page, a username/password error. 
See the screenshot below.
![U9Mh8rwtG9](https://user-images.githubusercontent.com/103085894/179893573-bd5290d4-65d4-4b09-9a30-61d801ec895e.jpg)

### Does this close any open issues?

https://github.com/apache/incubator-devlake/issues/2531



