### PR TITLE
fix: fix walk fields not filter struct

### DIFF
--- a/utils/structfield_test.go
+++ b/utils/structfield_test.go
@@ -19,33 +19,25 @@ package utils
 
 import (
 	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
-// WalkFields get the field data by tag
-func WalkFields(t reflect.Type, filter func(field *reflect.StructField) bool) (f []reflect.StructField) {
-	if t.Kind() == reflect.Ptr {
-		t = t.Elem()
-	}
+type TestStructForWalkFields struct {
+	ID   string    `gorm:"primaryKey"`
+	Time time.Time `gorm:"primaryKey"`
+	Data string
+}
 
-	if filter == nil {
-		for i := 0; i < t.NumField(); i++ {
-			field := t.Field(i)
-			if field.Type.Kind() == reflect.Struct {
-				f = append(f, WalkFields(field.Type, filter)...)
-			} else {
-				f = append(f, field)
-			}
-		}
-	} else {
-		for i := 0; i < t.NumField(); i++ {
-			field := t.Field(i)
-			if filter(&field) {
-				f = append(f, field)
-			} else if field.Type.Kind() == reflect.Struct {
-				f = append(f, WalkFields(field.Type, filter)...)
-			}
-		}
-	}
+// TestWalkFields test the WalkFields
+func TestWalkFields(t *testing.T) {
+	fs := WalkFields(reflect.TypeOf(TestStructForWalkFields{}), func(field *reflect.StructField) bool {
+		return strings.Contains(strings.ToLower(field.Tag.Get("gorm")), "primarykey")
+	})
 
-	return f
+	assert.Equal(t, fs[0].Name, "ID")
+	assert.Equal(t, fs[1].Name, "Time")
 }


### PR DESCRIPTION
# Summary
Add TestWalkFields
Fix WalkFileds lost to filter the struct.

cherry-pick from #2661 
<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Does this close any open issues?
Please mention the issues here.

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
