### PR TITLE
feat(gitlab): convert comments to adapt cycle time calculation

### DIFF
--- a/models/domainlayer/code/pull_request_comment.go
+++ b/models/domainlayer/code/pull_request_comment.go
@@ -38,3 +38,9 @@ type PullRequestComment struct {
 func (PullRequestComment) TableName() string {
 	return "pull_request_comments"
 }
+
+const (
+	NORMAL_COMMENT = "NORMAL"
+	DIFF_COMMENT   = "DIFF"
+	REVIEW         = "REVIEW"
+)

--- a/plugins/github/tasks/pr_comment_convertor.go
+++ b/plugins/github/tasks/pr_comment_convertor.go
@@ -80,9 +80,9 @@ func ConvertPullRequestComments(taskCtx core.SubTaskContext) error {
 				UserId:        accountIdGen.Generate(data.Options.ConnectionId, githubPullRequestComment.AuthorUserId),
 				CreatedDate:   githubPullRequestComment.GithubCreatedAt,
 				CommitSha:     githubPullRequestComment.CommitSha,
-				Type:          githubPullRequestComment.Type,
 				ReviewId:      prReviewIdGen.Generate(data.Options.ConnectionId, githubPullRequestComment.ReviewId),
 			}
+			domainPrComment.Type = getStdCommentType(githubPullRequestComment.Type)
 			return []interface{}{
 				domainPrComment,
 			}, nil
@@ -93,4 +93,17 @@ func ConvertPullRequestComments(taskCtx core.SubTaskContext) error {
 	}
 
 	return converter.Execute()
+}
+
+func getStdCommentType(originType string) string {
+	if originType == "DIFF" {
+		return code.DIFF_COMMENT
+	}
+	if originType == "REVIEW" {
+		return code.REVIEW
+	}
+	if originType == "NORMAL" {
+		return code.NORMAL_COMMENT
+	}
+	return ""
 }

--- a/plugins/gitlab/tasks/mr_comment_convertor.go
+++ b/plugins/gitlab/tasks/mr_comment_convertor.go
@@ -77,8 +77,9 @@ func ConvertMergeRequestComment(taskCtx core.SubTaskContext) error {
 				Body:          gitlabComments.Body,
 				UserId:        accountIdGen.Generate(data.Options.ConnectionId, gitlabComments.AuthorUserId),
 				CreatedDate:   gitlabComments.GitlabCreatedAt,
-				Type:          gitlabComments.Type,
 			}
+
+			domainComment.Type = getStdCommentType(gitlabComments.Type)
 			return []interface{}{
 				domainComment,
 			}, nil
@@ -89,4 +90,14 @@ func ConvertMergeRequestComment(taskCtx core.SubTaskContext) error {
 	}
 
 	return converter.Execute()
+}
+
+func getStdCommentType(originType string) string {
+	if originType == "DiffNote" {
+		return code.DIFF_COMMENT
+	}
+	if originType == "REVIEW" {
+		return code.REVIEW
+	}
+	return code.NORMAL_COMMENT
 }

--- a/plugins/gitlab/tasks/mr_note_extractor.go
+++ b/plugins/gitlab/tasks/mr_note_extractor.go
@@ -67,7 +67,7 @@ func ExtractApiMergeRequestsNotes(taskCtx core.SubTaskContext) error {
 				return nil, err
 			}
 			results := make([]interface{}, 0, 2)
-			if !toolMrNote.IsSystem || toolMrNote.Body == "approved this merge request" {
+			if !toolMrNote.IsSystem || (toolMrNote.IsSystem && toolMrNote.Body == "approved this merge request") {
 				toolMrComment := &models.GitlabMrComment{
 					GitlabId:        toolMrNote.GitlabId,
 					MergeRequestId:  toolMrNote.MergeRequestId,


### PR DESCRIPTION
# Summary

classify gitlab mr comments to three types: DIFF, NORMAL, REVIEW to adapt cycle time calculation
also define these three types in `pull_request_comment.go`

### Does this close any open issues?
closes #2818

### Screenshots
<img width="90" alt="image" src="https://user-images.githubusercontent.com/39366025/186385414-703f93bc-69c3-4ba0-b482-5d92e61dcf09.png">

### Other Information
Any other information that is important to this PR.
