### PR TITLE
fix: github.ExtractApiPullRequestReviews panic

### DIFF
--- a/plugins/github/tasks/pr_review_extractor.go
+++ b/plugins/github/tasks/pr_review_extractor.go
@@ -71,7 +71,7 @@ func ExtractApiPullRequestReviews(taskCtx core.SubTaskContext) error {
 			if err != nil {
 				return nil, err
 			}
-			if apiPullRequestReview.State == "PENDING" {
+			if apiPullRequestReview.State == "PENDING" || apiPullRequestReview.User == nil {
 				return nil, nil
 			}
 			pull := &SimplePr{}


### PR DESCRIPTION
# Summary

fix #2645 ([Bug][github] clickhouse collects fail)

The bug was caused by null pointer dereference, It was fixed by adding a simple conditional statement.

### Does this close any open issues?
close #2645 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
