### PR TITLE
fix: add NoPKModel to commit_parents

### DIFF
--- a/models/migrationscripts/20220801_add_NoPKModel_to_CommitParent.go
+++ b/models/migrationscripts/20220801_add_NoPKModel_to_CommitParent.go
@@ -15,16 +15,39 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package code
+package migrationscripts
 
-import "github.com/apache/incubator-devlake/models/common"
+import (
+	"context"
+	"github.com/apache/incubator-devlake/models/common"
+	"gorm.io/gorm"
+)
 
-type CommitParent struct {
+type commitParent struct {
 	common.NoPKModel
 	CommitSha       string `json:"commitSha" gorm:"primaryKey;type:varchar(40);comment:commit hash"`
 	ParentCommitSha string `json:"parentCommitSha" gorm:"primaryKey;type:varchar(40);comment:parent commit hash"`
 }
 
-func (CommitParent) TableName() string {
+func (commitParent) TableName() string {
 	return "commit_parents"
+}
+
+type addNoPKModelToCommitParent struct{}
+
+func (*addNoPKModelToCommitParent) Up(ctx context.Context, db *gorm.DB) error {
+	err := db.Migrator().AutoMigrate(&commitParent{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (*addNoPKModelToCommitParent) Version() uint64 {
+	return 20220801162735
+}
+
+func (*addNoPKModelToCommitParent) Name() string {
+	return "add NoPKModel to commit_parents"
 }

--- a/models/migrationscripts/register.go
+++ b/models/migrationscripts/register.go
@@ -32,5 +32,6 @@ func All() []migration.Script {
 		new(commitfileComponent),
 		new(removeNotes),
 		new(addProjectMapping),
+		new(addNoPKModelToCommitParent),
 	}
 }

--- a/plugins/gitextractor/parser/repo.go
+++ b/plugins/gitextractor/parser/repo.go
@@ -235,7 +235,8 @@ func (r *GitRepo) CollectCommits(subtaskCtx core.SubTaskContext) error {
 			c.CommitterId = committer.Email
 			c.CommittedDate = committer.When
 		}
-		if err != r.storeParentCommits(commitSha, commit) {
+		err = r.storeParentCommits(commitSha, commit)
+		if err != nil {
 			return err
 		}
 		if commit.ParentCount() > 0 {


### PR DESCRIPTION
# Summary

fix #2650 ([Bug][GitExtractor] Some commits are missing during collectGitCommits)
When the first `commit` came in,
several lines of buggy code hid an error.
```go
if err != r.storeParentCommits(commitSha, commit) {
          return err
}
```
Which caused an interruption in the execution process. So the first `commit` can not be saved to the database.
It won't happen again from the second `commit`, due to the nature of `BatchSaveDivider.ForType`


### Does this close any open issues?
close #2650 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
