### PR TITLE
fix: connection saving must return after 2 seconds even though the ne…

### DIFF
--- a/config-ui/src/hooks/useConnectionManager.jsx
+++ b/config-ui/src/hooks/useConnectionManager.jsx
@@ -256,13 +256,16 @@ function useConnectionManager (
       }
     }
 
+    let savePromise
     if (updateMode && activeConnection?.id !== null) {
       modifyConfiguration(connectionPayload)
+      savePromise = modifyConfiguration(connectionPayload)
     } else {
       saveConfiguration(connectionPayload)
+      savePromise = saveConfiguration(connectionPayload)
     }
 
-    setTimeout(() => {
+    savePromise.then(() => {
       if (saveResponse.success && errors.length === 0) {
         ToastNotification.show({
           message: 'Connection saved successfully.',
@@ -282,7 +285,11 @@ function useConnectionManager (
         if (!updateMode) {
           history.push(`/integrations/${provider.id}`)
         }
-      } else {
+      }
+    })
+
+    setTimeout(() => {
+      if (!saveResponse.success || errors.length !== 0) {
         ToastNotification.show({
           message: 'Connection failed to save, please try again.',
           intent: 'danger',
@@ -312,7 +319,6 @@ function useConnectionManager (
       try {
         setIsFetching(!silent)
         setErrors([])
-        ToastNotification.clear()
         console.log('>> FETCHING CONNECTION SOURCE')
         const fetch = async () => {
           const f = await request.get(
@@ -341,6 +347,7 @@ function useConnectionManager (
         setIsFetching(false)
         setActiveConnection(NullConnection)
         setErrors([e.message])
+        ToastNotification.clear()
         ToastNotification.show({
           message: `${e}`,
           intent: 'danger',


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->
connection saving must return after 2 seconds even though the network is in localhost.
So I fix it by using `promise.then`. 

Actually, the root reason is `Notification` is only displayed when save after several seconds. So I fix the root reason here too.

### Does this close any open issues?
close #2111
