### PR TITLE
fix: cached plan must not change result type

### DIFF
--- a/models/migrationscripts/20220622_rename_tasks_to_plan.go
+++ b/models/migrationscripts/20220622_rename_tasks_to_plan.go
@@ -45,11 +45,7 @@ func (blueprintNormalMode_Pipeline) TableName() string {
 type renameTasksToPlan struct{}
 
 func (*renameTasksToPlan) Up(ctx context.Context, db *gorm.DB) error {
-	err := db.Migrator().AutoMigrate(&blueprintNormalMode_Blueprint{})
-	if err != nil {
-		return err
-	}
-	err = db.Migrator().RenameColumn(&blueprintNormalMode_Blueprint{}, "tasks", "plan")
+	err := db.Migrator().RenameColumn(&blueprintNormalMode_Blueprint{}, "tasks", "plan")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Summary
Repeated migration: _devlake_blueprints
https://github.com/merico-dev/lake/blob/fix%232684/models/migrationscripts/20220616_update_blueprint_mode.go
https://github.com/merico-dev/lake/blob/fix%232684/models/migrationscripts/20220622_rename_tasks_to_plan.go


### Does this close any open issues?
fix #2684 

### Screenshots
![image](https://user-images.githubusercontent.com/101256042/183000083-586db7bd-cde2-415a-803b-3f83d366509d.png)

### Other Information
Any other information that is important to this PR.
