### PR TITLE
fix(tapd): modify changelog

### DIFF
--- a/plugins/tapd/models/story_changelog.go
+++ b/plugins/tapd/models/story_changelog.go
@@ -45,6 +45,8 @@ type TapdStoryChangelogItemRes struct {
 	Field             string          `json:"field" gorm:"primaryKey;type:varchar(255)"`
 	ValueBeforeParsed json.RawMessage `json:"value_before_parsed"`
 	ValueAfterParsed  json.RawMessage `json:"value_after_parsed"`
+	ValueBefore       json.RawMessage `json:"value_before"`
+	ValueAfter        json.RawMessage `json:"value_after"`
 	IterationIdFrom   uint64
 	IterationIdTo     uint64
 	common.NoPKModel

--- a/plugins/tapd/models/task_changelog.go
+++ b/plugins/tapd/models/task_changelog.go
@@ -58,6 +58,8 @@ type TapdTaskChangelogItemRes struct {
 	Field             string          `json:"field" gorm:"primaryKey;type:varchar(255)"`
 	ValueBeforeParsed json.RawMessage `json:"value_before_parsed"`
 	ValueAfterParsed  json.RawMessage `json:"value_after_parsed"`
+	ValueBefore       json.RawMessage `json:"value_before"`
+	ValueAfter        json.RawMessage `json:"value_after"`
 	IterationIdFrom   uint64
 	IterationIdTo     uint64
 	common.NoPKModel

--- a/plugins/tapd/tasks/task_changelog_extractor.go
+++ b/plugins/tapd/tasks/task_changelog_extractor.go
@@ -56,23 +56,39 @@ func ExtractTaskChangelog(taskCtx core.SubTaskContext) error {
 			for _, fc := range taskChangelog.FieldChanges {
 				var item models.TapdTaskChangelogItem
 				var valueAfterMap interface{}
-				if err = json.Unmarshal(fc.ValueAfterParsed, &valueAfterMap); err != nil {
-					return nil, err
+				var valueBeforeMap interface{}
+				if fc.ValueAfterParsed == nil {
+					if err = json.Unmarshal(fc.ValueAfter, &valueAfterMap); err != nil {
+						return nil, err
+					}
+				} else {
+					if err = json.Unmarshal(fc.ValueAfterParsed, &valueAfterMap); err != nil {
+						return nil, err
+					}
+				}
+				if fc.ValueBeforeParsed == nil {
+					if err = json.Unmarshal(fc.ValueBefore, &valueBeforeMap); err != nil {
+						return nil, err
+					}
+				} else {
+					if err = json.Unmarshal(fc.ValueBeforeParsed, &valueBeforeMap); err != nil {
+						return nil, err
+					}
 				}
 				switch valueAfterMap.(type) {
 				case map[string]interface{}:
-					valueBeforeMap := map[string]string{}
-					err = json.Unmarshal(fc.ValueBeforeParsed, &valueBeforeMap)
-					if err != nil {
-						return nil, err
-					}
 					for k, v := range valueAfterMap.(map[string]interface{}) {
 						item.ConnectionId = data.Options.ConnectionId
 						item.ChangelogId = taskChangelog.Id
 						item.Field = k
 						item.ValueAfterParsed = v.(string)
-						item.ValueBeforeParsed = valueBeforeMap[k]
-						results = append(results, item)
+						switch valueBeforeMap.(type) {
+						case map[string]interface{}:
+							item.ValueBeforeParsed = valueBeforeMap.(map[string]interface{})[k].(string)
+						default:
+							item.ValueBeforeParsed = valueBeforeMap.(string)
+						}
+						results = append(results, &item)
 					}
 				default:
 					item.ConnectionId = data.Options.ConnectionId


### PR DESCRIPTION
# Summary

Seems like tapd has modified their api, so we got error when extracting story changelog
right now, I added one more logic to adopt the change.
Detail:
if somebody add comment on story/task, it will generate a changelog. And this changelog may have different struct comparing with before.

### Does this close any open issues?
close #2757

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
