### PR TITLE
Issues/2888-2 move local var connectionsList to the local scope

### DIFF
--- a/config-ui/src/hooks/useConnectionManager.jsx
+++ b/config-ui/src/hooks/useConnectionManager.jsx
@@ -78,8 +78,6 @@ function useConnectionManager (
   [/*provider?.id, */sourceLimits, connectionCount],
   )
 
-  const [connectionsList, setConnectionsList] = useState([])
-
   const [saveComplete, setSaveComplete] = useState(false)
   const [deleteComplete, setDeleteComplete] = useState(false)
   const connectionTestPayload = useMemo(() => ({ endpoint: endpointUrl, username, password, token, proxy }), [endpointUrl, password, proxy, token, username])
@@ -636,28 +634,6 @@ function useConnectionManager (
     setProvider(activeProvider)
   }, [activeProvider])
 
-  useEffect(() => {
-    console.log('>>> ALL DATA PROVIDER CONNECTIONS...', allProviderConnections)
-    setConnectionsList(
-      allProviderConnections?.map((c, cIdx) => ({
-        ...c,
-        id: cIdx,
-        key: cIdx,
-        connectionId: c.id,
-        name: c.name,
-        title: c.name,
-        value: c.id,
-        status:
-          ConnectionStatusLabels[c.status] ||
-          ConnectionStatusLabels[ConnectionStatus.OFFLINE],
-        statusResponse: null,
-        provider: c.provider,
-        providerId: c.provider,
-        plugin: c.provider,
-      }))
-    )
-  }, [allProviderConnections])
-
   return {
     activeConnection,
     fetchConnection,
@@ -702,11 +678,9 @@ function useConnectionManager (
     setTestResponse,
     setAllTestResponses,
     setConnectionLimits,
-    setConnectionsList,
     setSaveComplete,
     allConnections,
     allProviderConnections,
-    connectionsList,
     domainRepositories,
     testedConnections,
     sourceLimits,

--- a/config-ui/src/pages/blueprints/blueprint-settings.jsx
+++ b/config-ui/src/pages/blueprints/blueprint-settings.jsx
@@ -43,7 +43,7 @@ import {
 import { integrationsData } from '@/data/integrations'
 import { NullBlueprint, BlueprintMode } from '@/data/NullBlueprint'
 import { NullPipelineRun } from '@/data/NullPipelineRun'
-import { Providers, ProviderLabels, ProviderIcons } from '@/data/Providers'
+import { Providers, ProviderLabels, ProviderIcons, ConnectionStatusLabels, ConnectionStatus } from '@/data/Providers'
 import {
   TaskStatus,
 } from '@/data/Task'
@@ -186,10 +186,7 @@ const BlueprintSettings = (props) => {
   })
 
   const {
-    fetchConnection,
     allProviderConnections,
-    connectionsList,
-    isFetching: isFetchingConnection,
     fetchAllConnections,
   } = useConnectionManager(
     {
@@ -198,6 +195,26 @@ const BlueprintSettings = (props) => {
     },
     configuredConnection && configuredConnection?.id !== null
   )
+
+  const connectionsList = useMemo(() => {
+    console.log('>>> ALL DATA PROVIDER CONNECTIONS...', allProviderConnections)
+    return allProviderConnections?.map((c, cIdx) => ({
+      ...c,
+      id: cIdx,
+      key: cIdx,
+      connectionId: c.id,
+      name: c.name,
+      title: c.name,
+      value: c.id,
+      status:
+        ConnectionStatusLabels[c.status] ||
+        ConnectionStatusLabels[ConnectionStatus.OFFLINE],
+      statusResponse: null,
+      provider: c.provider,
+      providerId: c.provider,
+      plugin: c.provider,
+    }))
+  }, [allProviderConnections])
 
   const {
     // eslint-disable-next-line no-unused-vars

--- a/config-ui/src/pages/blueprints/create-blueprint.jsx
+++ b/config-ui/src/pages/blueprints/create-blueprint.jsx
@@ -28,6 +28,8 @@ import {
 import { integrationsData } from '@/data/integrations'
 import { Intent } from '@blueprintjs/core'
 import {
+  ConnectionStatus,
+  ConnectionStatusLabels,
   Providers,
 } from '@/data/Providers'
 import Nav from '@/components/Nav'
@@ -256,9 +258,7 @@ const CreateBlueprint = (props) => {
     saveConnection,
     // eslint-disable-next-line no-unused-vars
     fetchConnection,
-    // eslint-disable-next-line no-unused-vars
     allProviderConnections,
-    connectionsList,
     errors: connectionErrors,
     isSaving: isSavingConnection,
     isTesting: isTestingConnection,
@@ -287,7 +287,6 @@ const CreateBlueprint = (props) => {
     setTestStatus,
     setTestResponse,
     setAllTestResponses,
-    setConnectionsList,
     setSaveComplete: setSaveConnectionComplete,
     fetchAllConnections,
     clearConnection: clearActiveConnection,
@@ -655,7 +654,7 @@ const CreateBlueprint = (props) => {
     cronConfig,
     customCronConfig,
     blueprintTasks,
-    connectionsList,
+    allProviderConnections,
     enable,
     validateBlueprint,
   ])
@@ -937,14 +936,30 @@ const CreateBlueprint = (props) => {
     })))
   }, [onlineStatus, blueprintConnections])
 
-  useEffect(() => {
-    setConnectionsList(cList => cList.map((c, cIdx) => ({
+  const connectionsList = useMemo(() => {
+    console.log('>>> ALL DATA PROVIDER CONNECTIONS...', allProviderConnections)
+    return allProviderConnections?.map((c, cIdx) => ({
       ...c,
+      id: cIdx,
+      key: cIdx,
+      connectionId: c.id,
+      name: c.name,
+      title: c.name,
+      value: c.id,
+      status:
+        dataConnections.find(dC => dC.id === c.id && dC.provider === c.provider)?.status ||
+        ConnectionStatusLabels[c.status] ||
+        ConnectionStatusLabels[ConnectionStatus.OFFLINE],
       statusResponse: dataConnections.find(dC => dC.id === c.id && dC.provider === c.provider),
-      status: dataConnections.find(dC => dC.id === c.id && dC.provider === c.provider)?.status
-    })))
+      provider: c.provider,
+      providerId: c.provider,
+      plugin: c.provider,
+    }))
+  }, [dataConnections, allProviderConnections])
+
+  useEffect(() => {
     setCanAdvanceNext(dataConnections.every(dC => dC.status === 200))
-  }, [dataConnections, setConnectionsList])
+  }, [dataConnections])
 
   return (
     <>


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->
base on #2889 

move local var connectionsList to the local scope config-ui/src/pages/blueprints/create-blueprint.jsx from the global manager.

We should not use `setXXX` to change the response result in the manager. It breaks the cohesion rule of useManager.

### Does this close any open issues?
close #2888