### PR TITLE
fix: mask credentials

### DIFF
--- a/api/task/task.go
+++ b/api/task/task.go
@@ -18,6 +18,7 @@ limitations under the License.
 package task
 
 import (
+	"github.com/apache/incubator-devlake/plugins/core"
 	"net/http"
 	"strconv"
 
@@ -68,6 +69,14 @@ func Index(c *gin.Context) {
 	if err != nil {
 		shared.ApiOutputError(c, err, http.StatusBadRequest)
 		return
+	}
+	for i, task := range tasks {
+		plugin, err := core.GetPlugin(task.Plugin)
+		if err == nil {
+			if masker, ok := plugin.(core.CredentialMasker); ok {
+				tasks[i].Options = masker.Mask(task.Options)
+			}
+		}
 	}
 	shared.ApiOutputSuccess(c, gin.H{"tasks": tasks, "count": count}, http.StatusOK)
 }

--- a/plugins/core/hub.go
+++ b/plugins/core/hub.go
@@ -21,16 +21,20 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 )
 
 // Allowing plugin to know each other
 
 var plugins map[string]PluginMeta
+var mutex sync.Mutex
 
 func RegisterPlugin(name string, plugin PluginMeta) error {
 	if plugins == nil {
 		plugins = make(map[string]PluginMeta)
 	}
+	mutex.Lock()
+	defer mutex.Unlock()
 	plugins[name] = plugin
 	return nil
 }
@@ -39,6 +43,8 @@ func GetPlugin(name string) (PluginMeta, error) {
 	if plugins == nil {
 		return nil, errors.New("RegisterPlugin have never been called.")
 	}
+	mutex.Lock()
+	defer mutex.Unlock()
 	if plugin, ok := plugins[name]; ok {
 		return plugin, nil
 	}

--- a/plugins/core/plugin_task.go
+++ b/plugins/core/plugin_task.go
@@ -118,3 +118,7 @@ type CloseablePluginTask interface {
 	PluginTask
 	Close(taskCtx TaskContext) error
 }
+
+type CredentialMasker interface {
+	Mask(input []byte) []byte
+}


### PR DESCRIPTION
# Summary
fix #2800 ([Question][GitHub]security)
replace the sensitive data with asterisks in the response of the API `/pipelines/{id}/tasks`

### Does this close any open issues?
close #2800 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
