### PR TITLE
`hotfix` `v0.12.0` blueprint detail - enable auto-refresh for created status

### DIFF
--- a/config-ui/src/pages/blueprints/blueprint-detail.jsx
+++ b/config-ui/src/pages/blueprints/blueprint-detail.jsx
@@ -711,7 +711,7 @@ const BlueprintDetail = (props) => {
   useEffect(() => {
     if (activePipeline?.id && activePipeline?.id !== null) {
       setCurrentStages(buildPipelineStages(activePipeline.tasks))
-      setAutoRefresh(activePipeline?.status === TaskStatus.RUNNING)
+      setAutoRefresh([TaskStatus.RUNNING, TaskStatus.CREATED].includes(activePipeline?.status))
     }
   }, [activePipeline, buildPipelineStages])
 


### PR DESCRIPTION
### 🆘  Config UI / Blueprints / Blueprint Detail (Auto-Polling)

### Description
This PR applies a hotfix to turn on Auto-refresh (Activity Polling) for a **CREATED** Pipeline (`TASK_CREATED`). Previously when pipelines were created, the task was always set to `TASK_RUNNING` as the pipeline started immediately, which was a pre-requisite for having turning on polling in the first place. The backend recently made a change to now place the task in a `TASK_CREATED` status to provide a "throttling" feature, which caused this bug.

`TASK_CREATED` and `TASK_RUNNING` are now both supported in the check that turns on polling. 

### Does this close any open issues?
#2593

