### PR TITLE
fix: fix the wrong router when adding a connection

### DIFF
--- a/config-ui/src/hooks/useConnectionManager.jsx
+++ b/config-ui/src/hooks/useConnectionManager.jsx
@@ -280,7 +280,7 @@ function useConnectionManager (
           testConnection()
         }
         if (!updateMode) {
-          history.push(`/integrations/${provider.id}`)
+          history.replace(`/integrations/${provider.id}`)
         }
       } else {
         ToastNotification.show({


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->
fix the wrong router when adding a connection.
 
We should use `history.replace` when saving success.

### Does this close any open issues?
close #2891