### PR TITLE
fix: add missing jenkins proxy field on save

### DIFF
--- a/config-ui/src/hooks/useConnectionManager.jsx
+++ b/config-ui/src/hooks/useConnectionManager.jsx
@@ -184,6 +184,7 @@ function useConnectionManager (
           endpoint: endpointUrl,
           username: username,
           password: password,
+          proxy: proxy,
           rateLimitPerHour: rateLimit,
           ...connectionPayload,
         }
@@ -563,6 +564,7 @@ function useConnectionManager (
         case Providers.JENKINS:
           setUsername(activeConnection.username)
           setPassword(activeConnection.password)
+          setProxy(activeConnection.Proxy || activeConnection.proxy)
           setRateLimit(activeConnection.rateLimitPerHour)
           break
         case Providers.GITLAB:


### PR DESCRIPTION
### :package: Config-UI / Data Integrations / Jenkins Connection + Proxy URL

- [x] `Fix` Add missing **Jenkins Proxy URL** field on save

### Description

This PR resolves a bug with Jenkins Connection where the Proxy URL field was not properly dispatched with the Connection Save Handler, resulting in an empty proxy field. Ideally, this should have been caught during prior QA Testing.

### Does this close any open issues?
Closes #2897

### Screenshots
`[PATCH]`
<img width="1422" alt="Screen Shot 2022-08-31 at 12 52 41 PM" src="https://user-images.githubusercontent.com/1742233/187735358-fa5c698f-95be-4639-8950-1beeddac3fd1.png">

`[GET]`
<img width="1423" alt="Screen Shot 2022-08-31 at 12 53 03 PM" src="https://user-images.githubusercontent.com/1742233/187735812-8570372d-f22a-4884-82be-89722b33230a.png">
