### PR TITLE
fix: add missing pipeline var with logfile download

### DIFF
--- a/config-ui/src/pages/blueprints/blueprint-detail.jsx
+++ b/config-ui/src/pages/blueprints/blueprint-detail.jsx
@@ -221,24 +221,24 @@ const BlueprintDetail = (props) => {
     setIsDownloading(true)
     ToastNotification.clear()
     let downloadStatus = 404
-    const checkDownloadStatus = async (pipeline) => {
+    const checkStatusAndDownload = async (pipeline) => {
       const d = await request.get(getPipelineLogfile(pipeline?.id))
       downloadStatus = d?.status
+      if (pipeline?.id && downloadStatus === 200) {
+        saveAs(
+          getPipelineLogfile(pipeline?.id),
+          pipelineLogFilename
+        )
+        setIsDownloading(false)
+      } else if (pipeline?.id && downloadStatus === 404) {
+        ToastNotification.show({ message: d?.message || 'Logfile not available', intent: 'danger', icon: 'error' })
+        setIsDownloading(false)
+      } else {
+        ToastNotification.show({ message: 'Pipeline Invalid or Missing', intent: 'danger', icon: 'error' })
+        setIsDownloading(false)
+      }
     }
-    checkDownloadStatus()
-    if (pipeline?.id && downloadStatus === 200) {
-      saveAs(
-        getPipelineLogfile(pipeline?.id),
-        pipelineLogFilename
-      )
-      setIsDownloading(false)
-    } else if (pipeline?.id && downloadStatus === 404) {
-      ToastNotification.show({ message: 'Logfile not available', intent: 'danger', icon: 'error' })
-      setIsDownloading(false)
-    } else {
-      ToastNotification.show({ message: 'Pipeline Invalid or Missing', intent: 'danger', icon: 'error' })
-      setIsDownloading(false)
-    }
+    checkStatusAndDownload(pipeline)
   }, [getPipelineLogfile, pipelineLogFilename])
 
   useEffect(() => {


### PR DESCRIPTION
### :b: Config-UI / Blueprints / Activity Status / **Logfile Download**

- [x] `Fix` Resolve missing `pipeline` object var when async `download` handler is called
- [x] `Fix` Relay `404` `message` from API when pipeline not found 
- [x] Test Logfile Download

### Description

This PR resolves an issue with the Pipeline Logfile Download process where Pipeline ID defaulted to `0` due to missing pipeline object as argument. It also relays the API message if present in a `404` scenario.

### Does this close any open issues?
#2765 

