### PR TITLE
hotfix: update test connection flow for github tokens

### DIFF
--- a/config-ui/src/components/blueprints/create-workflow/DataConnections.jsx
+++ b/config-ui/src/components/blueprints/create-workflow/DataConnections.jsx
@@ -47,6 +47,7 @@ const DataConnections = (props) => {
     manageConnection = () => {},
     onAdvancedMode = () => {},
     isSaving = false,
+    isTesting = false,
     advancedMode = false
   } = props
 
@@ -178,7 +179,7 @@ const DataConnections = (props) => {
                 </div>
               ))}
             </Card>
-            {blueprintConnections.some(c => c.status !== 200) && (
+            {blueprintConnections.some(c => c.status !== 200) && !isTesting && (
               <p style={{ margin: '10px 0', color: Colors.RED4 }}>
                 Please fix the offline connection.
               </p>

--- a/config-ui/src/hooks/usePipelineValidation.jsx
+++ b/config-ui/src/hooks/usePipelineValidation.jsx
@@ -91,20 +91,20 @@ function usePipelineValidation ({
 
     setErrors(errs)
   }, [
-    enabledProviders,
+    // enabledProviders,
     pipelineName,
-    projectId,
-    boardId,
-    owner,
-    repositoryName,
-    gitExtractorUrl,
-    gitExtractorRepoId,
-    refDiffRepoId,
-    refDiffTasks,
-    refDiffPairs,
-    connectionId,
-    boards,
-    projects
+    // projectId,
+    // boardId,
+    // owner,
+    // repositoryName,
+    // gitExtractorUrl,
+    // gitExtractorRepoId,
+    // refDiffRepoId,
+    // refDiffTasks,
+    // refDiffPairs,
+    // connectionId,
+    // boards,
+    // projects
   ])
 
   const validateAdvanced = useCallback(() => {

--- a/config-ui/src/pages/blueprints/create-blueprint.jsx
+++ b/config-ui/src/pages/blueprints/create-blueprint.jsx
@@ -1132,6 +1132,7 @@ const CreateBlueprint = (props) => {
                       addConnection={addConnection}
                       manageConnection={manageConnection}
                       onAdvancedMode={handleAdvancedMode}
+                      isTesting={isTestingConnection}
                     />
                   )}
 


### PR DESCRIPTION
### ⚠️ Config-UI / GitHub Integration / Personal Access Tokens & Connection Testing
> WIP DO NOT MERGE

- [ ] **Check the Active/Focus'ed Element** before running GitHub's Personal Access Token Sync.
   - Exclude Connection Endpoint URL and Proxy URL fields when testing connection
- [ ] Extract Connection Test Payload Parameters to a memoized/cache value
   - Update `Connection Manager` Hook
- [ ] Test GitHub Connection & Personal Access Tokens
- [ ] Test GitHub Connection
- [ ] Test JIRA Connections
- [ ] Test Jenkins Connections
- [ ] Test GitLab Connections
- [ ] Code Linting & Cleanups

### Description

This PR applies optimizations to the **GitHub Connection Testing** workflow with regard Personal Access Tokens. To prevent unwanted firing but still achieve onChange testing with the token input fields, the test routine will only execute if the currently focused elements are **NOT** Connection Endpoint and Token. Additionally, the Connection Testing parameters (`connectionTestPayload`) within the testConnection main routine provided by the Connection Manager Hook have been extracted to a memoized cache call to further reduce dependencies of the test connection callback and lessen complexity. 

Testing has also been done in Chrome Browser to ensure consistency with the environment this bug was reported with.

### Does this close any open issues?
#2599

### Screenshots
<img width="1386" alt="Screen Shot 2022-07-26 at 12 17 06 AM" src="https://user-images.githubusercontent.com/1742233/180921884-a3f5672b-8ef1-4cb2-9c9c-07f3cb3e74b0.png">


