### PR TITLE
fix: fetch proxy only if jira is an enabled provider

### DIFF
--- a/config-ui/src/pages/blueprints/create-blueprint.jsx
+++ b/config-ui/src/pages/blueprints/create-blueprint.jsx
@@ -580,7 +580,10 @@ const CreateBlueprint = (props) => {
       const getAllSources = true
       fetchAllConnections(enableNotifications, getAllSources)
     }
-    if (mode === BlueprintMode.NORMAL && ([2, 3].includes(activeStep?.id))) {
+    if (mode === BlueprintMode.NORMAL
+        && ([2, 3].includes(activeStep?.id))
+        && enabledProviders.includes(Providers.JIRA)
+      ) {
       fetchBoards()
       fetchIssueTypes()
       fetchFields()


### PR DESCRIPTION
### 🔁  Config-UI / Blueprints / Create Blueprint

- [x] Fetch JIRA Proxy Resources only if JIRA is an Enabled (selected) Provider
- [x] Test Create Workflow

This PR adds a needed restriction to the **Create Blueprint Workflow** so that **JIRA Proxy** API resources are **only** fetched if JIRA is an _enabled_ Provider (ie. the user selects a JIRA connection for the current blueprint). In a scenario where JIRA is not detected, such as a blueprint with GitHub only -- API request calls for JIRA resources will not be made.

### Does this close any open issues?
#2789

