### PR TITLE
fix: do not pre-select active entity in create-mode

### DIFF
--- a/config-ui/src/components/blueprints/create-workflow/DataTransformations.jsx
+++ b/config-ui/src/components/blueprints/create-workflow/DataTransformations.jsx
@@ -26,6 +26,9 @@ import {
   Elevation,
   Card,
   Colors,
+  Spinner,
+  Tooltip,
+  Position
 } from '@blueprintjs/core'
 import { Select } from '@blueprintjs/select'
 import { integrationsData } from '@/data/integrations'
@@ -380,6 +383,14 @@ const DataTransformations = (props) => {
                             onClick={() => onSave()}
                             // disabled={[Providers.GITLAB].includes(configuredConnection?.provider)}
                             style={{ marginLeft: '5px' }}
+                            icon={(
+                              <Tooltip
+                                position={Position.TOP}
+                                intent={Intent.PRIMARY}
+                                content={'Close Editor to Continue'}>
+                                  <Spinner size={12} />
+                              </Tooltip>
+                            )}
                           />
                         )}
                       </div>

--- a/config-ui/src/components/blueprints/create-workflow/DataTransformations.jsx
+++ b/config-ui/src/components/blueprints/create-workflow/DataTransformations.jsx
@@ -116,18 +116,18 @@ const DataTransformations = (props) => {
   }, [entityList])
 
   useEffect(() => {
-    console.log('>>>>> PROJECT / BOARD ENTITY SELECTED!', activeEntity)
-    switch (activeEntity?.type) {
-      case 'board':
-        addBoardTransformation(activeEntity?.entity)
-        // addProjectTransformation(null)
-        break
-      case 'project':
-        addProjectTransformation(activeEntity?.entity)
-        // addBoardTransformation(null)
-        break
+    if (useDropdownSelector) {
+      console.log('>>>>> PROJECT / BOARD ENTITY SELECTED!', activeEntity)
+      switch (activeEntity?.type) {
+        case 'board':
+          addBoardTransformation(activeEntity?.entity)
+          break
+        case 'project':
+          addProjectTransformation(activeEntity?.entity)
+          break
+      }
     }
-  }, [activeEntity, addBoardTransformation, addProjectTransformation])
+  }, [activeEntity, addBoardTransformation, addProjectTransformation, useDropdownSelector])
 
   return (
     <div className='workflow-step workflow-step-add-transformation' data-step={activeStep?.id}>


### PR DESCRIPTION
### Config-UI / Blueprints / Create Blueprint / Edit Transformation

- [x] `Fix` Do Not Pre-Select the Active Entity (Project/Board) for **Blueprint Create Mode**
- [x] `Feature` Add **Tooltip** & Spinner Indicator to **Go Back** Button

### Description
This PR applies an adjustment to the Create Blueprint Workflow so that the first Active Project or Board is not automatically selected for editing. This is needed so that users can see the list of projects/boards to "edit" first. A Tooltip Indicator has also been added to the "Go Back" action so users are aware that they must complete editing before proceeding _Next_.

### Does this close any open issues?
#2784

### Screenshots
<img width="1215" alt="Screen Shot 2022-08-22 at 8 10 05 PM" src="https://user-images.githubusercontent.com/1742233/186041021-88b803e5-d32e-4eea-a57c-ff94bfbbfbd7.png">

