### PR TITLE
API `/version` returning `@` in docker mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 #While incubation status is not necessarily a reflection of the completeness or stability of the code,
 #it does indicate that the project has yet to be fully endorsed by the ASF.
 
-FROM mericodev/lake-builder:0.0.5 as builder
+FROM mericodev/lake-builder:v0.0.7 as builder
 
 # docker build --build-arg GOPROXY=https://goproxy.io,direct -t mericodev/lake .
 ARG GOPROXY=

--- a/devops/lake-builder/Dockerfile
+++ b/devops/lake-builder/Dockerfile
@@ -17,5 +17,5 @@
 # current tag: mericodev/lake-builder:0.0.5
 FROM golang:1.17-alpine3.15 as builder
 #RUN apk add --update gcc=130.2.1_pre1-r3 g++=10.2.1_pre1-r3
-RUN apk update && apk upgrade && apk add --no-cache tzdata libgit2-dev gcc g++ make tar
-RUN go install github.com/vektra/mockery/v2@latest
+RUN apk update && apk upgrade && apk add --no-cache tzdata libgit2-dev gcc g++ make tar git
+RUN go install github.com/vektra/mockery/v2@v2.12.3

--- a/devops/lake-builder/Dockerfile
+++ b/devops/lake-builder/Dockerfile
@@ -19,3 +19,4 @@ FROM golang:1.17-alpine3.15 as builder
 #RUN apk add --update gcc=130.2.1_pre1-r3 g++=10.2.1_pre1-r3
 RUN apk update && apk upgrade && apk add --no-cache tzdata libgit2-dev gcc g++ make tar git
 RUN go install github.com/vektra/mockery/v2@v2.12.3
+RUN go install github.com/swaggo/swag/cmd/swag@v1.8.4


### PR DESCRIPTION
# Summary

- fix missing version for docker-image
- fix missing `swag` command for lake-builder

### Does this close any open issues?
Closes #2708 

### Screenshots
Since the version is determined by the `tag` that my local `HEAD` is pointing to, the version `builder-v0.0.7` is  expected. It should be `v0.13.0` for next release
![image](https://user-images.githubusercontent.com/61080/183583544-f519d288-2255-44a1-a2ef-9c03e992af07.png)

