### PR TITLE
fix: plugins endpoint url miss /

### DIFF
--- a/config-ui/src/data/Providers.js
+++ b/config-ui/src/data/Providers.js
@@ -167,7 +167,7 @@ const ProviderFormPlaceholders = {
   },
   gitlab: {
     name: 'eg. GitLab',
-    endpoint: 'eg. https://gitlab.com/api/v4',
+    endpoint: 'eg. https://gitlab.com/api/v4/',
     proxy: 'eg. http://proxy.localhost:8080',
     token: 'eg. ff9d1ad0e5c04f1f98fa',
     username: 'Enter Username / E-mail',
@@ -175,7 +175,7 @@ const ProviderFormPlaceholders = {
   },
   jenkins: {
     name: 'eg. Jenkins',
-    endpoint: 'URL eg. https://api.jenkins.io',
+    endpoint: 'URL eg. https://api.jenkins.io/',
     proxy: 'eg. http://proxy.localhost:8080',
     token: 'eg. 6b057ffe68464c93a057',
     username: 'eg. admin',
@@ -191,7 +191,7 @@ const ProviderFormPlaceholders = {
   },
   github: {
     name: 'eg. GitHub',
-    endpoint: 'eg. https://api.github.com',
+    endpoint: 'eg. https://api.github.com/',
     proxy: 'eg. http://proxy.localhost:8080',
     token: 'eg. 4c5cbdb62c165e2b3d18, 40008ebccff9837bb8d2',
     username: 'eg. admin',


### PR DESCRIPTION
# Summary
gitlab, github, jenkins endpoint url is at end of '/'.

### Does this close any open issues?
close #2591 

### Screenshots
![image](https://user-images.githubusercontent.com/101256042/180735191-eab62241-958e-4d69-b885-155d88a37c1f.png)
![image](https://user-images.githubusercontent.com/101256042/180735257-44a9eb11-2695-425d-b9d3-293b62917171.png)
![image](https://user-images.githubusercontent.com/101256042/180735316-ebdef39d-d9e0-48cd-80bf-46e9ea7621e9.png)
![image](https://user-images.githubusercontent.com/101256042/180735379-568f0e80-9b4a-41ac-af3d-47b48170bbc2.png)


### Other Information
Any other information that is important to this PR.
