### PR TITLE
fix(gitlab): add approval to pr_comments

### DIFF
--- a/plugins/gitlab/tasks/mr_note_extractor.go
+++ b/plugins/gitlab/tasks/mr_note_extractor.go
@@ -67,7 +67,7 @@ func ExtractApiMergeRequestsNotes(taskCtx core.SubTaskContext) error {
 				return nil, err
 			}
 			results := make([]interface{}, 0, 2)
-			if !toolMrNote.IsSystem {
+			if !toolMrNote.IsSystem || toolMrNote.Body == "approved this merge request" {
 				toolMrComment := &models.GitlabMrComment{
 					GitlabId:        toolMrNote.GitlabId,
 					MergeRequestId:  toolMrNote.MergeRequestId,
@@ -79,6 +79,9 @@ func ExtractApiMergeRequestsNotes(taskCtx core.SubTaskContext) error {
 					Resolvable:      toolMrNote.Resolvable,
 					Type:            toolMrNote.Type,
 					ConnectionId:    data.Options.ConnectionId,
+				}
+				if toolMrNote.Body == "approved this merge request" {
+					toolMrComment.Type = "REVIEW"
 				}
 				results = append(results, toolMrComment)
 			}


### PR DESCRIPTION
# Summary

extract `approval` from notes to comments
also set this kind of comments' type to `REVIEW`

### Does this close any open issues?
closes #2814

### Screenshots
<img width="493" alt="image" src="https://user-images.githubusercontent.com/39366025/186326043-2a95b40d-8375-4b71-9dcb-5b333ad0ce54.png">

### Other Information
Any other information that is important to this PR.
