### PR TITLE
feat(gitlab): add projects api

### DIFF
--- a/plugins/gitlab/api/proxy.go
+++ b/plugins/gitlab/api/proxy.go
@@ -1,0 +1,73 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"time"
+
+	"github.com/apache/incubator-devlake/plugins/core"
+	"github.com/apache/incubator-devlake/plugins/gitlab/models"
+	"github.com/apache/incubator-devlake/plugins/helper"
+)
+
+const (
+	TimeOut = 10 * time.Second
+)
+
+func Proxy(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
+	connection := &models.GitlabConnection{}
+	err := connectionHelper.First(connection, input.Params)
+	if err != nil {
+		return nil, err
+	}
+	apiClient, err := helper.NewApiClient(
+		context.TODO(),
+		connection.Endpoint,
+		map[string]string{
+			"Authorization": fmt.Sprintf("Bearer %v", connection.Token),
+		},
+		30*time.Second,
+		connection.Proxy,
+		basicRes,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := apiClient.Get(input.Params["path"], input.Query, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	// verify response body is json
+	var tmp interface{}
+	err = json.Unmarshal(body, &tmp)
+	if err != nil {
+		return nil, err
+	}
+	return &core.ApiResourceOutput{Status: resp.StatusCode, Body: json.RawMessage(body)}, nil
+}

--- a/plugins/gitlab/impl/impl.go
+++ b/plugins/gitlab/impl/impl.go
@@ -141,6 +141,9 @@ func (plugin Gitlab) ApiResources() map[string]map[string]core.ApiResourceHandle
 			"DELETE": api.DeleteConnection,
 			"GET":    api.GetConnection,
 		},
+		"connections/:connectionId/proxy/rest/*path": {
+			"GET": api.Proxy,
+		},
 	}
 }
 


### PR DESCRIPTION
# Summary

add a proxy for gitlab, which can allow config-ui to use:
`http://localhost:4000/api/plugins/gitlab/connections/3/proxy/rest/projects?visibility=private` to request all gitlab projects which granted to the specified user with the given token

### Does this close any open issues?
relate to #2376

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
