### PR TITLE
feat: create paginator hook and paginate blueprints grid

### DIFF
--- a/config-ui/src/components/blueprints/BlueprintsGrid.jsx
+++ b/config-ui/src/components/blueprints/BlueprintsGrid.jsx
@@ -37,7 +37,6 @@ import DeletePopover from '@/components/blueprints/DeletePopover'
 const BlueprintsGrid = (props) => {
   const {
     blueprints = [],
-    filteredBlueprints = [],
     pipelines = [],
     activeBlueprint,
     blueprintSchedule,
@@ -152,7 +151,7 @@ const BlueprintsGrid = (props) => {
             minWidth: '830px'
           }}
         >
-          {(activeFilterStatus ? filteredBlueprints : blueprints).map((b, bIdx) => (
+          {(blueprints).map((b, bIdx) => (
             <div key={`blueprint-row-key-${bIdx}`}>
               <div
                 style={{
@@ -481,7 +480,7 @@ const BlueprintsGrid = (props) => {
               </Collapse>
             </div>
           ))}
-          {(activeFilterStatus ? filteredBlueprints.length === 0 : blueprints.length === 0) && (
+          {(blueprints.length === 0) && (
             <div style={{ padding: '12px' }}>
               <h3 style={{
                 fontWeight: 800,

--- a/config-ui/src/components/blueprints/create-workflow/DataTransformations.jsx
+++ b/config-ui/src/components/blueprints/create-workflow/DataTransformations.jsx
@@ -387,8 +387,9 @@ const DataTransformations = (props) => {
                               <Tooltip
                                 position={Position.TOP}
                                 intent={Intent.PRIMARY}
-                                content={'Close Editor to Continue'}>
-                                  <Spinner size={12} />
+                                content='Close Editor to Continue'
+                              >
+                                <Spinner size={12} />
                               </Tooltip>
                             )}
                           />

--- a/config-ui/src/hooks/useConnectionManager.jsx
+++ b/config-ui/src/hooks/useConnectionManager.jsx
@@ -588,7 +588,7 @@ function useConnectionManager (
           setPassword(activeConnection.password)
           setProxy(activeConnection.Proxy || activeConnection.proxy)
           setRateLimit(activeConnection.rateLimitPerHour)
-        break
+          break
       }
       ToastNotification.clear()
       // ToastNotification.show({ message: `Fetched settings for ${activeConnection.name}.`, intent: 'success', icon: 'small-tick' })

--- a/config-ui/src/hooks/usePaginator.jsx
+++ b/config-ui/src/hooks/usePaginator.jsx
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import React, { useState, useEffect, useRef, useCallback } from 'react'
+import {
+  Popover,
+  Menu,
+  MenuItem,
+  Button
+} from '@blueprintjs/core'
+
+import { integrationsData } from '@/data/integrations'
+
+const PagingOptionsMenu = (props) => {
+  const { perPage = 10, setPerPage = () => {} } = props
+  return (
+    <Menu>
+      <MenuItem
+        active={perPage === 10}
+        icon='key-option'
+        text='10 Records'
+        onClick={() => setPerPage(10)}
+      />
+      <MenuItem
+        active={perPage === 25}
+        icon='key-option'
+        text='25 Records'
+        onClick={() => setPerPage(25)}
+      />
+      <MenuItem
+        active={perPage === 50}
+        icon='key-option'
+        text='50 Records'
+        onClick={() => setPerPage(50)}
+      />
+      <MenuItem
+        active={perPage === 75}
+        icon='key-option'
+        text='75 Records'
+        onClick={() => setPerPage(75)}
+      />
+      <MenuItem
+        active={perPage === 100}
+        icon='key-option'
+        text='100 Records'
+        onClick={() => setPerPage(100)}
+      />
+    </Menu>
+  )
+}
+
+const Controls = (props) => {
+  const {
+    enabled = true,
+    pagingOptionsMenu,
+    currentPage,
+    perPage = 10,
+    maxPage,
+    onPrevPage = () => {},
+    onNextPage = () => {},
+    isLoading = false,
+  } = props
+
+  return (
+    <div
+      className='pagination-controls'
+      style={{ display: 'flex', whiteSpace: 'nowrap' }}
+    >
+      <Popover placement='bottom'>
+        <Button
+          className='btn-select-page-size'
+          style={{ whiteSpace: 'nowrap' }}
+          icon='numbered-list'
+          text={`Rows: ${perPage}`}
+          disabled={isLoading}
+          outlined
+          minimal
+        />
+        <>{pagingOptionsMenu}</>
+      </Popover>
+      <Button
+        onClick={onPrevPage}
+        className='pagination-btn btn-prev-page'
+        icon='step-backward'
+        small
+        text='PREV'
+        style={{ marginLeft: '5px', marginRight: '5px', whiteSpace: 'nowrap' }}
+        disabled={currentPage?.current === 1 || isLoading}
+      />
+      <Button
+        style={{ whiteSpace: 'nowrap' }}
+        disabled={currentPage?.current === maxPage || isLoading}
+        onClick={onNextPage}
+        className='pagination-btn btn-next-page'
+        rightIcon='step-forward'
+        text='NEXT'
+        small
+      />
+    </div>
+  )
+}
+
+function usePaginator (initialLoadingState = false) {
+  // const [integrations, setIntegrations] = useState(integrationsData)
+
+  const [data, setData] = useState([])
+
+  const [filteredData, setFilteredData] = useState([])
+  const [pagedData, setPagedData] = useState([])
+  const [pageOptions, setPageOptions] = useState([10, 25, 50, 75, 100])
+  const currentPage = useRef(1)
+  const [perPage, setPerPage] = useState(pageOptions[0])
+  const [maxPage, setMaxPage] = useState(
+    Math.max(1, Math.ceil(pagedData.length / perPage))
+  )
+
+  const [isLoading, setIsLoading] = useState(initialLoadingState || false)
+  const [isProcessing, setIsProcessing] = useState(false)
+  const [refresh, setRefresh] = useState(false)
+
+  const nextPage = useCallback(() => {
+    console.log('>>> PAGINATOR: GO NEXT PAGE ...')
+    currentPage.current = Math.min(maxPage, currentPage.current + 1)
+    // setRefresh((r) => !r)
+    console.log('>>>> NEXT PAGE', currentPage.current)
+  }, [maxPage, currentPage.current, setRefresh])
+
+  const prevPage = useCallback(() => {
+    console.log('>>> PAGINATOR: GO PREV PAGE ...')
+    currentPage.current = Math.max(1, currentPage.current - 1)
+    // setRefresh((r) => !r)
+    console.log('>>>> PREV PAGE', currentPage.current)
+  }, [maxPage, currentPage.current, setRefresh])
+
+  const resetPage = useCallback(() => {
+    currentPage.current = 1
+  }, [currentPage.current])
+
+  const paginateData = useCallback(() => {
+    console.log('>> PAGINATING DATA...', data)
+    const sliceOffset = currentPage.current >= 2 ? -1 : 0
+    const sliceBegin = currentPage.current === 1
+      ? 0
+      : (currentPage.current + sliceOffset) * perPage
+    const sliceEnd = currentPage.current === 1
+      ? perPage
+      : ((currentPage.current + sliceOffset) * perPage) + perPage
+    console.log('>> CURRENT PAGE = ', currentPage.current)
+    console.log('>> START RECORD INDEX ====', sliceBegin)
+    console.log('>> END RECORD INDEX ====', sliceEnd)
+    setPagedData(data.slice(sliceBegin, sliceEnd))
+  }, [data, perPage, currentPage?.current, setPagedData])
+
+  useEffect(() => {
+    paginateData()
+  }, [refresh, perPage, data, currentPage?.current, paginateData])
+
+  useEffect(() => {
+    console.log('>> PAGINATOR: DATA ON PAGE...', pagedData)
+    setMaxPage(Math.max(1, Math.ceil(pagedData.length / perPage)))
+  }, [pagedData, perPage])
+
+  const controls = useCallback(() => {
+    return (
+      <Controls
+        currentPage={currentPage}
+        onNextPage={nextPage}
+        onPrevPage={prevPage}
+        maxPage={maxPage}
+        perPage={perPage}
+        isLoading={isLoading}
+        pagingOptionsMenu={
+          <PagingOptionsMenu perPage={perPage} setPerPage={setPerPage} />
+        }
+      />
+    )
+  }, [currentPage, maxPage, perPage, isLoading, nextPage, prevPage, setPerPage])
+
+  useEffect(() => {
+    console.log('>>> PAGINATOR: DATA ...', data)
+  }, [data])
+
+  return {
+    nextPage,
+    prevPage,
+    resetPage,
+    controls,
+    isLoading,
+    isProcessing,
+    data,
+    pagedData,
+    filteredData,
+    perPage,
+    maxPage,
+    setIsLoading,
+    setIsProcessing,
+    setData,
+    setPagedData,
+    setFilteredData,
+    setMaxPage
+  }
+}
+
+export default usePaginator

--- a/config-ui/src/hooks/usePaginator.jsx
+++ b/config-ui/src/hooks/usePaginator.jsx
@@ -126,21 +126,21 @@ function usePaginator (initialLoadingState = false) {
   const setDataWithDefault = useCallback((data) => {
     console.log('>> SET ALL DATA...', data)
     setData(data || [])
-  }, [setData, setRefresh])
+  }, [setData])
 
   const goNextPage = useCallback(() => {
     console.log('>>> PAGINATOR: GO NEXT PAGE ...')
     setCurrentPage(currentPage => Math.min(maxPage, currentPage + 1))
     // setRefresh((r) => !r)
     console.log('>>>> NEXT PAGE', currentPage)
-  }, [maxPage, currentPage, setRefresh])
+  }, [maxPage, currentPage])
 
   const goPrevPage = useCallback(() => {
     console.log('>>> PAGINATOR: GO PREV PAGE ...')
     setCurrentPage(currentPage => Math.max(1, currentPage - 1))
     // setRefresh((r) => !r)
     console.log('>>>> PREV PAGE', currentPage)
-  }, [maxPage, currentPage, setRefresh])
+  }, [currentPage])
 
   const changePerPage = useCallback((perPage) => {
     setPerPage(perPage)
@@ -149,7 +149,7 @@ function usePaginator (initialLoadingState = false) {
 
   const resetPage = useCallback(() => {
     setCurrentPage(1)
-  }, [currentPage])
+  }, [setCurrentPage])
 
   const paginateData = useCallback(() => {
     console.log('>> FILTERED DATA...', filteredData)
@@ -161,7 +161,7 @@ function usePaginator (initialLoadingState = false) {
 
   useEffect(() => {
     paginateData()
-  }, [refresh, perPage, filteredData, currentPage, paginateData])
+  }, [/* refresh, */perPage, filteredData, currentPage, paginateData])
 
   useEffect(() => {
     setCurrentPage(currentPage => Math.min(maxPage, currentPage))
@@ -181,7 +181,7 @@ function usePaginator (initialLoadingState = false) {
         }
       />
     )
-  }, [currentPage, maxPage, perPage, isLoading, goNextPage, goPrevPage, changePerPage])
+  }, [currentPage, maxPage, perPage, pageOptions, isLoading, goNextPage, goPrevPage, changePerPage])
 
   return {
     goNextPage,

--- a/config-ui/src/hooks/usePaginator.jsx
+++ b/config-ui/src/hooks/usePaginator.jsx
@@ -95,45 +95,38 @@ const Controls = (props) => {
 function usePaginator (initialLoadingState = false) {
   // const [integrations, setIntegrations] = useState(integrationsData)
 
-  const [_data, _setData] = useState([])
+  const [data, setData] = useState([])
 
   // filter related
   const [filterParams, setFilterParams] = useState({})
   const [filterFunc, setFilterFunc] = useState(() => (params, item) => true)
   const filteredData = useMemo(() => {
-    console.log('>> SET FILTER DATA BY', filterParams, _data)
+    console.log('>> SET FILTER DATA BY', filterParams, data)
     const filteredData = []
-    for (const item of _data) {
-      console.log(item)
+    for (const item of data) {
       if (filterFunc(filterParams, item)) {
         filteredData.push(item)
       }
     }
     return filteredData
-  }, [_data, filterParams, filterFunc])
+  }, [data, filterParams, filterFunc])
 
   // page related
   const [pagedData, setPagedData] = useState([])
   const [pageOptions, setPageOptions] = useState([5, 25, 50, 75, 100])
   const [currentPage, setCurrentPage] = useState(1)
   const [perPage, setPerPage] = useState(pageOptions[1])
-  const [maxPage, setMaxPage] = useState(0)
+  const maxPage = useMemo(() => Math.max(1, Math.ceil(filteredData.length / perPage)), [filteredData, perPage])
 
   // others
   const [isLoading, setIsLoading] = useState(initialLoadingState || false)
   const [isProcessing, setIsProcessing] = useState(false)
   const [refresh, setRefresh] = useState(false)
 
-  const reCalMaxPage = useCallback(() => {
-    setMaxPage(Math.max(1, Math.ceil(filteredData.length / perPage)))
-    console.log('>> MAX PAGE = ', Math.max(1, Math.ceil(filteredData.length / perPage)))
-  }, [filteredData, perPage, setMaxPage])
-
-  const setData = useCallback((data) => {
-    console.log('>> SET ALL DATA...', _data)
-    _setData(data || [])
-    reCalMaxPage()
-  }, [_setData, setRefresh])
+  const setDataWithDefault = useCallback((data) => {
+    console.log('>> SET ALL DATA...', data)
+    setData(data || [])
+  }, [setData, setRefresh])
 
   const goNextPage = useCallback(() => {
     console.log('>>> PAGINATOR: GO NEXT PAGE ...')
@@ -152,7 +145,6 @@ function usePaginator (initialLoadingState = false) {
   const changePerPage = useCallback((perPage) => {
     setPerPage(perPage)
     setCurrentPage(1)
-    reCalMaxPage()
   }, [setPerPage])
 
   const resetPage = useCallback(() => {
@@ -172,8 +164,8 @@ function usePaginator (initialLoadingState = false) {
   }, [refresh, perPage, filteredData, currentPage, paginateData])
 
   useEffect(() => {
-    reCalMaxPage()
-  }, [refresh, reCalMaxPage, perPage, filteredData])
+    setCurrentPage(currentPage => Math.min(maxPage, currentPage))
+  }, [maxPage, setCurrentPage])
 
   const renderControlsComponent = useCallback(() => {
     return (
@@ -199,12 +191,12 @@ function usePaginator (initialLoadingState = false) {
     renderControlsComponent,
     isLoading,
     isProcessing,
-    data: _data,
+    data,
     filteredData,
     pagedData,
     perPage,
     maxPage,
-    setData,
+    setData: setDataWithDefault,
     setPagedData,
     setFilterParams,
     setFilterFunc,

--- a/config-ui/src/pages/blueprints/index.jsx
+++ b/config-ui/src/pages/blueprints/index.jsx
@@ -32,6 +32,7 @@ import {
 import usePipelineManager from '@/hooks/usePipelineManager'
 import useBlueprintManager from '@/hooks/useBlueprintManager'
 import useBlueprintValidation from '@/hooks/useBlueprintValidation'
+import usePaginator from '@/hooks/usePaginator'
 import Nav from '@/components/Nav'
 import Sidebar from '@/components/Sidebar'
 import AppCrumbs from '@/components/Breadcrumbs'
@@ -88,6 +89,14 @@ const Blueprints = (props) => {
     // eslint-disable-next-line no-unused-vars
     detectPipelineProviders
   } = usePipelineManager()
+
+  const {
+    data,
+    pagedData,
+    filteredData,
+    setData,
+    controls: renderPagnationControls
+  } = usePaginator()
 
   const [expandDetails, setExpandDetails] = useState(false)
   const [activeBlueprint, setActiveBlueprint] = useState(null)
@@ -282,6 +291,10 @@ const Blueprints = (props) => {
     console.log('>>>> DETECTED PROVIDERS TASKS....', detectedProviderTasks)
   }, [detectedProviderTasks])
 
+  useEffect(() => {
+    setData(blueprints)
+  }, [blueprints])
+
   return (
     <>
       <div className='container'>
@@ -316,7 +329,8 @@ const Blueprints = (props) => {
             {(!isFetchingBlueprints) && blueprints.length > 0 && (
               <>
                 <BlueprintsGrid
-                  blueprints={blueprints}
+                  // blueprints={blueprints}
+                  blueprints={pagedData}
                   pipelines={relatedPipelines}
                   filteredBlueprints={filteredBlueprints}
                   activeFilterStatus={activeFilterStatus}
@@ -381,6 +395,7 @@ const Blueprints = (props) => {
                 />
               </Card>
             )}
+            <div style={{ alignSelf: 'flex-end', padding: '10px' }}>{renderPagnationControls()}</div>
           </main>
         </Content>
       </div>

--- a/config-ui/src/pages/blueprints/index.jsx
+++ b/config-ui/src/pages/blueprints/index.jsx
@@ -94,7 +94,7 @@ const Blueprints = (props) => {
     pagedData,
     setFilterParams,
     setFilterFunc,
-    setData,
+    setData: setPaginatorData,
     renderControlsComponent: renderPagnationControls
   } = usePaginator()
 
@@ -281,7 +281,7 @@ const Blueprints = (props) => {
   }, [detectedProviderTasks])
 
   useEffect(() => {
-    setData(blueprints)
+    setPaginatorData(blueprints)
   }, [blueprints])
 
   return (

--- a/config-ui/src/pages/blueprints/index.jsx
+++ b/config-ui/src/pages/blueprints/index.jsx
@@ -91,9 +91,9 @@ const Blueprints = (props) => {
   } = usePipelineManager()
 
   const {
-    data,
     pagedData,
-    filteredData,
+    setFilterParams,
+    setFilterFunc,
     setData,
     renderControlsComponent: renderPagnationControls
   } = usePaginator()
@@ -107,7 +107,6 @@ const Blueprints = (props) => {
   const [pipelineTemplates, setPipelineTemplates] = useState([])
   const [selectedPipelineTemplate, setSelectedPipelineTemplate] = useState()
 
-  const [filteredBlueprints, setFilteredBlueprints] = useState([])
   const [activeFilterStatus, setActiveFilterStatus] = useState()
 
   const [relatedPipelines, setRelatedPipelines] = useState([])
@@ -248,37 +247,27 @@ const Blueprints = (props) => {
   }, [fetchAllPipelines])
 
   useEffect(() => {
-    if (activeFilterStatus) {
+    setFilterFunc(() => (activeFilterStatus, blueprint) => {
       switch (activeFilterStatus) {
         case 'hourly':
-          setFilteredBlueprints(blueprints.filter(b => b.cronConfig === getCronPreset(activeFilterStatus).cronConfig))
-          break
         case 'daily':
-          setFilteredBlueprints(blueprints.filter(b => b.cronConfig === getCronPreset(activeFilterStatus).cronConfig))
-          break
         case 'weekly':
-          setFilteredBlueprints(blueprints.filter(b => b.cronConfig === getCronPreset(activeFilterStatus).cronConfig))
-          break
         case 'monthly':
-          setFilteredBlueprints(blueprints.filter(b => b.cronConfig === getCronPreset(activeFilterStatus).cronConfig))
-          break
+          console.log(blueprint.cronConfig === getCronPreset(activeFilterStatus).cronConfig)
+          return blueprint.cronConfig === getCronPreset(activeFilterStatus).cronConfig
         case 'manual':
-          setFilteredBlueprints(blueprints.filter(b => b.isManual))
-          break
+          return blueprint.isManual
         case 'custom':
-          setFilteredBlueprints(blueprints.filter(
-            b => b.cronConfig !== getCronPreset('hourly').cronConfig &&
-            b.cronConfig !== getCronPreset('daily').cronConfig &&
-            b.cronConfig !== getCronPreset('weekly').cronConfig &&
-            b.cronConfig !== getCronPreset('monthly').cronConfig
-          ))
-          break
+          return blueprint.cronConfig !== getCronPreset('hourly').cronConfig &&
+            blueprint.cronConfig !== getCronPreset('daily').cronConfig &&
+            blueprint.cronConfig !== getCronPreset('weekly').cronConfig &&
+            blueprint.cronConfig !== getCronPreset('monthly').cronConfig
         default:
-        // NO FILTERS
-          break
+          return true
       }
-    }
-  }, [activeFilterStatus, blueprints, getCronPreset])
+    })
+    setFilterParams(activeFilterStatus)
+  }, [activeFilterStatus, setFilterParams, getCronPreset])
 
   // useEffect(() => {
   //   if (Array.isArray(tasks)) {
@@ -329,10 +318,8 @@ const Blueprints = (props) => {
             {(!isFetchingBlueprints) && blueprints.length > 0 && (
               <>
                 <BlueprintsGrid
-                  // blueprints={blueprints}
                   blueprints={pagedData}
                   pipelines={relatedPipelines}
-                  filteredBlueprints={filteredBlueprints}
                   activeFilterStatus={activeFilterStatus}
                   onFilter={setActiveFilterStatus}
                   activeBlueprint={activeBlueprint}

--- a/config-ui/src/pages/blueprints/index.jsx
+++ b/config-ui/src/pages/blueprints/index.jsx
@@ -95,7 +95,7 @@ const Blueprints = (props) => {
     pagedData,
     filteredData,
     setData,
-    controls: renderPagnationControls
+    renderControlsComponent: renderPagnationControls
   } = usePaginator()
 
   const [expandDetails, setExpandDetails] = useState(false)


### PR DESCRIPTION
### 📦  Config-UI / Hooks / Paginator


- [x] Create Paginator Hook
   - [x] Complete Basic Client-Side Pagination Support
   - [x] Enable Filter Support
- [x] Integrate w/ Blueprints Grid
- [x] **Chore** Resolve Lint Warnings

### Deferred to alternate PR
- [ ] Integrate w/ Historical Runs Grid (Blueprint _Status_) #2843 `TBD`

### Description

This PR creates a new **Paginator Hook** that will allow Page Components to use `client-side` pagination on larger data sets. Pagination has been enabled on the **Blueprints Grid**. Later on, the Paginator will be further enhanced to support `server-side` pagination to better accommodate listing of many pipelines (historical runs) and other api resources.


### Does this close any open issues?
#2837 


