### PR TITLE
feat: add connection rate limit setting

### DIFF
--- a/config-ui/src/components/blueprints/ConnectionDialog.jsx
+++ b/config-ui/src/components/blueprints/ConnectionDialog.jsx
@@ -95,6 +95,7 @@ const ConnectionDialog = (props) => {
     name,
     endpointUrl,
     proxy,
+    rateLimit = 0,
     token,
     initialTokenStore = {},
     username,
@@ -116,6 +117,7 @@ const ConnectionDialog = (props) => {
     onNameChange = () => {},
     onEndpointChange = () => {},
     onProxyChange = () => {},
+    onRateLimitChange = () => {},
     onTokenChange = () => {},
     onUsernameChange = () => {},
     onPasswordChange = () => {},
@@ -287,6 +289,7 @@ const ConnectionDialog = (props) => {
                     name={name}
                     endpointUrl={endpointUrl}
                     proxy={proxy}
+                    rateLimit={rateLimit}
                     token={token}
                     initialTokenStore={initialTokenStore}
                     username={username}
@@ -298,6 +301,7 @@ const ConnectionDialog = (props) => {
                     onNameChange={onNameChange}
                     onEndpointChange={onEndpointChange}
                     onProxyChange={onProxyChange}
+                    onRateLimitChange={onRateLimitChange}
                     onTokenChange={onTokenChange}
                     onUsernameChange={onUsernameChange}
                     onPasswordChange={onPasswordChange}

--- a/config-ui/src/data/NullConnection.js
+++ b/config-ui/src/data/NullConnection.js
@@ -21,6 +21,7 @@ const NullConnection = {
   name: null,
   endpoint: null,
   proxy: null,
+  rateLimit: 0,
   token: null,
   username: null,
   password: null,

--- a/config-ui/src/data/Providers.js
+++ b/config-ui/src/data/Providers.js
@@ -81,7 +81,8 @@ const ProviderFormLabels = {
     proxy: 'Proxy URL',
     token: 'Basic Auth Token',
     username: 'Username',
-    password: 'Password'
+    password: 'Password',
+    rateLimit: 'Rate Limit'
   },
   gitlab: {
     name: 'Connection Name',
@@ -89,7 +90,8 @@ const ProviderFormLabels = {
     proxy: 'Proxy URL',
     token: 'Access Token',
     username: 'Username',
-    password: 'Password'
+    password: 'Password',
+    rateLimit: <>Rate Limit <sup>(per hour)</sup></>
   },
   jenkins: {
     name: 'Connection Name',
@@ -97,7 +99,8 @@ const ProviderFormLabels = {
     proxy: 'Proxy URL',
     token: 'Basic Auth Token',
     username: 'Username',
-    password: 'Password'
+    password: 'Password',
+    rateLimit: <>Rate Limit <sup>(per hour)</sup></>
   },
   tapd: {
     name: 'Connection Name',
@@ -106,13 +109,14 @@ const ProviderFormLabels = {
     token: 'Basic Auth Token',
     username: 'Username',
     password: 'Password',
+    rateLimit: <>Rate Limit <sup>(per hour)</sup></>
   },
   jira: {
     name: 'Connection Name',
     endpoint: 'Endpoint URL',
     token: 'Basic Auth Token',
     username: 'Username / E-mail',
-    // password; 'Password',
+    proxy: 'Proxy URL',
     password: (
       <>
         Password
@@ -134,17 +138,17 @@ const ProviderFormLabels = {
           />
         </Tooltip>
       </>),
+    rateLimit: <>Rate Limit <sup>(per hour)</sup></>
   },
   github: {
     name: 'Connection Name',
     endpoint: 'Endpoint URL',
     proxy: 'Proxy URL',
-    // token: 'Auth Token(s)',
     token: (
       <>
         Auth Token(s)
         <Tooltip
-          content={(<span>Due to Github’s rate limit, input more tokens, <br />comma separated, to accelerate data collection.</span>)}
+          content={(<span>Due to Github's rate limit, input more tokens, <br />comma separated, to accelerate data collection.</span>)}
           intent='primary'
         >
           <Icon
@@ -162,8 +166,9 @@ const ProviderFormLabels = {
         </Tooltip>
       </>),
     username: 'Username',
-    password: 'Password'
-  },
+    password: 'Password',
+    rateLimit: <>Rate Limit <sup>(per hour)</sup></>
+  }
 }
 
 const ProviderFormPlaceholders = {
@@ -173,7 +178,8 @@ const ProviderFormPlaceholders = {
     proxy: 'eg. http://proxy.localhost:8080',
     token: 'eg. 3f5cda2a23ff410792e0',
     username: 'Enter Username / E-mail',
-    password: 'Enter Password'
+    password: 'Enter Password',
+    rateLimit: '1000'
   },
   gitlab: {
     name: 'eg. GitLab',
@@ -181,7 +187,8 @@ const ProviderFormPlaceholders = {
     proxy: 'eg. http://proxy.localhost:8080',
     token: 'eg. ff9d1ad0e5c04f1f98fa',
     username: 'Enter Username / E-mail',
-    password: 'Enter Password'
+    password: 'Enter Password',
+    rateLimit: '1000'
   },
   jenkins: {
     name: 'eg. Jenkins',
@@ -189,7 +196,8 @@ const ProviderFormPlaceholders = {
     proxy: 'eg. http://proxy.localhost:8080',
     token: 'eg. 6b057ffe68464c93a057',
     username: 'eg. admin',
-    password: 'eg. ************'
+    password: 'eg. ************',
+    rateLimit: '1000'
   },
   tapd: {
     name: 'eg. Tapd',
@@ -197,7 +205,8 @@ const ProviderFormPlaceholders = {
     proxy: 'eg. http://proxy.localhost:8080',
     token: 'eg. 6b057ffe68464c93a057',
     username: 'eg. admin',
-    password: 'eg. ************'
+    password: 'eg. ************',
+    rateLimit: '1000'
   },
   jira: {
     name: 'eg. JIRA',
@@ -205,7 +214,8 @@ const ProviderFormPlaceholders = {
     proxy: 'eg. http://proxy.localhost:8080',
     token: 'eg. 8c06a7cc50b746bfab30',
     username: 'eg. admin',
-    password: 'eg. ************'
+    password: 'eg. ************',
+    rateLimit: '1000'
   },
   github: {
     name: 'eg. GitHub',
@@ -213,7 +223,8 @@ const ProviderFormPlaceholders = {
     proxy: 'eg. http://proxy.localhost:8080',
     token: 'eg. 4c5cbdb62c165e2b3d18, 40008ebccff9837bb8d2',
     username: 'eg. admin',
-    password: 'eg. ************'
+    password: 'eg. ************',
+    rateLimit: '1000'
   }
 }
 

--- a/config-ui/src/hooks/useConnectionManager.jsx
+++ b/config-ui/src/hooks/useConnectionManager.jsx
@@ -44,6 +44,7 @@ function useConnectionManager (
   const [name, setName] = useState()
   const [endpointUrl, setEndpointUrl] = useState()
   const [proxy, setProxy] = useState()
+  const [rateLimit, setRateLimit] = useState(0)
   const [token, setToken] = useState()
   const [initialTokenStore, setInitialTokenStore] = useState({
     0: '',
@@ -148,6 +149,7 @@ function useConnectionManager (
           username: username,
           password: password,
           proxy: proxy,
+          rateLimit: rateLimit,
           ...connectionPayload,
         }
         break
@@ -158,6 +160,7 @@ function useConnectionManager (
           username: username,
           password: password,
           proxy: proxy,
+          rateLimit: rateLimit,
           ...connectionPayload,
         }
         break
@@ -167,6 +170,7 @@ function useConnectionManager (
           endpoint: endpointUrl,
           token: token,
           proxy: proxy,
+          rateLimit: rateLimit,
           ...connectionPayload,
         }
         break
@@ -177,6 +181,7 @@ function useConnectionManager (
           endpoint: endpointUrl,
           username: username,
           password: password,
+          rateLimit: rateLimit,
           ...connectionPayload,
         }
         break
@@ -186,6 +191,7 @@ function useConnectionManager (
           endpoint: endpointUrl,
           token: token,
           proxy: proxy,
+          rateLimit: rateLimit,
           ...connectionPayload,
         }
         break
@@ -321,6 +327,7 @@ function useConnectionManager (
             name: connectionData.name || connectionData.Name,
             endpoint: connectionData.endpoint || connectionData.Endpoint,
             proxy: connectionData.proxy || connectionData.Proxy,
+            rateLimit: connectionData.rateLimit,
             username: connectionData.username || connectionData.Username,
             password: connectionData.password || connectionData.Password,
             token: connectionData.token || connectionData.auth
@@ -544,6 +551,7 @@ function useConnectionManager (
       2: ''
     })
     setProxy('')
+    setRateLimit(0)
   }, [])
 
   useEffect(() => {
@@ -555,21 +563,25 @@ function useConnectionManager (
         case Providers.JENKINS:
           setUsername(activeConnection.username)
           setPassword(activeConnection.password)
+          setRateLimit(activeConnection.rateLimit)
           break
         case Providers.GITLAB:
           setToken(activeConnection.basicAuthEncoded || activeConnection.token || activeConnection.auth)
           setProxy(activeConnection.Proxy || activeConnection.proxy)
+          setRateLimit(activeConnection.rateLimit)
           break
         case Providers.GITHUB:
           setToken(connectionToken)
           setInitialTokenStore(connectionToken?.split(',')?.reduce((tS, cT, id) => ({ ...tS, [id]: cT }), {}))
           setProxy(activeConnection.Proxy || activeConnection.proxy)
+          setRateLimit(activeConnection.rateLimit)
           break
         case Providers.JIRA:
         // setToken(activeConnection.basicAuthEncoded || activeConnection.token)
           setUsername(activeConnection.username)
           setPassword(activeConnection.password)
           setProxy(activeConnection.Proxy || activeConnection.proxy)
+          setRateLimit(activeConnection.rateLimit)
           break
       }
       ToastNotification.clear()
@@ -657,6 +669,7 @@ function useConnectionManager (
     name,
     endpointUrl,
     proxy,
+    rateLimit,
     username,
     password,
     token,
@@ -667,6 +680,7 @@ function useConnectionManager (
     setName,
     setEndpointUrl,
     setProxy,
+    setRateLimit,
     setToken,
     setInitialTokenStore,
     setUsername,

--- a/config-ui/src/hooks/useConnectionManager.jsx
+++ b/config-ui/src/hooks/useConnectionManager.jsx
@@ -583,6 +583,12 @@ function useConnectionManager (
           setProxy(activeConnection.Proxy || activeConnection.proxy)
           setRateLimit(activeConnection.rateLimit)
           break
+        case Providers.TAPD:
+          setUsername(activeConnection.username)
+          setPassword(activeConnection.password)
+          setProxy(activeConnection.Proxy || activeConnection.proxy)
+          setRateLimit(activeConnection.rateLimit)
+        break
       }
       ToastNotification.clear()
       // ToastNotification.show({ message: `Fetched settings for ${activeConnection.name}.`, intent: 'success', icon: 'small-tick' })

--- a/config-ui/src/hooks/useConnectionManager.jsx
+++ b/config-ui/src/hooks/useConnectionManager.jsx
@@ -149,7 +149,7 @@ function useConnectionManager (
           username: username,
           password: password,
           proxy: proxy,
-          rateLimit: rateLimit,
+          rateLimitPerHour: rateLimit,
           ...connectionPayload,
         }
         break
@@ -160,7 +160,7 @@ function useConnectionManager (
           username: username,
           password: password,
           proxy: proxy,
-          rateLimit: rateLimit,
+          rateLimitPerHour: rateLimit,
           ...connectionPayload,
         }
         break
@@ -170,7 +170,7 @@ function useConnectionManager (
           endpoint: endpointUrl,
           token: token,
           proxy: proxy,
-          rateLimit: rateLimit,
+          rateLimitPerHour: rateLimit,
           ...connectionPayload,
         }
         break
@@ -181,7 +181,7 @@ function useConnectionManager (
           endpoint: endpointUrl,
           username: username,
           password: password,
-          rateLimit: rateLimit,
+          rateLimitPerHour: rateLimit,
           ...connectionPayload,
         }
         break
@@ -191,7 +191,7 @@ function useConnectionManager (
           endpoint: endpointUrl,
           token: token,
           proxy: proxy,
-          rateLimit: rateLimit,
+          rateLimitPerHour: rateLimit,
           ...connectionPayload,
         }
         break

--- a/config-ui/src/hooks/useConnectionValidation.jsx
+++ b/config-ui/src/hooks/useConnectionValidation.jsx
@@ -25,6 +25,7 @@ function useConnectionValidation ({
   name,
   endpointUrl,
   proxy,
+  rateLimit,
   token,
   username,
   password
@@ -48,6 +49,7 @@ function useConnectionValidation ({
       'NAME', name,
       'ENDPOINT URL', endpointUrl,
       'PROXY URL', proxy,
+      'RATE LIMIT', rateLimit,
       'TOKEN', token,
       'USERNAME', username,
       'PASSWORD', password
@@ -100,6 +102,7 @@ function useConnectionValidation ({
     name,
     endpointUrl,
     proxy,
+    rateLimit,
     token,
     username,
     password,

--- a/config-ui/src/pages/blueprints/create-blueprint.jsx
+++ b/config-ui/src/pages/blueprints/create-blueprint.jsx
@@ -268,6 +268,7 @@ const CreateBlueprint = (props) => {
     name: connectionName,
     endpointUrl,
     proxy,
+    rateLimit,
     token,
     initialTokenStore,
     username,
@@ -278,6 +279,7 @@ const CreateBlueprint = (props) => {
     setName,
     setEndpointUrl,
     setProxy,
+    setRateLimit,
     setUsername,
     setPassword,
     setToken,
@@ -333,6 +335,7 @@ const CreateBlueprint = (props) => {
     name: connectionName,
     endpointUrl,
     proxy,
+    rateLimit,
     token,
     username,
     password,
@@ -1129,6 +1132,7 @@ const CreateBlueprint = (props) => {
         endpointUrl={endpointUrl}
         name={connectionName}
         proxy={proxy}
+        rateLimit={rateLimit}
         token={token}
         initialTokenStore={initialTokenStore}
         username={username}
@@ -1145,6 +1149,7 @@ const CreateBlueprint = (props) => {
         onNameChange={setName}
         onEndpointChange={setEndpointUrl}
         onProxyChange={setProxy}
+        onRateLimitChange={setRateLimit}
         onTokenChange={setToken}
         onUsernameChange={setUsername}
         onPasswordChange={setPassword}

--- a/config-ui/src/pages/configure/connections/AddConnection.jsx
+++ b/config-ui/src/pages/configure/connections/AddConnection.jsx
@@ -57,6 +57,7 @@ export default function AddConnection () {
     name,
     endpointUrl,
     proxy,
+    rateLimit,
     token,
     initialTokenStore,
     username,
@@ -64,6 +65,7 @@ export default function AddConnection () {
     setName,
     setEndpointUrl,
     setProxy,
+    setRateLimit,
     setUsername,
     setPassword,
     setToken,
@@ -84,6 +86,7 @@ export default function AddConnection () {
     name,
     endpointUrl,
     proxy,
+    rateLimit,
     token,
     username,
     password
@@ -164,6 +167,7 @@ export default function AddConnection () {
                   name={name}
                   endpointUrl={endpointUrl}
                   proxy={proxy}
+                  rateLimit={rateLimit}
                   token={token}
                   initialTokenStore={initialTokenStore}
                   username={username}
@@ -175,6 +179,7 @@ export default function AddConnection () {
                   onNameChange={setName}
                   onEndpointChange={setEndpointUrl}
                   onProxyChange={setProxy}
+                  onRateLimitChange={setRateLimit}
                   onTokenChange={setToken}
                   onUsernameChange={setUsername}
                   onPasswordChange={setPassword}

--- a/config-ui/src/pages/configure/connections/ConfigureConnection.jsx
+++ b/config-ui/src/pages/configure/connections/ConfigureConnection.jsx
@@ -57,6 +57,7 @@ export default function ConfigureConnection () {
     name,
     endpointUrl,
     proxy,
+    rateLimit = 0,
     username,
     password,
     token,
@@ -71,6 +72,7 @@ export default function ConfigureConnection () {
     setName,
     setEndpointUrl,
     setProxy,
+    setRateLimit,
     setUsername,
     setPassword,
     setToken,
@@ -106,6 +108,7 @@ export default function ConfigureConnection () {
     name,
     endpointUrl,
     proxy,
+    rateLimit,
     token,
     username,
     password
@@ -250,6 +253,7 @@ export default function ConfigureConnection () {
                             name={name}
                             endpointUrl={endpointUrl}
                             proxy={proxy}
+                            rateLimit={rateLimit}
                             token={token}
                             initialTokenStore={initialTokenStore}
                             username={username}
@@ -262,6 +266,7 @@ export default function ConfigureConnection () {
                             onNameChange={setName}
                             onEndpointChange={setEndpointUrl}
                             onProxyChange={setProxy}
+                            onRateLimitChange={setRateLimit}
                             onTokenChange={setToken}
                             onUsernameChange={setUsername}
                             onPasswordChange={setPassword}

--- a/config-ui/src/pages/configure/connections/ConnectionForm.jsx
+++ b/config-ui/src/pages/configure/connections/ConnectionForm.jsx
@@ -768,8 +768,7 @@ export default function ConnectionForm (props) {
                 }
                   allowNumericCharactersOnly={true}
                   onValueChange={(rateLimitPerHour) => { onRateLimitChange(rateLimitPerHour) }}
-                // value={rateLimit}
-                  defaultValue={rateLimit}
+                  value={rateLimit}
                   rightElement={
                     <InputValidationError error={getFieldError('RateLimit')} />
                 }

--- a/config-ui/src/pages/configure/connections/ConnectionForm.jsx
+++ b/config-ui/src/pages/configure/connections/ConnectionForm.jsx
@@ -742,41 +742,41 @@ export default function ConnectionForm (props) {
               </FormGroup>
             </div>
             <div className='formContainer'>
-            <FormGroup
-              disabled={isTesting || isSaving || isLocked}
-              inline={true}
-              labelFor='connection-ratelimit'
-              className={formGroupClassName}
-              contentClassName='formGroupContent'
-            >
-              <Label>{labels ? labels.rateLimit : <>Rate&nbsp;Limit</>}</Label>
-              <NumericInput
-                id='connection-ratelimit'
-                ref={connectionRateLimitRef}
+              <FormGroup
                 disabled={isTesting || isSaving || isLocked}
-                min={0}
-                max={1000000000}
-                clampValueOnBlur={true}
-                className={`input input-ratelimit ${
+                inline={true}
+                labelFor='connection-ratelimit'
+                className={formGroupClassName}
+                contentClassName='formGroupContent'
+              >
+                <Label>{labels ? labels.rateLimit : <>Rate&nbsp;Limit</>}</Label>
+                <NumericInput
+                  id='connection-ratelimit'
+                  ref={connectionRateLimitRef}
+                  disabled={isTesting || isSaving || isLocked}
+                  min={0}
+                  max={1000000000}
+                  clampValueOnBlur={true}
+                  className={`input input-ratelimit ${
                   fieldHasError('RateLimit') ? 'invalid-field' : ''
                 }`}
-                fill={false}
-                placeholder={
+                  fill={false}
+                  placeholder={
                   placeholders.rateLimit
                     ? placeholders.rateLimit
                     : '1000'
                 }
-                allowNumericCharactersOnly={true}
-                onValueChange={(rateLimitPerHour) => {(e) => onRateLimitChange(rateLimitPerHour)}}
+                  allowNumericCharactersOnly={true}
+                  onValueChange={(rateLimitPerHour) => { onRateLimitChange(rateLimitPerHour) }}
                 // value={rateLimit}
-                defaultValue={rateLimit}
-                rightElement={
-                  <InputValidationError error={getFieldError('RateLimit')} />
+                  defaultValue={rateLimit}
+                  rightElement={
+                    <InputValidationError error={getFieldError('RateLimit')} />
                 }
-              />
-            </FormGroup>
-          </div>  
-        </>        
+                />
+              </FormGroup>
+            </div>
+          </>
         )}
         {enableActions && (
           <div

--- a/config-ui/src/pages/configure/connections/ConnectionForm.jsx
+++ b/config-ui/src/pages/configure/connections/ConnectionForm.jsx
@@ -707,7 +707,7 @@ export default function ConnectionForm (props) {
             </div>
           </>
         )}
-        {[Providers.GITHUB, Providers.GITLAB, Providers.JIRA, Providers.TAPD].includes(
+        {[Providers.GITHUB, Providers.GITLAB, Providers.JIRA, Providers.JENKINS, Providers.TAPD].includes(
           activeProvider.id
         ) && (
           <>

--- a/config-ui/src/pages/configure/connections/ConnectionForm.jsx
+++ b/config-ui/src/pages/configure/connections/ConnectionForm.jsx
@@ -31,6 +31,7 @@ import {
   // PopoverInteractionKind,
   Intent,
   PopoverInteractionKind,
+  NumericInput
 } from '@blueprintjs/core'
 import { Providers } from '@/data/Providers'
 import FormValidationErrors from '@/components/messages/FormValidationErrors'
@@ -56,6 +57,7 @@ export default function ConnectionForm (props) {
     username,
     password,
     proxy = '',
+    rateLimit = 0,
     isSaving,
     isTesting,
     showError,
@@ -72,6 +74,7 @@ export default function ConnectionForm (props) {
     onUsernameChange = () => {},
     onPasswordChange = () => {},
     onProxyChange = () => {},
+    onRateLimitChange = () => {},
     onValidate = () => {},
     authType = 'token',
     sourceLimits = {},
@@ -89,6 +92,7 @@ export default function ConnectionForm (props) {
   const connectionUsernameRef = useRef()
   const connectionPasswordRef = useRef()
   const connectionProxyRef = useRef()
+  const connectionRateLimitRef = useRef()
 
   // const [isValidForm, setIsValidForm] = useState(true)
   const [allowedAuthTypes, setAllowedAuthTypes] = useState(['token', 'plain'])
@@ -123,8 +127,9 @@ export default function ConnectionForm (props) {
       token,
       username,
       password,
+      rateLimit,
     })
-  }, [name, endpointUrl, token, username, password, onValidate])
+  }, [name, endpointUrl, token, username, password, rateLimit, onValidate])
   const fieldHasError = (fieldId) => {
     return validationErrors.some((e) => e.includes(fieldId))
   }
@@ -705,36 +710,73 @@ export default function ConnectionForm (props) {
         {[Providers.GITHUB, Providers.GITLAB, Providers.JIRA, Providers.TAPD].includes(
           activeProvider.id
         ) && (
-          <div className='formContainer'>
+          <>
+            <div className='formContainer'>
+              <FormGroup
+                disabled={isTesting || isSaving || isLocked}
+                inline={true}
+                labelFor='connection-proxy'
+                className={formGroupClassName}
+                contentClassName='formGroupContent'
+              >
+                <Label>{labels ? labels.proxy : <>Proxy&nbsp;URL</>}</Label>
+                <InputGroup
+                  id='connection-proxy'
+                  inputRef={connectionProxyRef}
+                  tabIndex={3}
+                  placeholder={
+                    placeholders.proxy
+                      ? placeholders.proxy
+                      : 'http://proxy.localhost:8080'
+                  }
+                  defaultValue={proxy}
+                  onChange={(e) => onProxyChange(e.target.value)}
+                  disabled={isTesting || isSaving || isLocked}
+                  className={`input input-proxy ${
+                    fieldHasError('Proxy') ? 'invalid-field' : ''
+                  }`}
+                  rightElement={
+                    <InputValidationError error={getFieldError('Proxy')} />
+                  }
+                />
+              </FormGroup>
+            </div>
+            <div className='formContainer'>
             <FormGroup
               disabled={isTesting || isSaving || isLocked}
               inline={true}
-              labelFor='connection-proxy'
+              labelFor='connection-ratelimit'
               className={formGroupClassName}
               contentClassName='formGroupContent'
             >
-              <Label>{labels ? labels.proxy : <>Proxy&nbsp;URL</>}</Label>
-              <InputGroup
-                id='connection-proxy'
-                inputRef={connectionProxyRef}
-                tabIndex={3}
-                placeholder={
-                  placeholders.proxy
-                    ? placeholders.proxy
-                    : 'http://proxy.localhost:8080'
-                }
-                defaultValue={proxy}
-                onChange={(e) => onProxyChange(e.target.value)}
+              <Label>{labels ? labels.rateLimit : <>Rate&nbsp;Limit</>}</Label>
+              <NumericInput
+                id='connection-ratelimit'
+                ref={connectionRateLimitRef}
                 disabled={isTesting || isSaving || isLocked}
-                className={`input input-proxy ${
-                  fieldHasError('Proxy') ? 'invalid-field' : ''
+                min={0}
+                max={1000000000}
+                clampValueOnBlur={true}
+                className={`input input-ratelimit ${
+                  fieldHasError('RateLimit') ? 'invalid-field' : ''
                 }`}
+                fill={false}
+                placeholder={
+                  placeholders.rateLimit
+                    ? placeholders.rateLimit
+                    : '1000'
+                }
+                allowNumericCharactersOnly={true}
+                onValueChange={(rateLimitPerHour) => {(e) => onRateLimitChange(rateLimitPerHour)}}
+                // value={rateLimit}
+                defaultValue={rateLimit}
                 rightElement={
-                  <InputValidationError error={getFieldError('Proxy')} />
+                  <InputValidationError error={getFieldError('RateLimit')} />
                 }
               />
             </FormGroup>
-          </div>
+          </div>  
+        </>        
         )}
         {enableActions && (
           <div


### PR DESCRIPTION
### :package: Config-UI / Data Integrations / Connections - **Rate Limit** 

- [x] Add **Rate Limit** Connection Form Field
- [x] Update Connection Manager Hook (Define `rateLimit`)
- [x] Update Component Properties
- [x] Test Rate Limit Setting

### Description

This PR adds the **Rate Limit** (per hour) numeric setting for the **Connections** definition for All Data Providers (Plugins). The default value is `0`. NOTE: It's property is `NOT` included when _Testing_ a connection.

### Does this close any open issues?
#931

### Screenshots
<img width="1163" alt="Screen Shot 2022-08-19 at 7 19 03 PM" src="https://user-images.githubusercontent.com/1742233/185718577-4eda9747-a17d-40c0-a4c7-403ab3eb05ac.png">

<img width="1162" alt="Screen Shot 2022-08-19 at 7 25 21 PM" src="https://user-images.githubusercontent.com/1742233/185718913-d26eea55-cb98-4a8e-afe0-ca30394f0c8b.png">

