### PR TITLE
`hotfix` `v0.12.0` blueprint detail: update current run object status on refresh

### DIFF
--- a/config-ui/src/pages/blueprints/blueprint-detail.jsx
+++ b/config-ui/src/pages/blueprints/blueprint-detail.jsx
@@ -683,7 +683,7 @@ const BlueprintDetail = (props) => {
         status: lastPipeline.status,
         statusLabel: TaskStatusLabels[lastPipeline.status],
         icon: getTaskStatusIcon(lastPipeline.status),
-        startedAt: dayjs(lastPipeline.beganAt || lastPipeline.createdAt).format('L LTS'),
+        startedAt: lastPipeline.beganAt ? dayjs(lastPipeline.beganAt).format('L LTS') : '-',
         duration:
           [TaskStatus.CREATED, TaskStatus.RUNNING].includes(lastPipeline.status)
             ? dayjs(lastPipeline.beganAt || lastPipeline.createdAt).toNow(true)
@@ -713,6 +713,8 @@ const BlueprintDetail = (props) => {
       setAutoRefresh([TaskStatus.RUNNING, TaskStatus.CREATED].includes(activePipeline?.status))
       setCurrentRun((cR) => ({
         ...cR,
+        startedAt: activePipeline?.beganAt ? dayjs(activePipeline?.beganAt).format('L LTS') : '-',
+        stage: `Stage ${activePipeline.stage}`,
         status: activePipeline?.status,
         statusLabel: TaskStatusLabels[activePipeline?.status],
         icon: getTaskStatusIcon(activePipeline?.status),

--- a/config-ui/src/pages/blueprints/blueprint-detail.jsx
+++ b/config-ui/src/pages/blueprints/blueprint-detail.jsx
@@ -675,7 +675,6 @@ const BlueprintDetail = (props) => {
   }, [blueprintPipelines])
 
   useEffect(() => {
-    // if (lastPipeline?.id && lastPipeline.status === TaskStatus.RUNNING) {
     if (lastPipeline?.id && [TaskStatus.CREATED, TaskStatus.RUNNING, TaskStatus.COMPLETE, TaskStatus.FAILED].includes(lastPipeline.status)) {
       fetchPipeline(lastPipeline?.id)
       setCurrentRun((cR) => ({
@@ -684,10 +683,10 @@ const BlueprintDetail = (props) => {
         status: lastPipeline.status,
         statusLabel: TaskStatusLabels[lastPipeline.status],
         icon: getTaskStatusIcon(lastPipeline.status),
-        startedAt: dayjs(lastPipeline.beganAt).format('L LTS'),
+        startedAt: dayjs(lastPipeline.beganAt || lastPipeline.createdAt).format('L LTS'),
         duration:
-          lastPipeline.status === 'TASK_RUNNING'
-            ? dayjs(lastPipeline.beganAt).toNow(true)
+          [TaskStatus.CREATED, TaskStatus.RUNNING].includes(lastPipeline.status)
+            ? dayjs(lastPipeline.beganAt || lastPipeline.createdAt).toNow(true)
             : dayjs(lastPipeline.beganAt).from(
               lastPipeline.finishedAt || lastPipeline.updatedAt,
               true
@@ -712,6 +711,12 @@ const BlueprintDetail = (props) => {
     if (activePipeline?.id && activePipeline?.id !== null) {
       setCurrentStages(buildPipelineStages(activePipeline.tasks))
       setAutoRefresh([TaskStatus.RUNNING, TaskStatus.CREATED].includes(activePipeline?.status))
+      setCurrentRun((cR) => ({
+        ...cR,
+        status: activePipeline?.status,
+        statusLabel: TaskStatusLabels[activePipeline?.status],
+        icon: getTaskStatusIcon(activePipeline?.status),
+      }))
     }
   }, [activePipeline, buildPipelineStages])
 


### PR DESCRIPTION
### 🆘 Config-UI / Blueprints / Blueprint Detail - **Current Run Activity**

### Description

This PR applies a supplemental hotfix to the last PR #2595 that further updates status on the **Current Run's** Activity, as well as resolves the **Started At** and **Duration** display values to take into consideration the pipeline's Pending or "Created State".

### Does this close any open issues?
#2593 

### Screenshots
<img width="1032" alt="Screen Shot 2022-07-25 at 11 36 13 AM" src="https://user-images.githubusercontent.com/1742233/180818278-6f8b61f0-6f5c-461e-a784-4ebd9b1beabe.png">

