### PR TITLE
fix: grafana is reverse-proxied since v0.12

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,17 +29,17 @@ services:
       MYSQL_USER: merico
       MYSQL_PASSWORD: merico
 
-  postgres:
-    image: postgres:14.2
-    volumes:
-      - postgres-storage:/var/lib/postgresql
-    restart: always
-    ports:
-      - 127.0.0.1:5432:5432
-    environment:
-      POSTGRES_DB: lake
-      POSTGRES_USER: merico
-      POSTGRES_PASSWORD: merico
+  # postgres:
+  #   image: postgres:14.2
+  #   volumes:
+  #     - postgres-storage:/var/lib/postgresql
+  #   restart: always
+  #   ports:
+  #     - 127.0.0.1:5432:5432
+  #   environment:
+  #     POSTGRES_DB: lake
+  #     POSTGRES_USER: merico
+  #     POSTGRES_PASSWORD: merico
 
   grafana:
     image: mericodev/devlake-dashboard:latest
@@ -50,11 +50,7 @@ services:
     volumes:
       - grafana-storage:/var/lib/grafana
     environment:
-      GF_USERS_ALLOW_SIGN_UP: 'false'
       GF_SERVER_ROOT_URL: "http://localhost:4000/grafana"
-      GF_SERVER_SERVE_FROM_SUB_PATH: 'true'
-      GF_DASHBOARDS_JSON_ENABLED: 'true'
-      GF_LIVE_ALLOWED_ORIGINS: '*'
       MYSQL_URL: mysql:3306
       MYSQL_DATABASE: lake
       MYSQL_USER: merico

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -29,4 +29,8 @@ COPY ./provisioning/datasources /etc/grafana/provisioning/datasources
 COPY ./dashboards /etc/grafana/dashboards
 COPY ./img/grafana_icon.svg /usr/share/grafana/public/img/grafana_icon.svg
 COPY ./img /usr/share/grafana/public/img/lake
+ENV GF_USERS_ALLOW_SIGN_UP=false
+ENV GF_SERVER_SERVE_FROM_SUB_PATH=true
+ENV GF_DASHBOARDS_JSON_ENABLED=true
+ENV GF_LIVE_ALLOWED_ORIGINS='*'
 RUN grafana-cli plugins install grafana-piechart-panel

--- a/k8s-deploy.yaml
+++ b/k8s-deploy.yaml
@@ -12,8 +12,8 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-  
-  ---
+
+---
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -25,10 +25,20 @@ metadata:
   name: devlake-config
   namespace: devlake
 data:
+  # shared between deployment
   MYSQL_USER: merico
   MYSQL_PASSWORD: merico
   MYSQL_DATABASE: lake
   MYSQL_ROOT_PASSWORD: admin
+  MYSQL_URL: mysql:3306
+  # grafana deployment
+  GF_SERVER_ROOT_URL: http://YOURDOMAIN:30002/grafana
+  # for devlake deployment
+  DB_URL: mysql://merico:merico@mysql:3306/lake?charset=utf8mb4&parseTime=True
+  DEVLAKE_ENDPOINT: devlake.devlake.svc.cluster.local:8080
+  GRAFANA_ENDPOINT: grafana.devlake.svc.cluster.local:3000
+  # ADMIN_USER: devlake
+  # ADMIN_PASS: merico
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -104,15 +114,6 @@ spec:
           envFrom:
             - configMapRef:
                 name: devlake-config
-          env:
-            - name: GF_USERS_ALLOW_SIGN_UP
-              value: 'false'
-            - name: GF_DASHBOARDS_JSON_ENABLED
-              value: 'true'
-            - name: GF_LIVE_ALLOWED_ORIGINS
-              value: '*'
-            - name: MYSQL_URL
-              value: mysql:3306
 
 ---
 apiVersion: v1
@@ -157,14 +158,6 @@ spec:
             - configMapRef:
                 name: devlake-config
           env:
-            - name: DEVLAKE_ENDPOINT
-              value: devlake.devlake.svc.cluster.local:8080
-            - name: GRAFANA_ENDPOINT
-              value: grafana.devlake.svc.cluster.local:3000
-            #- name: ADMIN_USER
-              #value: devlake
-            #- name: ADMIN_PASS
-              #value: merico
 ---
 apiVersion: v1
 kind: Service
@@ -204,9 +197,9 @@ spec:
           image: mericodev/devlake:latest
           ports:
             - containerPort: 8080
-          env:
-            - name: DB_URL
-              value: 'mysql://merico:merico@mysql:3306/lake?charset=utf8mb4&parseTime=True'
+          envFrom:
+            - configMapRef:
+                name: devlake-config
           volumeMounts:
             - name: config
               mountPath: "/app/.env"

--- a/k8s-deploy.yaml
+++ b/k8s-deploy.yaml
@@ -160,7 +160,7 @@ spec:
             - name: DEVLAKE_ENDPOINT
               value: devlake.devlake.svc.cluster.local:8080
             - name: GRAFANA_ENDPOINT
-              value: http://grafana-on-yourdomain.example.com
+              value: grafana.devlake.svc.cluster.local:3000
             #- name: ADMIN_USER
               #value: devlake
             #- name: ADMIN_PASS


### PR DESCRIPTION
# Summary

The `grafana` service is reverse-proxied by `config-ui` since v0.12

### Does this close any open issues?
related to #2609 

