### PR TITLE
feat: setup database migration alert dialog on ui

### DIFF
--- a/config-ui/src/App.js
+++ b/config-ui/src/App.js
@@ -21,9 +21,6 @@ import {
   BrowserRouter as Router,
   Route
 } from 'react-router-dom'
-import {
-  Intent
-} from '@blueprintjs/core'
 
 import 'normalize.css'
 import '@/styles/app.scss'
@@ -35,13 +32,9 @@ import '@fontsource/inter/variable-full.css'
 // Theme variables (@styles/theme.scss) injected via Webpack w/ @sass-loader additionalData option!
 // import '@/styles/theme.scss'
 
-import { MigrationOptions } from '@/config/migration'
-import request from '@/utils/request'
-
 import useDatabaseMigrations from '@/hooks/useDatabaseMigrations'
 
 import ErrorBoundary from '@/components/ErrorBoundary'
-import { ToastNotification } from '@/components/Toast'
 // import Configure from './pages/configure/index'
 import Integration from '@/pages/configure/integration/index'
 import ManageIntegration from '@/pages/configure/integration/manage'
@@ -61,13 +54,6 @@ import Connections from '@/pages/connections/index'
 import MigrationAlertDialog from '@/components/MigrationAlertDialog'
 
 function App (props) {
-  // const [isProcessing, setIsProcessing] = useState(false)
-
-  // const [migrationWarning, setMigrationWarning] = useState(localStorage.getItem(MigrationOptions.warningId))
-  // const [migrationAlertOpened, setMigrationAlertOpened] = useState(false)
-  // const [wasMigrationSuccessful, setWasMigrationSuccessful] = useState(false)
-  // const [hasMigrationFailed, setHasMigrationFailed] = useState(false)
-
   const {
     isProcessing,
     migrationWarning,
@@ -82,63 +68,6 @@ function App (props) {
     handleCancelMigration,
     handleMigrationDialogClose
   } = useDatabaseMigrations()
-
-  // const handleConfirmMigration = useCallback(() => {
-  //   setIsProcessing(true)
-  //   const m = request.get(MigrationOptions.apiProceedEndpoint)
-  //   setWasMigrationSuccessful(m?.status === 200 && m?.success === true)
-  //   setTimeout(() => {
-  //     setIsProcessing(false)
-  //     setHasMigrationFailed(m?.status !== 200)
-  //   }, 3000)
-  // }, [])
-
-  // const handleCancelMigration = useCallback(() => {
-  //   setIsProcessing(true)
-  //   localStorage.removeItem(MigrationOptions.warningId)
-  //   setMigrationAlertOpened(false)
-  //   setIsProcessing(false)
-  //   ToastNotification.clear()
-  //   ToastNotification.show({
-  //     // eslint-disable-next-line max-len
-  //     message: MigrationOptions.cancelToastMessage,
-  //     intent: Intent.NONE,
-  //     icon: 'warning-sign'
-  //   })
-  // }, [])
-
-  // const handleMigrationDialogClose = useCallback(() => {
-  //   setMigrationAlertOpened(false)
-  // }, [setMigrationAlertOpened])
-
-  // useEffect(() => {
-  //   setMigrationAlertOpened(migrationWarning !== null)
-  // }, [migrationWarning, setMigrationAlertOpened])
-
-  // useEffect(() => {
-  //   if (wasMigrationSuccessful) {
-  //     localStorage.removeItem(MigrationOptions.warningId)
-  //   }
-  // }, [wasMigrationSuccessful])
-
-  // useEffect(() => {
-  //   if (hasMigrationFailed) {
-  //     ToastNotification.clear()
-  //     ToastNotification.show({
-  //       // eslint-disable-next-line max-len
-  //       message: MigrationOptions.failedToastMessage,
-  //       intent: Intent.DANGER,
-  //       icon: 'error'
-  //     })
-  //   }
-  // }, [hasMigrationFailed])
-
-  // useEffect(() => {
-  //   if (migrationWarning) {
-  //     // eslint-disable-next-line max-len
-  //     console.log(`>>> MIGRATION WARNING DETECTED !! Local Storage Key = [${MigrationOptions.warningId}]:`, migrationWarning)
-  //   }
-  // }, [migrationWarning])
 
   return (
     <Router>

--- a/config-ui/src/App.js
+++ b/config-ui/src/App.js
@@ -38,6 +38,8 @@ import '@fontsource/inter/variable-full.css'
 import { MigrationOptions } from '@/config/migration'
 import request from '@/utils/request'
 
+import useDatabaseMigrations from '@/hooks/useDatabaseMigrations'
+
 import ErrorBoundary from '@/components/ErrorBoundary'
 import { ToastNotification } from '@/components/Toast'
 // import Configure from './pages/configure/index'
@@ -59,69 +61,84 @@ import Connections from '@/pages/connections/index'
 import MigrationAlertDialog from '@/components/MigrationAlertDialog'
 
 function App (props) {
-  const [isProcessing, setIsProcessing] = useState(false)
+  // const [isProcessing, setIsProcessing] = useState(false)
 
-  const [migrationWarning, setMigrationWarning] = useState(localStorage.getItem(MigrationOptions.warningId))
-  const [migrationAlertOpened, setMigrationAlertOpened] = useState(false)
-  const [wasMigrationSuccessful, setWasMigrationSuccessful] = useState(false)
-  const [hasMigrationFailed, setHasMigrationFailed] = useState(false)
+  // const [migrationWarning, setMigrationWarning] = useState(localStorage.getItem(MigrationOptions.warningId))
+  // const [migrationAlertOpened, setMigrationAlertOpened] = useState(false)
+  // const [wasMigrationSuccessful, setWasMigrationSuccessful] = useState(false)
+  // const [hasMigrationFailed, setHasMigrationFailed] = useState(false)
 
-  const handleConfirmMigration = useCallback(() => {
-    setIsProcessing(true)
-    const m = request.get(MigrationOptions.apiProceedEndpoint)
-    setWasMigrationSuccessful(m?.status === 200 && m?.success === true)
-    setTimeout(() => {
-      setIsProcessing(false)
-      setHasMigrationFailed(m?.status !== 200)
-    }, 3000)
-  }, [])
+  const {
+    isProcessing,
+    migrationWarning,
+    migrationAlertOpened,
+    wasMigrationSuccessful,
+    hasMigrationFailed,
+    setMigrationWarning,
+    setMigrationAlertOpened,
+    setWasMigrationSuccessful,
+    setHasMigrationFailed,
+    handleConfirmMigration,
+    handleCancelMigration,
+    handleMigrationDialogClose
+  } = useDatabaseMigrations()
 
-  const handleCancelMigration = useCallback(() => {
-    setIsProcessing(true)
-    localStorage.removeItem(MigrationOptions.warningId)
-    setMigrationAlertOpened(false)
-    setIsProcessing(false)
-    ToastNotification.clear()
-    ToastNotification.show({
-      // eslint-disable-next-line max-len
-      message: MigrationOptions.cancelToastMessage,
-      intent: Intent.NONE,
-      icon: 'warning-sign'
-    })
-  }, [])
+  // const handleConfirmMigration = useCallback(() => {
+  //   setIsProcessing(true)
+  //   const m = request.get(MigrationOptions.apiProceedEndpoint)
+  //   setWasMigrationSuccessful(m?.status === 200 && m?.success === true)
+  //   setTimeout(() => {
+  //     setIsProcessing(false)
+  //     setHasMigrationFailed(m?.status !== 200)
+  //   }, 3000)
+  // }, [])
 
-  const handleMigrationDialogClose = useCallback(() => {
-    setMigrationAlertOpened(false)
-  }, [setMigrationAlertOpened])
+  // const handleCancelMigration = useCallback(() => {
+  //   setIsProcessing(true)
+  //   localStorage.removeItem(MigrationOptions.warningId)
+  //   setMigrationAlertOpened(false)
+  //   setIsProcessing(false)
+  //   ToastNotification.clear()
+  //   ToastNotification.show({
+  //     // eslint-disable-next-line max-len
+  //     message: MigrationOptions.cancelToastMessage,
+  //     intent: Intent.NONE,
+  //     icon: 'warning-sign'
+  //   })
+  // }, [])
 
-  useEffect(() => {
-    setMigrationAlertOpened(migrationWarning !== null)
-  }, [migrationWarning, setMigrationAlertOpened])
+  // const handleMigrationDialogClose = useCallback(() => {
+  //   setMigrationAlertOpened(false)
+  // }, [setMigrationAlertOpened])
 
-  useEffect(() => {
-    if (wasMigrationSuccessful) {
-      localStorage.removeItem(MigrationOptions.warningId)
-    }
-  }, [wasMigrationSuccessful])
+  // useEffect(() => {
+  //   setMigrationAlertOpened(migrationWarning !== null)
+  // }, [migrationWarning, setMigrationAlertOpened])
 
-  useEffect(() => {
-    if (hasMigrationFailed) {
-      ToastNotification.clear()
-      ToastNotification.show({
-        // eslint-disable-next-line max-len
-        message: MigrationOptions.failedToastMessage,
-        intent: Intent.DANGER,
-        icon: 'error'
-      })
-    }
-  }, [hasMigrationFailed])
+  // useEffect(() => {
+  //   if (wasMigrationSuccessful) {
+  //     localStorage.removeItem(MigrationOptions.warningId)
+  //   }
+  // }, [wasMigrationSuccessful])
 
-  useEffect(() => {
-    if (migrationWarning) {
-      // eslint-disable-next-line max-len
-      console.log(`>>> MIGRATION WARNING DETECTED !! Local Storage Key = [${MigrationOptions.warningId}]:`, migrationWarning)
-    }
-  }, [migrationWarning])
+  // useEffect(() => {
+  //   if (hasMigrationFailed) {
+  //     ToastNotification.clear()
+  //     ToastNotification.show({
+  //       // eslint-disable-next-line max-len
+  //       message: MigrationOptions.failedToastMessage,
+  //       intent: Intent.DANGER,
+  //       icon: 'error'
+  //     })
+  //   }
+  // }, [hasMigrationFailed])
+
+  // useEffect(() => {
+  //   if (migrationWarning) {
+  //     // eslint-disable-next-line max-len
+  //     console.log(`>>> MIGRATION WARNING DETECTED !! Local Storage Key = [${MigrationOptions.warningId}]:`, migrationWarning)
+  //   }
+  // }, [migrationWarning])
 
   return (
     <Router>

--- a/config-ui/src/App.js
+++ b/config-ui/src/App.js
@@ -35,22 +35,22 @@ import '@fontsource/inter/variable-full.css'
 // Theme variables (@styles/theme.scss) injected via Webpack w/ @sass-loader additionalData option!
 // import '@/styles/theme.scss'
 
-import { DEVLAKE_ENDPOINT } from '@/utils/config'
+import { MigrationOptions } from '@/config/migration'
 import request from '@/utils/request'
 
 import ErrorBoundary from '@/components/ErrorBoundary'
 import { ToastNotification } from '@/components/Toast'
-import Configure from './pages/configure/index'
+// import Configure from './pages/configure/index'
 import Integration from '@/pages/configure/integration/index'
 import ManageIntegration from '@/pages/configure/integration/manage'
 import AddConnection from '@/pages/configure/connections/AddConnection'
-import EditConnection from '@/pages/configure/connections/EditConnection'
+// import EditConnection from '@/pages/configure/connections/EditConnection'
 import ConfigureConnection from '@/pages/configure/connections/ConfigureConnection'
-import Triggers from '@/pages/triggers/index'
+// import Triggers from '@/pages/triggers/index'
 import Offline from '@/pages/offline/index'
-import Pipelines from '@/pages/pipelines/index'
-import CreatePipeline from '@/pages/pipelines/create'
-import PipelineActivity from '@/pages/pipelines/activity'
+// import Pipelines from '@/pages/pipelines/index'
+// import CreatePipeline from '@/pages/pipelines/create'
+// import PipelineActivity from '@/pages/pipelines/activity'
 import Blueprints from '@/pages/blueprints/index'
 import CreateBlueprint from '@/pages/blueprints/create-blueprint'
 import BlueprintDetail from '@/pages/blueprints/blueprint-detail'
@@ -58,21 +58,17 @@ import BlueprintSettings from '@/pages/blueprints/blueprint-settings'
 import Connections from '@/pages/connections/index'
 import MigrationAlertDialog from '@/components/MigrationAlertDialog'
 
-// @todo: lift to configuration level or data const
-const DEVLAKE__MIGRATION_WARNING = 'DEVLAKE__MIGRATION_WARNING'
-
 function App (props) {
   const [isProcessing, setIsProcessing] = useState(false)
 
-  const [migrationWarning, setMigrationWarning] = useState(localStorage.getItem(DEVLAKE__MIGRATION_WARNING))
+  const [migrationWarning, setMigrationWarning] = useState(localStorage.getItem(MigrationOptions.warningId))
   const [migrationAlertOpened, setMigrationAlertOpened] = useState(false)
   const [wasMigrationSuccessful, setWasMigrationSuccessful] = useState(false)
   const [hasMigrationFailed, setHasMigrationFailed] = useState(false)
 
   const handleConfirmMigration = useCallback(() => {
-    // @todo: lift db migration endpoint to configuration level
     setIsProcessing(true)
-    const m = request.get(`${DEVLAKE_ENDPOINT}/proceed-db-migration`)
+    const m = request.get(MigrationOptions.apiProceedEndpoint)
     setWasMigrationSuccessful(m?.status === 200 && m?.success === true)
     setTimeout(() => {
       setIsProcessing(false)
@@ -82,13 +78,13 @@ function App (props) {
 
   const handleCancelMigration = useCallback(() => {
     setIsProcessing(true)
-    localStorage.removeItem(DEVLAKE__MIGRATION_WARNING)
+    localStorage.removeItem(MigrationOptions.warningId)
     setMigrationAlertOpened(false)
     setIsProcessing(false)
     ToastNotification.clear()
     ToastNotification.show({
       // eslint-disable-next-line max-len
-      message: 'Migration Halted - Please downgrade manually, you will continue to receive a warning unless you proceed migration or rollback.',
+      message: MigrationOptions.cancelToastMessage,
       intent: Intent.NONE,
       icon: 'warning-sign'
     })
@@ -104,17 +100,16 @@ function App (props) {
 
   useEffect(() => {
     if (wasMigrationSuccessful) {
-      localStorage.removeItem(DEVLAKE__MIGRATION_WARNING)
+      localStorage.removeItem(MigrationOptions.warningId)
     }
   }, [wasMigrationSuccessful])
 
   useEffect(() => {
     if (hasMigrationFailed) {
-      const migrationFailureMessage = 'Database Migration Failed! (Check Network Console)'
       ToastNotification.clear()
       ToastNotification.show({
         // eslint-disable-next-line max-len
-        message: migrationFailureMessage,
+        message: MigrationOptions.failedToastMessage,
         intent: Intent.DANGER,
         icon: 'error'
       })
@@ -124,7 +119,7 @@ function App (props) {
   useEffect(() => {
     if (migrationWarning) {
       // eslint-disable-next-line max-len
-      console.log(`>>> MIGRATION WARNING DETECTED !! Local Storage Key = [${DEVLAKE__MIGRATION_WARNING}]:`, migrationWarning)
+      console.log(`>>> MIGRATION WARNING DETECTED !! Local Storage Key = [${MigrationOptions.warningId}]:`, migrationWarning)
     }
   }, [migrationWarning])
 

--- a/config-ui/src/App.js
+++ b/config-ui/src/App.js
@@ -16,7 +16,7 @@
  *
  */
 
-import React from 'react'
+import React, { useEffect, useState, useCallback } from 'react'
 import {
   BrowserRouter as Router,
   Route
@@ -49,8 +49,24 @@ import CreateBlueprint from '@/pages/blueprints/create-blueprint'
 import BlueprintDetail from '@/pages/blueprints/blueprint-detail'
 import BlueprintSettings from '@/pages/blueprints/blueprint-settings'
 import Connections from '@/pages/connections/index'
+import MigrationAlertDialog from '@/components/MigrationAlertDialog'
 
-function App () {
+function App (props) {
+  const migrationWarning = localStorage.getItem('DEVLAKE__MIGRATION_WARNING')
+  const [migrationAlertOpened, setMigrationAlertOpened] = useState(false)
+
+  const handleDatabaseMigration = useCallback(() => {
+
+  }, [])
+
+  const handleMigrationDialogClose = useCallback(() => {
+    setMigrationAlertOpened(false)
+  }, [setMigrationAlertOpened])
+
+  useEffect(() => {
+    setMigrationAlertOpened(migrationWarning !== null)
+  }, [migrationWarning, setMigrationAlertOpened])
+
   return (
     <Router>
       <Route exact path='/'>
@@ -104,6 +120,11 @@ function App () {
       <Route exact path='/offline'>
         <Offline />
       </Route>
+      <MigrationAlertDialog
+        isOpen={migrationAlertOpened}
+        onClose={handleMigrationDialogClose}
+        onConfirm={handleDatabaseMigration}
+      />
     </Router>
 
   )

--- a/config-ui/src/components/MigrationAlertDialog.jsx
+++ b/config-ui/src/components/MigrationAlertDialog.jsx
@@ -49,7 +49,7 @@ const MigrationAlertDialog = (props) => {
     },
     confirmButtonOpts = {
       text: MigrationOptions.AlertDialog.confirmBtnText,
-      intent: Intent.PRIMARY,
+      intent: hasFailed ? Intent.WARNING : Intent.PRIMARY,
       icon: hasFailed ? 'error' : null
     },
     continueButtonOpts = {

--- a/config-ui/src/components/MigrationAlertDialog.jsx
+++ b/config-ui/src/components/MigrationAlertDialog.jsx
@@ -48,9 +48,9 @@ const MigrationAlertDialog = (props) => {
       outlined: true
     },
     confirmButtonOpts = {
-      text: MigrationOptions.AlertDialog.confirmBtnText,
-      intent: hasFailed ? Intent.WARNING : Intent.PRIMARY,
-      icon: hasFailed ? 'error' : null
+      text: props.hasFailed ? MigrationOptions.AlertDialog.confirmRetryBtnText : MigrationOptions.AlertDialog.confirmBtnText,
+      intent: props.hasFailed ? Intent.WARNING : Intent.PRIMARY,
+      icon: props.hasFailed ? 'error' : null
     },
     continueButtonOpts = {
       icon: 'small-tick',

--- a/config-ui/src/components/MigrationAlertDialog.jsx
+++ b/config-ui/src/components/MigrationAlertDialog.jsx
@@ -73,17 +73,17 @@ const MigrationAlertDialog = (props) => {
         isCloseButtonShown={isCloseButtonShown}
       >
         <div className={Classes.DIALOG_BODY}>
-        {!isMigrating && hasFailed && (
+          {!isMigrating && hasFailed && (
           <>
-              <p style={{ margin: 0, padding: 0, color: Colors.RED4 }}>
-                <strong>Database Migration Failed!</strong>
-              </p>
-              <p style={{ margin: 0, padding: 0 }}>
-                There was a problem running migrations, please check server logs for details.{' '}
-                You may also try again, if the problem persists please file an issue on <strong>GitHub</strong>.
-              </p>
+            <p style={{ margin: 0, padding: 0, color: Colors.RED4 }}>
+              <strong>Database Migration Failed!</strong>
+            </p>
+            <p style={{ margin: 0, padding: 0 }}>
+              There was a problem running migrations, please check server logs for details.{' '}
+              You may also try again, if the problem persists please file an issue on <strong>GitHub</strong>.
+            </p>
           </>
-        )}
+          )}
           {!isMigrating && wasSuccessful ? (
             <>
               <p style={{ margin: 0, padding: 0, color: Colors.GREEN4 }}>
@@ -112,26 +112,28 @@ const MigrationAlertDialog = (props) => {
                   />
                 </>
               ) : (
-                !hasFailed && <>
-                  <p style={{ margin: 0, padding: 0, color: Colors.RED4 }}>
-                    WARNING: Performing migration may wipe collected data for
-                    consistency and re-collecting data may be required.
-                  </p>
-                  <p style={{ margin: 0, padding: 0 }}>
-                    A Database migration is required to launch{' '}
-                    <strong>DevLake</strong>, to proceed, please send a request
-                    to{' '}
-                    <code style={{ backgroundColor: '#eeeeee' }}>
-                      &lt;config-ui-endpoint&gt;/api/proceed-db-migration
-                    </code>{' '}
-                    ( or{' '}
-                    <code style={{ backgroundColor: '#eeeeee' }}>
-                      &lt;devlake-endpoint&gt;/proceed-db-migration
-                    </code>
-                    ) Alternatively, you may downgrade back to the previous
-                    DevLake version.
-                  </p>
-                </>
+                !hasFailed && (
+                  <>
+                    <p style={{ margin: 0, padding: 0, color: Colors.RED4 }}>
+                      WARNING: Performing migration may wipe collected data for
+                      consistency and re-collecting data may be required.
+                    </p>
+                    <p style={{ margin: 0, padding: 0 }}>
+                      A Database migration is required to launch{' '}
+                      <strong>DevLake</strong>, to proceed, please send a request
+                      to{' '}
+                      <code style={{ backgroundColor: '#eeeeee' }}>
+                        &lt;config-ui-endpoint&gt;/api/proceed-db-migration
+                      </code>{' '}
+                      ( or{' '}
+                      <code style={{ backgroundColor: '#eeeeee' }}>
+                        &lt;devlake-endpoint&gt;/proceed-db-migration
+                      </code>
+                      ) Alternatively, you may downgrade back to the previous
+                      DevLake version.
+                    </p>
+                  </>
+                )
               )}
             </>
           )}

--- a/config-ui/src/components/MigrationAlertDialog.jsx
+++ b/config-ui/src/components/MigrationAlertDialog.jsx
@@ -22,7 +22,9 @@ import {
   Colors,
   Dialog,
   Intent,
+  Elevation,
 } from '@blueprintjs/core'
+import ContentLoader from '@/components/loaders/ContentLoader'
 
 const MigrationAlertDialog = (props) => {
   const {
@@ -31,10 +33,14 @@ const MigrationAlertDialog = (props) => {
     title = 'New Migration Scripts Detected',
     onClose = () => {},
     onClosed = () => {},
+    onCancel = () => {},
     onConfirm = () => {},
     canEscapeKeyClose = false,
     canOutsideClickClose = false,
-    isCloseButtonShown = false
+    isCloseButtonShown = false,
+    isMigrating = false,
+    wasSuccessful = false,
+    hasFailed = false,
   } = props
 
   return (
@@ -51,19 +57,87 @@ const MigrationAlertDialog = (props) => {
         isCloseButtonShown={isCloseButtonShown}
       >
         <div className={Classes.DIALOG_BODY}>
-          <p style={{ margin: 0, padding: 0, color: Colors.RED4 }}>
-            WARNING: Performing migration may wipe collected data for consistency and re-collecting data may be required.
-          </p>
-          <p style={{ margin: 0, padding: 0 }}>
-            A Database migration is required to launch <strong>DevLake</strong>, to proceed, please send a request to <code style={{ backgroundColor: '#eeeeee' }}>&lt;config-ui-endpoint&gt;/api/proceed-db-migration</code>{' '}
-            ( or <code style={{ backgroundColor: '#eeeeee' }}>&lt;devlake-endpoint&gt;/proceed-db-migration</code>){' '}
-            Alternatively, you may downgrade back to the previous DevLake version.
-          </p>
+          {!isMigrating && wasSuccessful ? (
+            <>
+              <p style={{ margin: 0, padding: 0, color: Colors.GREEN4 }}>
+                <strong>Database Migration Successful!</strong>
+              </p>
+              <p style={{ margin: 0, padding: 0 }}>
+                There is no further action, You may continue using DevLake by
+                clicking below or Reloading your browser.
+              </p>
+            </>
+          ) : (
+            <>
+              {isMigrating ? (
+                <>
+                  <ContentLoader
+                    title='Running Migrations...'
+                    elevation={Elevation.ZERO}
+                    cardStyleOverrides={{ backgroundColor: 'transparent', marginBottom: 0, fontSize: '12px' }}
+                    messageClasses={['bp3-ui-text']}
+                    message={
+                      <>
+                        Please wait for database migrations to complete, do{' '}
+                        <strong>NOT</strong> close your browser at this time.
+                      </>
+                    }
+                  />
+                </>
+              ) : (
+                <>
+                  <p style={{ margin: 0, padding: 0, color: Colors.RED4 }}>
+                    WARNING: Performing migration may wipe collected data for
+                    consistency and re-collecting data may be required.
+                  </p>
+                  <p style={{ margin: 0, padding: 0 }}>
+                    A Database migration is required to launch{' '}
+                    <strong>DevLake</strong>, to proceed, please send a request
+                    to{' '}
+                    <code style={{ backgroundColor: '#eeeeee' }}>
+                      &lt;config-ui-endpoint&gt;/api/proceed-db-migration
+                    </code>{' '}
+                    ( or{' '}
+                    <code style={{ backgroundColor: '#eeeeee' }}>
+                      &lt;devlake-endpoint&gt;/proceed-db-migration
+                    </code>
+                    ) Alternatively, you may downgrade back to the previous
+                    DevLake version.
+                  </p>
+                </>
+              )}
+            </>
+          )}
         </div>
         <div className={Classes.DIALOG_FOOTER}>
           <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-            <Button text='Downgrade' intent={Intent.PRIMARY} outlined onClick={onClose} />
-            <Button text='Proceed to Database Migration' intent={Intent.PRIMARY} onClick={onConfirm} />
+            {wasSuccessful ? (
+              <>
+                <Button
+                  icon='small-tick'
+                  text='Continue'
+                  intent={Intent.SUCCESS}
+                  onClick={onClose}
+                />
+              </>
+            ) : (
+              <>
+                <Button
+                  disabled={isMigrating}
+                  text='Downgrade'
+                  intent={Intent.PRIMARY}
+                  onClick={onCancel}
+                  outlined
+                />
+                <Button
+                  disabled={isMigrating}
+                  loading={isMigrating}
+                  text='Proceed to Database Migration'
+                  intent={Intent.PRIMARY}
+                  onClick={onConfirm}
+                />
+              </>
+            )}
           </div>
         </div>
       </Dialog>

--- a/config-ui/src/components/MigrationAlertDialog.jsx
+++ b/config-ui/src/components/MigrationAlertDialog.jsx
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import React, { useEffect, useState } from 'react'
+import {
+  Button,
+  Classes,
+  Colors,
+  Dialog,
+  Intent,
+} from '@blueprintjs/core'
+
+const MigrationAlertDialog = (props) => {
+  const {
+    isOpen = false,
+    icon = 'outdated',
+    title = 'New Migration Scripts Detected',
+    onClose = () => {},
+    onClosed = () => {},
+    onConfirm = () => {},
+    canEscapeKeyClose = false,
+    canOutsideClickClose = false,
+    isCloseButtonShown = false
+  } = props
+
+  return (
+    <>
+      <Dialog
+        className='dialog-db-migration'
+        icon={icon}
+        title={title}
+        isOpen={isOpen}
+        onClose={onClose}
+        onClosed={onClosed}
+        canEscapeKeyClose={canEscapeKeyClose}
+        canOutsideClickClose={canOutsideClickClose}
+        isCloseButtonShown={isCloseButtonShown}
+      >
+        <div className={Classes.DIALOG_BODY}>
+          <p style={{ margin: 0, padding: 0, color: Colors.RED4 }}>
+            WARNING: Performing migration may wipe collected data for consistency and re-collecting data may be required.
+          </p>
+          <p style={{ margin: 0, padding: 0 }}>
+            A Database migration is required to launch <strong>DevLake</strong>, to proceed, please send a request to <code style={{ backgroundColor: '#eeeeee' }}>&lt;config-ui-endpoint&gt;/api/proceed-db-migration</code>{' '}
+            ( or <code style={{ backgroundColor: '#eeeeee' }}>&lt;devlake-endpoint&gt;/proceed-db-migration</code>){' '}
+            Alternatively, you may downgrade back to the previous DevLake version.
+          </p>
+        </div>
+        <div className={Classes.DIALOG_FOOTER}>
+          <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+            <Button text='Downgrade' intent={Intent.PRIMARY} outlined onClick={onClose} />
+            <Button text='Proceed to Database Migration' intent={Intent.PRIMARY} onClick={onConfirm} />
+          </div>
+        </div>
+      </Dialog>
+    </>
+  )
+}
+
+export default MigrationAlertDialog

--- a/config-ui/src/components/MigrationAlertDialog.jsx
+++ b/config-ui/src/components/MigrationAlertDialog.jsx
@@ -15,7 +15,8 @@
  * limitations under the License.
  *
  */
-import React, { useEffect, useState } from 'react'
+import React from 'react'
+import { MigrationOptions } from '@/config/migration'
 import {
   Button,
   Classes,
@@ -29,8 +30,8 @@ import ContentLoader from '@/components/loaders/ContentLoader'
 const MigrationAlertDialog = (props) => {
   const {
     isOpen = false,
-    icon = 'outdated',
-    title = 'New Migration Scripts Detected',
+    icon = props.hasFailed ? 'warning-sign' : 'outdated',
+    title = MigrationOptions.AlertDialog.title,
     onClose = () => {},
     onClosed = () => {},
     onCancel = () => {},
@@ -41,6 +42,21 @@ const MigrationAlertDialog = (props) => {
     isMigrating = false,
     wasSuccessful = false,
     hasFailed = false,
+    cancelButtonOpts = {
+      text: MigrationOptions.AlertDialog.cancelBtnText,
+      intent: Intent.PRIMARY,
+      outlined: true
+    },
+    confirmButtonOpts = {
+      text: MigrationOptions.AlertDialog.confirmBtnText,
+      intent: Intent.PRIMARY,
+      icon: hasFailed ? 'error' : null
+    },
+    continueButtonOpts = {
+      icon: 'small-tick',
+      text: MigrationOptions.AlertDialog.continueBtnText,
+      intent: Intent.SUCCESS
+    },
   } = props
 
   return (
@@ -57,6 +73,17 @@ const MigrationAlertDialog = (props) => {
         isCloseButtonShown={isCloseButtonShown}
       >
         <div className={Classes.DIALOG_BODY}>
+        {!isMigrating && hasFailed && (
+          <>
+              <p style={{ margin: 0, padding: 0, color: Colors.RED4 }}>
+                <strong>Database Migration Failed!</strong>
+              </p>
+              <p style={{ margin: 0, padding: 0 }}>
+                There was a problem running migrations, please check server logs for details.{' '}
+                You may also try again, if the problem persists please file an issue on <strong>GitHub</strong>.
+              </p>
+          </>
+        )}
           {!isMigrating && wasSuccessful ? (
             <>
               <p style={{ margin: 0, padding: 0, color: Colors.GREEN4 }}>
@@ -85,7 +112,7 @@ const MigrationAlertDialog = (props) => {
                   />
                 </>
               ) : (
-                <>
+                !hasFailed && <>
                   <p style={{ margin: 0, padding: 0, color: Colors.RED4 }}>
                     WARNING: Performing migration may wipe collected data for
                     consistency and re-collecting data may be required.
@@ -114,27 +141,22 @@ const MigrationAlertDialog = (props) => {
             {wasSuccessful ? (
               <>
                 <Button
-                  icon='small-tick'
-                  text='Continue'
-                  intent={Intent.SUCCESS}
                   onClick={onClose}
+                  {...continueButtonOpts}
                 />
               </>
             ) : (
               <>
                 <Button
                   disabled={isMigrating}
-                  text='Downgrade'
-                  intent={Intent.PRIMARY}
                   onClick={onCancel}
-                  outlined
+                  {...cancelButtonOpts}
                 />
                 <Button
                   disabled={isMigrating}
                   loading={isMigrating}
-                  text='Proceed to Database Migration'
-                  intent={Intent.PRIMARY}
                   onClick={onConfirm}
+                  {...confirmButtonOpts}
                 />
               </>
             )}

--- a/config-ui/src/components/MigrationAlertDialog.jsx
+++ b/config-ui/src/components/MigrationAlertDialog.jsx
@@ -44,7 +44,7 @@ const MigrationAlertDialog = (props) => {
     hasFailed = false,
     cancelButtonOpts = {
       text: MigrationOptions.AlertDialog.cancelBtnText,
-      intent: Intent.PRIMARY,
+      intent: hasFailed ? Intent.WARNING : Intent.PRIMARY,
       outlined: true
     },
     confirmButtonOpts = {

--- a/config-ui/src/components/Toast.jsx
+++ b/config-ui/src/components/Toast.jsx
@@ -18,6 +18,6 @@
 import { Position, Toaster } from '@blueprintjs/core'
 
 export const ToastNotification = Toaster.create({
-  className: 'recipe-toaster',
+  className: 'default-toaster',
   position: Position.BOTTOM,
 })

--- a/config-ui/src/components/loaders/ContentLoader.jsx
+++ b/config-ui/src/components/loaders/ContentLoader.jsx
@@ -29,7 +29,9 @@ const ContentLoader = (props) => {
     spinnerSize = 24,
     spinnerIntent = Intent.PRIMARY,
     elevation = Elevation.TWO,
-    cardStyle = { width: '100%', marginBottom: '20px', boxShadow: elevation === Elevation.ZERO ? 'none' : 'initial' }
+    cardStyle = { width: '100%', marginBottom: '20px', boxShadow: elevation === Elevation.ZERO ? 'none' : 'initial' },
+    cardStyleOverrides = {},
+    messageClasses = ['bp3-ui-text', 'bp3-text-large']
   } = props
 
   useEffect(() => {
@@ -37,7 +39,7 @@ const ContentLoader = (props) => {
   }, [title, message, spinnerSize])
 
   return (
-    <Card interactive={false} elevation={elevation} style={cardStyle}>
+    <Card interactive={false} elevation={elevation} style={{...cardStyle, ...cardStyleOverrides}}>
       <div style={{}}>
         <div style={{ display: 'flex' }}>
           <Spinner intent={spinnerIntent} size={spinnerSize} />
@@ -45,7 +47,7 @@ const ContentLoader = (props) => {
             <h4 className='bp3-heading' style={{ margin: '0 0 2px 0' }}>
               {title}
             </h4>
-            <p className='bp3-ui-text bp3-text-large' style={{ margin: 0 }}>
+            <p className={messageClasses.join(' ')} style={{ margin: 0 }}>
               {message}
             </p>
           </div>

--- a/config-ui/src/components/loaders/ContentLoader.jsx
+++ b/config-ui/src/components/loaders/ContentLoader.jsx
@@ -39,7 +39,7 @@ const ContentLoader = (props) => {
   }, [title, message, spinnerSize])
 
   return (
-    <Card interactive={false} elevation={elevation} style={{...cardStyle, ...cardStyleOverrides}}>
+    <Card interactive={false} elevation={elevation} style={{ ...cardStyle, ...cardStyleOverrides }}>
       <div style={{}}>
         <div style={{ display: 'flex' }}>
           <Spinner intent={spinnerIntent} size={spinnerSize} />

--- a/config-ui/src/config/migration.js
+++ b/config-ui/src/config/migration.js
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import { DEVLAKE_ENDPOINT } from '@/utils/config'
+const MigrationOptions = {
+  apiProceedEndpoint: `${DEVLAKE_ENDPOINT}/proceed-db-migration`, // API Get Endpoint
+  // NO Api.Get action required for cancel at this time
+  apiCancelEndpoint: null,
+  apiStatusCode: 400, // API Response Code for Migration Required
+  warningId: 'DEVLAKE__MIGRATION_WARNING', // Local Storage Warning ID Key
+  cancelToastMessage: 'Migration Halted - Please downgrade manually, you will continue to receive a warning unless you proceed with migration or rollback.',
+  failedToastMessage: 'Database Migration Failed! (Check Network Console)',
+  AlertDialog: {
+    title: 'New Migration Scripts Detected',
+    cancelBtnText: 'Cancel',
+    confirmBtnText: 'Proceed to Database Migration',
+    continueBtnText: 'Continue'
+  }
+}
+
+export {
+  MigrationOptions
+}

--- a/config-ui/src/config/migration.js
+++ b/config-ui/src/config/migration.js
@@ -20,7 +20,7 @@ const MigrationOptions = {
   apiProceedEndpoint: `${DEVLAKE_ENDPOINT}/proceed-db-migration`, // API Get Endpoint
   // NO Api.Get action required for cancel at this time
   apiCancelEndpoint: null,
-  apiStatusCode: 400, // API Response Code for Migration Required
+  apiStatusCode: 428, // API Response Code for Migration Required
   warningId: 'DEVLAKE__MIGRATION_WARNING', // Local Storage Warning ID Key
   cancelToastMessage: 'Migration Halted - Please downgrade manually, you will continue to receive a warning unless you proceed with migration or rollback.',
   failedToastMessage: 'Database Migration Failed! (Check Network Console)',

--- a/config-ui/src/config/migration.js
+++ b/config-ui/src/config/migration.js
@@ -28,6 +28,7 @@ const MigrationOptions = {
     title: 'New Migration Scripts Detected',
     cancelBtnText: 'Cancel',
     confirmBtnText: 'Proceed to Database Migration',
+    confirmRetryBtnText: 'Retry Database Migration',
     continueBtnText: 'Continue'
   }
 }

--- a/config-ui/src/hooks/useDatabaseMigrations.jsx
+++ b/config-ui/src/hooks/useDatabaseMigrations.jsx
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import { useState, useEffect, useCallback } from 'react'
+import request from '@/utils/request'
+import { MigrationOptions } from '@/config/migration'
+import {
+  Intent
+} from '@blueprintjs/core'
+import { ToastNotification } from '@/components/Toast'
+
+function useDatabaseMigrations (Configuration = MigrationOptions) {
+  const [isProcessing, setIsProcessing] = useState(false)
+
+  const [migrationWarning, setMigrationWarning] = useState(localStorage.getItem(Configuration.warningId))
+  const [migrationAlertOpened, setMigrationAlertOpened] = useState(false)
+  const [wasMigrationSuccessful, setWasMigrationSuccessful] = useState(false)
+  const [hasMigrationFailed, setHasMigrationFailed] = useState(false)
+
+  const handleConfirmMigration = useCallback(() => {
+    setIsProcessing(true)
+    const m = request.get(Configuration.apiProceedEndpoint)
+    setWasMigrationSuccessful(m?.status === 200 && m?.success === true)
+    setTimeout(() => {
+      setIsProcessing(false)
+      setHasMigrationFailed(m?.status !== 200)
+    }, 3000)
+  }, [])
+
+  const handleCancelMigration = useCallback(() => {
+    setIsProcessing(true)
+    localStorage.removeItem(Configuration.warningId)
+    setMigrationAlertOpened(false)
+    setIsProcessing(false)
+    ToastNotification.clear()
+    ToastNotification.show({
+      // eslint-disable-next-line max-len
+      message: Configuration.cancelToastMessage,
+      intent: Intent.NONE,
+      icon: 'warning-sign'
+    })
+  }, [])
+
+  const handleMigrationDialogClose = useCallback(() => {
+    setMigrationAlertOpened(false)
+  }, [setMigrationAlertOpened])
+
+  useEffect(() => {
+    setMigrationAlertOpened(migrationWarning !== null)
+  }, [migrationWarning, setMigrationAlertOpened])
+
+  useEffect(() => {
+    if (wasMigrationSuccessful) {
+      localStorage.removeItem(MigrationOptions.warningId)
+    }
+  }, [wasMigrationSuccessful])
+
+  useEffect(() => {
+    if (hasMigrationFailed) {
+      ToastNotification.clear()
+      ToastNotification.show({
+        // eslint-disable-next-line max-len
+        message: MigrationOptions.failedToastMessage,
+        intent: Intent.DANGER,
+        icon: 'error'
+      })
+    }
+  }, [hasMigrationFailed])
+
+  useEffect(() => {
+    if (migrationWarning) {
+      // eslint-disable-next-line max-len
+      console.log(`>>> MIGRATION WARNING DETECTED !! Local Storage Key = [${MigrationOptions.warningId}]:`, migrationWarning)
+    }
+  }, [migrationWarning])
+
+  return {
+    migrationWarning,
+    migrationAlertOpened,
+    wasMigrationSuccessful,
+    hasMigrationFailed,
+    isProcessing,
+    setMigrationWarning,
+    setMigrationAlertOpened,
+    setWasMigrationSuccessful,
+    setHasMigrationFailed,
+    setIsProcessing,
+    handleConfirmMigration,
+    handleCancelMigration,
+    handleMigrationDialogClose
+  }
+}
+
+export default useDatabaseMigrations

--- a/config-ui/src/pages/blueprints/create-blueprint.jsx
+++ b/config-ui/src/pages/blueprints/create-blueprint.jsx
@@ -580,10 +580,10 @@ const CreateBlueprint = (props) => {
       const getAllSources = true
       fetchAllConnections(enableNotifications, getAllSources)
     }
-    if (mode === BlueprintMode.NORMAL
-        && ([2, 3].includes(activeStep?.id))
-        && enabledProviders.includes(Providers.JIRA)
-      ) {
+    if (mode === BlueprintMode.NORMAL &&
+        ([2, 3].includes(activeStep?.id)) &&
+        enabledProviders.includes(Providers.JIRA)
+    ) {
       fetchBoards()
       fetchIssueTypes()
       fetchFields()

--- a/config-ui/src/utils/request.js
+++ b/config-ui/src/utils/request.js
@@ -32,12 +32,11 @@ const handleErrorResponse = (e, cb = () => {}) => {
   }
   localStorage.removeItem(migrationWarningId)
   if (e.response?.status === 428) {
+    console.log('>>> DATABASE MIGRATION REQUESTED! Setting Warning Identifier in Browser Storage...')
     localStorage.setItem(migrationWarningId, JSON.stringify({
       migration: true,
       message: e.response?.data?.message
     }))
-  } else {
-    localStorage.removeItem(migrationWarningId)
   }
   cb(e)
   return errorResponse

--- a/config-ui/src/utils/request.js
+++ b/config-ui/src/utils/request.js
@@ -16,12 +16,12 @@
  *
  */
 import axios from 'axios'
+import { MigrationOptions } from '@/config/migration'
 
 const headers = {}
 
 const handleErrorResponse = (e, cb = () => {}) => {
   let errorResponse = { success: false, message: e.message, data: null, status: 504 }
-  const migrationWarningId = 'DEVLAKE__MIGRATION_WARNING'
   if (e.response) {
     errorResponse = {
       ...errorResponse,
@@ -30,10 +30,10 @@ const handleErrorResponse = (e, cb = () => {}) => {
       status: e.response ? e.response.status : 504,
     }
   }
-  localStorage.removeItem(migrationWarningId)
-  if (e.response?.status === 428) {
+  localStorage.removeItem(MigrationOptions.warningId)
+  if (e.response?.status === MigrationOptions.apiStatusCode) {
     console.log('>>> DATABASE MIGRATION REQUESTED! Setting Warning Identifier in Browser Storage...')
-    localStorage.setItem(migrationWarningId, JSON.stringify({
+    localStorage.setItem(MigrationOptions.warningId, JSON.stringify({
       migration: true,
       message: e.response?.data?.message
     }))


### PR DESCRIPTION
### 📦  Config-UI / App / Database Migration Alert

- [x] **Feature** Add Database Migration Alert Dialog & UX Flow
- [x] Create Database Migrations Hook `useDatabaseMigrations.jsx`
- [x] **Refactor** Remove UI/Rendering obligations from `Request.js` XHR Utility
- [x] Allow User-controlled Migration Confirmation Request
- [x] Test Migration Routine
- [x] **Chore** Code Cleanups & Linting
### Description

This PR adds a formal Database Migration Alert Dialog to Configuration UI. If the API has detected a migration, all its resource responses will return a `428` Status response, in which case a special `localStorage` key will be set to indicate that a migration warning is in effect. The Alert is mounted at the Application level so that it renders no matter what Page Service is being accessed. At this point the user can choose to **Proceed** with the migration operation or **Cancel** and take no action (Abort).

If the user chooses to **Proceed to Database Migration**, a `[GET]` request will be pushed to the Migration API Endpoint, if successful, the user will be given the option to continue or they can manually reload the browser. The local storage warning will be _removed_, and no additional migration warnings will be displayed.

If the user chooses to **Cancel Migration** (Abort), the migration warning local storage key will be temporarily removed, however they will continue to receive a migration warning if they attempt to use Configuration UI until DevLake is manually downgraded.

In the event of a Migration Failure, the alert dialog will transition states and allow the user to "Retry" the migration (though it will likely fail again) and advised to check the server logs for details.

### Does this close any open issues?
#2788

### Screenshots
`NOTE: "Downgrade" has been replaced with "Cancel"`
<img width="1428" alt="Screen Shot 2022-08-26 at 6 08 25 PM" src="https://user-images.githubusercontent.com/1742233/186996977-660886c9-dd9d-4977-bacc-16e998f77063.png">
<img width="1336" alt="Screen Shot 2022-08-26 at 7 49 33 PM" src="https://user-images.githubusercontent.com/1742233/187004832-0f1e8bb0-09ff-4ca7-b5b8-482af6328d16.png">
<img width="1350" alt="Screen Shot 2022-08-26 at 7 49 00 PM" src="https://user-images.githubusercontent.com/1742233/187004803-ee82c85e-fbf0-4d3f-9890-2dbd0dd1b4cf.png">

<img width="1327" alt="Screen Shot 2022-08-29 at 3 59 13 PM" src="https://user-images.githubusercontent.com/1742233/187287508-a7efbab4-0a55-42f0-9f90-692e4ae8dc01.png">

