### PR TITLE
fix: add `type` field in `boards` table

### DIFF
--- a/models/domainlayer/ticket/board.go
+++ b/models/domainlayer/ticket/board.go
@@ -30,7 +30,7 @@ type Board struct {
 	Description string
 	Url         string `gorm:"type:varchar(255)"`
 	CreatedDate *time.Time
-	Type        string
+	Type        string `gorm:"type:varchar(255)"`
 }
 
 func (Board) TableName() string {

--- a/models/migrationscripts/20220830_add_type_field_in_board.go
+++ b/models/migrationscripts/20220830_add_type_field_in_board.go
@@ -15,34 +15,44 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package ticket
+package migrationscripts
 
 import (
-	"github.com/apache/incubator-devlake/models/common"
+	"context"
+	"github.com/apache/incubator-devlake/models/migrationscripts/archived"
+	"gorm.io/gorm"
 	"time"
-
-	"github.com/apache/incubator-devlake/models/domainlayer"
 )
 
-type Board struct {
-	domainlayer.DomainEntity
+type AddFieldTask20220830 struct {
+	archived.DomainEntity
 	Name        string `gorm:"type:varchar(255)"`
 	Description string
 	Url         string `gorm:"type:varchar(255)"`
 	CreatedDate *time.Time
-	Type        string
+	Type string
 }
 
-func (Board) TableName() string {
+func (AddFieldTask20220830) TableName() string {
 	return "boards"
 }
 
-type BoardSprint struct {
-	common.NoPKModel
-	BoardId  string `gorm:"primaryKey;type:varchar(255)"`
-	SprintId string `gorm:"primaryKey;type:varchar(255)"`
+type addTypeFieldInBoard struct{}
+
+func (*addTypeFieldInBoard) Up(ctx context.Context, db *gorm.DB) error {
+
+	err := db.Migrator().AddColumn(AddFieldTask20220830{}, "type")
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
-func (BoardSprint) TableName() string {
-	return "board_sprints"
+func (*addTypeFieldInBoard) Version() uint64 {
+	return 20220830142321
+}
+
+func (*addTypeFieldInBoard) Name() string {
+	return "add column `type` at boards"
 }

--- a/models/migrationscripts/20220830_add_type_field_in_board.go
+++ b/models/migrationscripts/20220830_add_type_field_in_board.go
@@ -24,16 +24,16 @@ import (
 	"time"
 )
 
-type AddFieldTask20220830 struct {
+type addFieldTask20220830 struct {
 	archived.DomainEntity
 	Name        string `gorm:"type:varchar(255)"`
 	Description string
 	Url         string `gorm:"type:varchar(255)"`
 	CreatedDate *time.Time
-	Type string
+	Type        string `gorm:"type:varchar(255)"`
 }
 
-func (AddFieldTask20220830) TableName() string {
+func (addFieldTask20220830) TableName() string {
 	return "boards"
 }
 
@@ -41,7 +41,7 @@ type addTypeFieldInBoard struct{}
 
 func (*addTypeFieldInBoard) Up(ctx context.Context, db *gorm.DB) error {
 
-	err := db.Migrator().AddColumn(AddFieldTask20220830{}, "type")
+	err := db.Migrator().AddColumn(addFieldTask20220830{}, "type")
 	if err != nil {
 		return err
 	}

--- a/models/migrationscripts/register.go
+++ b/models/migrationscripts/register.go
@@ -37,5 +37,6 @@ func All() []migration.Script {
 		new(addSubtasksTable),
 		new(addCICD),
 		new(modifyTablesForDora),
+		new(addTypeFieldInBoard),
 	}
 }

--- a/plugins/dora/models/migrationscripts/20220829_add_init_tables.go
+++ b/plugins/dora/models/migrationscripts/20220829_add_init_tables.go
@@ -22,11 +22,11 @@ import (
 	"gorm.io/gorm"
 )
 
-type addInitTables struct {}
+type addInitTables struct{}
 
 func (u *addInitTables) Up(ctx context.Context, db *gorm.DB) error {
 	return db.Migrator().AutoMigrate(
-		// TODO add you models
+	// TODO add you models
 	)
 }
 

--- a/plugins/jira/e2e/board_test.go
+++ b/plugins/jira/e2e/board_test.go
@@ -73,6 +73,7 @@ func TestBoardDataFlow(t *testing.T) {
 			"description",
 			"url",
 			"created_date",
+			"type",
 		},
 	)
 }

--- a/plugins/jira/e2e/snapshot_tables/boards.csv
+++ b/plugins/jira/e2e/snapshot_tables/boards.csv
@@ -1,2 +1,2 @@
-id,id,name,description,url,created_date
-jira:JiraBoard:2:8,jira:JiraBoard:2:8,迭代开发看板（停用）,,https://merico.atlassian.net/rest/agile/1.0/board/8,
+id,name,description,url,created_date,type
+jira:JiraBoard:2:8,迭代开发看板（停用）,,https://merico.atlassian.net/rest/agile/1.0/board/8,,scrum

--- a/plugins/jira/impl/impl.go
+++ b/plugins/jira/impl/impl.go
@@ -87,45 +87,45 @@ func (plugin Jira) SubTaskMetas() []core.SubTaskMeta {
 		tasks.CollectBoardMeta,
 		tasks.ExtractBoardMeta,
 
-		//tasks.CollectIssueTypesMeta,
-		//tasks.ExtractIssueTypesMeta,
+		tasks.CollectIssueTypesMeta,
+		tasks.ExtractIssueTypesMeta,
 
-		//tasks.CollectIssuesMeta,
-		//tasks.ExtractIssuesMeta,
+		tasks.CollectIssuesMeta,
+		tasks.ExtractIssuesMeta,
 
-		//tasks.CollectIssueChangelogsMeta,
-		//tasks.ExtractIssueChangelogsMeta,
+		tasks.CollectIssueChangelogsMeta,
+		tasks.ExtractIssueChangelogsMeta,
 
-		//tasks.CollectAccountsMeta,
+		tasks.CollectAccountsMeta,
 
-		//tasks.CollectWorklogsMeta,
-		//tasks.ExtractWorklogsMeta,
+		tasks.CollectWorklogsMeta,
+		tasks.ExtractWorklogsMeta,
 
-		//tasks.CollectRemotelinksMeta,
-		//tasks.ExtractRemotelinksMeta,
+		tasks.CollectRemotelinksMeta,
+		tasks.ExtractRemotelinksMeta,
 
-		//tasks.CollectSprintsMeta,
-		//tasks.ExtractSprintsMeta,
+		tasks.CollectSprintsMeta,
+		tasks.ExtractSprintsMeta,
 
 		tasks.ConvertBoardMeta,
 
-		//tasks.ConvertIssuesMeta,
+		tasks.ConvertIssuesMeta,
 
-		//tasks.ConvertWorklogsMeta,
+		tasks.ConvertWorklogsMeta,
 
-		//tasks.ConvertIssueChangelogsMeta,
+		tasks.ConvertIssueChangelogsMeta,
 
-		//tasks.ConvertSprintsMeta,
-		//tasks.ConvertSprintIssuesMeta,
+		tasks.ConvertSprintsMeta,
+		tasks.ConvertSprintIssuesMeta,
 
-		//tasks.ConvertIssueCommitsMeta,
-		//tasks.ConvertIssueRepoCommitsMeta,
+		tasks.ConvertIssueCommitsMeta,
+		tasks.ConvertIssueRepoCommitsMeta,
 
-		//tasks.ExtractAccountsMeta,
-		//tasks.ConvertAccountsMeta,
+		tasks.ExtractAccountsMeta,
+		tasks.ConvertAccountsMeta,
 
-		//tasks.CollectEpicsMeta,
-		//tasks.ExtractEpicsMeta,
+		tasks.CollectEpicsMeta,
+		tasks.ExtractEpicsMeta,
 	}
 }
 

--- a/plugins/jira/impl/impl.go
+++ b/plugins/jira/impl/impl.go
@@ -87,45 +87,45 @@ func (plugin Jira) SubTaskMetas() []core.SubTaskMeta {
 		tasks.CollectBoardMeta,
 		tasks.ExtractBoardMeta,
 
-		tasks.CollectIssueTypesMeta,
-		tasks.ExtractIssueTypesMeta,
+		//tasks.CollectIssueTypesMeta,
+		//tasks.ExtractIssueTypesMeta,
 
-		tasks.CollectIssuesMeta,
-		tasks.ExtractIssuesMeta,
+		//tasks.CollectIssuesMeta,
+		//tasks.ExtractIssuesMeta,
 
-		tasks.CollectIssueChangelogsMeta,
-		tasks.ExtractIssueChangelogsMeta,
+		//tasks.CollectIssueChangelogsMeta,
+		//tasks.ExtractIssueChangelogsMeta,
 
-		tasks.CollectAccountsMeta,
+		//tasks.CollectAccountsMeta,
 
-		tasks.CollectWorklogsMeta,
-		tasks.ExtractWorklogsMeta,
+		//tasks.CollectWorklogsMeta,
+		//tasks.ExtractWorklogsMeta,
 
-		tasks.CollectRemotelinksMeta,
-		tasks.ExtractRemotelinksMeta,
+		//tasks.CollectRemotelinksMeta,
+		//tasks.ExtractRemotelinksMeta,
 
-		tasks.CollectSprintsMeta,
-		tasks.ExtractSprintsMeta,
+		//tasks.CollectSprintsMeta,
+		//tasks.ExtractSprintsMeta,
 
 		tasks.ConvertBoardMeta,
 
-		tasks.ConvertIssuesMeta,
+		//tasks.ConvertIssuesMeta,
 
-		tasks.ConvertWorklogsMeta,
+		//tasks.ConvertWorklogsMeta,
 
-		tasks.ConvertIssueChangelogsMeta,
+		//tasks.ConvertIssueChangelogsMeta,
 
-		tasks.ConvertSprintsMeta,
-		tasks.ConvertSprintIssuesMeta,
+		//tasks.ConvertSprintsMeta,
+		//tasks.ConvertSprintIssuesMeta,
 
-		tasks.ConvertIssueCommitsMeta,
-		tasks.ConvertIssueRepoCommitsMeta,
+		//tasks.ConvertIssueCommitsMeta,
+		//tasks.ConvertIssueRepoCommitsMeta,
 
-		tasks.ExtractAccountsMeta,
-		tasks.ConvertAccountsMeta,
+		//tasks.ExtractAccountsMeta,
+		//tasks.ConvertAccountsMeta,
 
-		tasks.CollectEpicsMeta,
-		tasks.ExtractEpicsMeta,
+		//tasks.CollectEpicsMeta,
+		//tasks.ExtractEpicsMeta,
 	}
 }
 

--- a/plugins/jira/tasks/board_convertor.go
+++ b/plugins/jira/tasks/board_convertor.go
@@ -70,6 +70,7 @@ func ConvertBoard(taskCtx core.SubTaskContext) error {
 				DomainEntity: domainlayer.DomainEntity{Id: idGen.Generate(data.Options.ConnectionId, data.Options.BoardId)},
 				Name:         board.Name,
 				Url:          board.Self,
+				Type:         board.Type,
 			}
 			return []interface{}{
 				domainBoard,


### PR DESCRIPTION
# Summary
Add field type to domain layer boards table
Convert jira_board.type to board.type
Other plugins can't find the corresponding fields so  their board.type not be filled.

### Does this close any open issues?
closes #2801 

### Screenshots
_tool_jira_boards table
<img width="1040" alt="Screen Shot 2022-08-30 at 22 48 54" src="https://user-images.githubusercontent.com/47466847/187475858-f61e8e10-0315-4016-b441-720c5a5b64b5.png">

boards table
<img width="1043" alt="Screen Shot 2022-08-30 at 22 49 02" src="https://user-images.githubusercontent.com/47466847/187475843-0f35c924-c6a7-499b-9600-f2089b76dc03.png">



