### PR TITLE
fix the worklog collecting taking too long

### DIFF
--- a/plugins/jira/tasks/issue_changelog_collector.go
+++ b/plugins/jira/tasks/issue_changelog_collector.go
@@ -57,9 +57,9 @@ func CollectIssueChangelogs(taskCtx core.SubTaskContext) error {
 		dal.From("_tool_jira_board_issues bi"),
 		dal.Join("LEFT JOIN _tool_jira_issues i ON (bi.connection_id = i.connection_id AND bi.issue_id = i.issue_id)"),
 		dal.Join("LEFT JOIN _tool_jira_issue_changelogs c ON (c.connection_id = i.connection_id AND c.issue_id = i.issue_id)"),
-		dal.Where(`i.updated > i.created AND bi.connection_id = ?  AND bi.board_id = ? AND i.std_type != ? `, data.Options.ConnectionId, data.Options.BoardId, "Epic"),
+		dal.Where("i.updated > i.created AND bi.connection_id = ?  AND bi.board_id = ? AND i.std_type != ? ", data.Options.ConnectionId, data.Options.BoardId, "Epic"),
 		dal.Groupby("i.issue_id, i.updated"),
-		dal.Having("i.updated > max(c.issue_updated) OR  max(c.issue_updated) IS NULL"),
+		dal.Having("i.updated > max(c.issue_updated) OR  (max(c.issue_updated) IS NULL AND COUNT(c.changelog_id) > 0)"),
 	}
 	// apply time range if any
 	since := data.Since

--- a/plugins/jira/tasks/worklog_collector.go
+++ b/plugins/jira/tasks/worklog_collector.go
@@ -53,7 +53,7 @@ func CollectWorklogs(taskCtx core.SubTaskContext) error {
 		dal.Join("LEFT JOIN _tool_jira_worklogs wl ON (wl.connection_id = i.connection_id AND wl.issue_id = i.issue_id)"),
 		dal.Where("i.updated > i.created AND bi.connection_id = ?  AND bi.board_id = ?  ", data.Options.ConnectionId, data.Options.BoardId),
 		dal.Groupby("i.issue_id, i.updated"),
-		dal.Having("i.updated > max(wl.issue_updated) OR  max(wl.issue_updated) IS NULL"),
+		dal.Having("i.updated > max(wl.issue_updated) OR  (max(wl.issue_updated) IS NULL AND COUNT(wl.worklog_id) > 0)"),
 	}
 	// apply time range if any
 	if since != nil {


### PR DESCRIPTION
# Summary
fix #2653 ([Bug][jira] The worklog Diff Sync didn't work as expected )

It is reasonable that collecting Jira worklogs takes a long time.
But from the second time, it should not take too long.
Before collecting, we first select issues which should be collecting worklogs.
It turns out, that issues without any worklogs were selected due to an unprecise SQL query.

### Does this close any open issues?
close #2653 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
