### PR TITLE
feat: add projects selector fetching by api for gitlab when adding blueprint

### DIFF
--- a/config-ui/src/components/blueprints/BlueprintDataScopesDialog.jsx
+++ b/config-ui/src/components/blueprints/BlueprintDataScopesDialog.jsx
@@ -72,6 +72,8 @@ const BlueprintDataScopesDialog = (props) => {
     issueTypesList = [],
     fieldsList = [],
     boards = {},
+    gitlabProjects = [],
+    fetchGitlabProjects = () => [],
     entities = {},
     projects = {},
     mode = Modes.EDIT,
@@ -105,6 +107,8 @@ const BlueprintDataScopesDialog = (props) => {
     isTesting = false,
     isFetchingJIRA = false,
     jiraProxyError,
+    isFetchingGitlab,
+    gitlabProxyError,
     errors = [],
     content = null,
     backButtonProps = {
@@ -112,28 +116,28 @@ const BlueprintDataScopesDialog = (props) => {
       intent: Intent.PRIMARY,
       text: 'Previous Step',
       outlined: true,
-      loading: isFetchingJIRA || isSaving
+      loading: isFetchingJIRA || isFetchingGitlab || isSaving
     },
     nextButtonProps = {
       disabled: !isValid,
       intent: Intent.PRIMARY,
       text: 'Next Step',
       outlined: true,
-      loading: isFetchingJIRA || isSaving,
+      loading: isFetchingJIRA || isFetchingGitlab || isSaving,
     },
     finalButtonProps = {
       disabled: !isValid,
       intent: Intent.PRIMARY,
       onClick: onSave,
       text: 'Save Changes',
-      loading: isFetchingJIRA || isSaving
+      loading: isFetchingJIRA || isFetchingGitlab || isSaving
     },
     closeButtonProps = {
       // disabled:
       intent: Intent.PRIMARY,
       text: 'Cancel',
       outlined: true,
-      loading: isFetchingJIRA || isSaving
+      loading: isFetchingJIRA || isFetchingGitlab || isSaving
     }
   } = props
 
@@ -180,6 +184,10 @@ const BlueprintDataScopesDialog = (props) => {
                 dataEntitiesList={dataEntitiesList}
                 boardsList={boardsList}
                 boards={boards}
+                fetchGitlabProjects={fetchGitlabProjects}
+                gitlabProjects={gitlabProjects}
+                isFetchingGitlab={isFetchingGitlab}
+                gitlabProxyError={gitlabProxyError}
                 dataEntities={entities}
                 projects={projects}
                 configuredConnection={configuredConnection}

--- a/config-ui/src/components/blueprints/DataScopesGrid.jsx
+++ b/config-ui/src/components/blueprints/DataScopesGrid.jsx
@@ -156,7 +156,7 @@ const DataScopesGrid = (props) => {
                 >
                   {c.projects.map((project, pIdx) => (
                     <li key={`list-item-key-${pIdx}`}>
-                      {project}
+                      {project.title}
                     </li>
                   ))}
                 </ul>
@@ -169,8 +169,8 @@ const DataScopesGrid = (props) => {
                     padding: 0,
                   }}
                 >
-                  {c.boards.map((board, bIdx) => (
-                    <li key={`list-item-key-${bIdx}`}>{board}</li>
+                  {c.boardsList.map((board, bIdx) => (
+                    <li key={`list-item-key-${bIdx}`}>{board.title}</li>
                   ))}
                 </ul>
               )}

--- a/config-ui/src/components/blueprints/DataScopesGrid.jsx
+++ b/config-ui/src/components/blueprints/DataScopesGrid.jsx
@@ -169,8 +169,8 @@ const DataScopesGrid = (props) => {
                     padding: 0,
                   }}
                 >
-                  {c.boardsList.map((board, bIdx) => (
-                    <li key={`list-item-key-${bIdx}`}>{board.title}</li>
+                  {c.boards.map((board, bIdx) => (
+                    <li key={`list-item-key-${bIdx}`}>{board}</li>
                   ))}
                 </ul>
               )}

--- a/config-ui/src/components/blueprints/DataScopesGrid.jsx
+++ b/config-ui/src/components/blueprints/DataScopesGrid.jsx
@@ -155,7 +155,7 @@ const DataScopesGrid = (props) => {
                   }}
                 >
                   {c.projects.map((project, pIdx) => (
-                    <li key={`list-item-key-${pIdx}`}>
+                    <li key={`list-item-key-${pIdx}`} style={{ whiteSpace: 'break-spaces' }}>
                       {project.title}
                     </li>
                   ))}

--- a/config-ui/src/components/blueprints/GitlabProjectsSelector.jsx
+++ b/config-ui/src/components/blueprints/GitlabProjectsSelector.jsx
@@ -21,8 +21,8 @@ import { MultiSelect } from '@blueprintjs/select'
 
 const GitlabProjectsSelector = (props) => {
   const {
-    fetchGitlabProjects = () => [],
-    isFetchingGitlab = false,
+    fetchGitlabProjects: onFetch = () => [],
+    isFetchingGitlab: isFetching = false,
     configuredConnection,
     placeholder = 'Select Projects',
     items = [],
@@ -68,24 +68,12 @@ const GitlabProjectsSelector = (props) => {
   const [onlyQueryMemberRepo, setOnlyQueryMemberRepo] = useState(true)
 
   useEffect(() => {
-    if (query.length <= 2) {
-      // only search when type more than 2 char or empty
-      return
-    }
     // prevent request too frequently
     const timer = setTimeout(() => {
-      fetchGitlabProjects(query, onlyQueryMemberRepo)
+      onFetch(query, onlyQueryMemberRepo)
     }, 200)
     return () => clearTimeout(timer)
-  }, [fetchGitlabProjects, query])
-
-  useEffect(() => {
-    if (query.length <= 2) {
-      // only search when type more than 2 char or empty
-      return
-    }
-    fetchGitlabProjects(query, onlyQueryMemberRepo)
-  }, [fetchGitlabProjects, onlyQueryMemberRepo])
+  }, [onFetch, query, onlyQueryMemberRepo])
 
   return (
     <div
@@ -118,8 +106,8 @@ const GitlabProjectsSelector = (props) => {
             },
           }}
           noResults={
-            (query.length <= 2 && <MenuItem disabled={true} text='Please type more than 2 char to search.' />) ||
-            (isFetchingGitlab && <MenuItem disabled={true} text='Fetching...' />) ||
+            (query.length <= 2 && <MenuItem disabled={true} text='Please type more than 2 characters to search.' />) ||
+            (isFetching && <MenuItem disabled={true} text='Fetching...' />) ||
             <MenuItem disabled={true} text='No Projects Available.' />
           }
           onRemove={(item) => {
@@ -149,7 +137,7 @@ const GitlabProjectsSelector = (props) => {
         />
 
         <Checkbox
-          label='only search repos joined' checked={onlyQueryMemberRepo}
+          label='Only search my repositories' checked={onlyQueryMemberRepo}
           onChange={e => setOnlyQueryMemberRepo(!onlyQueryMemberRepo)}
           style={{ margin: '10px 0 0 6px' }}
         />

--- a/config-ui/src/components/blueprints/GitlabProjectsSelector.jsx
+++ b/config-ui/src/components/blueprints/GitlabProjectsSelector.jsx
@@ -61,7 +61,7 @@ const GitlabProjectsSelector = (props) => {
         }}
       />
     ),
-    tagRenderer = (item) => item?.title,
+    tagRenderer = (item) => item.shortTitle || item.title
   } = props
 
   const [query, setQuery] = useState('')

--- a/config-ui/src/components/blueprints/GitlabProjectsSelector.jsx
+++ b/config-ui/src/components/blueprints/GitlabProjectsSelector.jsx
@@ -15,12 +15,10 @@
  * limitations under the License.
  *
  */
-import React, { useEffect, useMemo, useState } from 'react'
-import {
-  Intent,
-  MenuItem,
-} from '@blueprintjs/core'
-import { MultiSelect, Select } from '@blueprintjs/select'
+import React, { useEffect, useState } from 'react'
+import { Checkbox, Intent, MenuItem, } from '@blueprintjs/core'
+import { MultiSelect } from '@blueprintjs/select'
+
 const GitlabProjectsSelector = (props) => {
   const {
     fetchGitlabProjects = () => [],
@@ -67,14 +65,27 @@ const GitlabProjectsSelector = (props) => {
   } = props
 
   const [query, setQuery] = useState('')
+  const [onlyQueryMemberRepo, setOnlyQueryMemberRepo] = useState(true)
 
   useEffect(() => {
+    if (query.length <= 2) {
+      // only search when type more than 2 char or empty
+      return
+    }
     // prevent request too frequently
     const timer = setTimeout(() => {
-      fetchGitlabProjects(query)
+      fetchGitlabProjects(query, onlyQueryMemberRepo)
     }, 200)
     return () => clearTimeout(timer)
   }, [fetchGitlabProjects, query])
+
+  useEffect(() => {
+    if (query.length <= 2) {
+      // only search when type more than 2 char or empty
+      return
+    }
+    fetchGitlabProjects(query, onlyQueryMemberRepo)
+  }, [fetchGitlabProjects, onlyQueryMemberRepo])
 
   return (
     <div
@@ -107,9 +118,9 @@ const GitlabProjectsSelector = (props) => {
             },
           }}
           noResults={
-            isFetchingGitlab
-              ? <MenuItem disabled={true} text='Fetching' />
-              : <MenuItem disabled={true} text='No Projects Available.' />
+            (query.length <= 2 && <MenuItem disabled={true} text='Please type more than 2 char to search.' />) ||
+            (isFetchingGitlab && <MenuItem disabled={true} text='Fetching...' />) ||
+            <MenuItem disabled={true} text='No Projects Available.' />
           }
           onRemove={(item) => {
             onRemove((rT) => {
@@ -135,6 +146,11 @@ const GitlabProjectsSelector = (props) => {
             })
           }}
           style={{ borderRight: 0 }}
+        />
+
+        <Checkbox
+          label='only search repos joined' checked={onlyQueryMemberRepo}
+          onChange={e => setOnlyQueryMemberRepo(!onlyQueryMemberRepo)}
         />
       </div>
     </div>

--- a/config-ui/src/components/blueprints/GitlabProjectsSelector.jsx
+++ b/config-ui/src/components/blueprints/GitlabProjectsSelector.jsx
@@ -151,6 +151,7 @@ const GitlabProjectsSelector = (props) => {
         <Checkbox
           label='only search repos joined' checked={onlyQueryMemberRepo}
           onChange={e => setOnlyQueryMemberRepo(!onlyQueryMemberRepo)}
+          style={{ margin: '10px 0 0 6px' }}
         />
       </div>
     </div>

--- a/config-ui/src/components/blueprints/GitlabProjectsSelector.jsx
+++ b/config-ui/src/components/blueprints/GitlabProjectsSelector.jsx
@@ -21,8 +21,8 @@ import { MultiSelect } from '@blueprintjs/select'
 
 const GitlabProjectsSelector = (props) => {
   const {
-    fetchGitlabProjects: onFetch = () => [],
-    isFetchingGitlab: isFetching = false,
+    onFetch = () => [],
+    isFetching = false,
     configuredConnection,
     placeholder = 'Select Projects',
     items = [],

--- a/config-ui/src/components/blueprints/GitlabProjectsSelector.jsx
+++ b/config-ui/src/components/blueprints/GitlabProjectsSelector.jsx
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import React, { useEffect, useMemo, useState } from 'react'
+import {
+  Intent,
+  MenuItem,
+} from '@blueprintjs/core'
+import { MultiSelect, Select } from '@blueprintjs/select'
+const GitlabProjectsSelector = (props) => {
+  const {
+    fetchGitlabProjects = () => [],
+    isFetchingGitlab = false,
+    configuredConnection,
+    placeholder = 'Select Projects',
+    items = [],
+    selectedItems = [],
+    activeItem = null,
+    disabled = false,
+    isLoading = false,
+    isSaving = false,
+    onItemSelect = () => {},
+    onRemove = () => {},
+    onClear = () => {},
+    itemRenderer = (item, { handleClick, modifiers }) => (
+      <MenuItem
+        active={modifiers.active}
+        disabled={
+          selectedItems.find(i => i?.id === item?.id)
+        }
+        key={item.value}
+        onClick={handleClick}
+        text={
+          selectedItems.find(i => i?.id === item?.id)
+            ? (
+              <>
+                <input type='checkbox' checked readOnly /> {item?.title}
+              </>
+              )
+            : (
+              <span style={{ fontWeight: 700 }}>
+                <input type='checkbox' readOnly /> {item?.title}
+              </span>
+              )
+        }
+        style={{
+          marginBottom: '2px',
+          fontWeight: items.includes(item) ? 700 : 'normal',
+        }}
+      />
+    ),
+    tagRenderer = (item) => item?.title,
+  } = props
+
+  const [query, setQuery] = useState('')
+
+  useEffect(() => {
+    // prevent request too frequently
+    const timer = setTimeout(() => {
+      fetchGitlabProjects(query)
+    }, 200)
+    return () => clearTimeout(timer)
+  }, [fetchGitlabProjects, query])
+
+  return (
+    <div
+      className='gitlab-projects-multiselect'
+      style={{ display: 'flex', marginBottom: '10px' }}
+    >
+      <div
+        className='gitlab-projects-multiselect-selector'
+        style={{ minWidth: '200px', width: '100%' }}
+      >
+        <MultiSelect
+          disabled={disabled || isSaving || isLoading}
+          // openOnKeyDown={true}
+          resetOnSelect={true}
+          placeholder={placeholder}
+          popoverProps={{ usePortal: false, minimal: true }}
+          className='multiselector-projects'
+          inline={true}
+          fill={true}
+          items={items}
+          selectedItems={selectedItems}
+          activeItem={activeItem}
+          onQueryChange={query => setQuery(query)}
+          itemRenderer={itemRenderer}
+          tagRenderer={tagRenderer}
+          tagInputProps={{
+            tagProps: {
+              intent: Intent.PRIMARY,
+              minimal: true
+            },
+          }}
+          noResults={
+            isFetchingGitlab
+              ? <MenuItem disabled={true} text='Fetching' />
+              : <MenuItem disabled={true} text='No Projects Available.' />
+          }
+          onRemove={(item) => {
+            onRemove((rT) => {
+              return {
+                ...rT,
+                [configuredConnection.id]: rT[configuredConnection.id].filter(
+                  (t) => t?.id !== item.id
+                ),
+              }
+            })
+          }}
+          onItemSelect={(item) => {
+            onItemSelect((rT) => {
+              return !rT[configuredConnection.id].includes(item)
+                ? {
+                    ...rT,
+                    [configuredConnection.id]: [
+                      ...rT[configuredConnection.id],
+                      item,
+                    ],
+                  }
+                : { ...rT }
+            })
+          }}
+          style={{ borderRight: 0 }}
+        />
+      </div>
+    </div>
+  )
+}
+
+export default GitlabProjectsSelector

--- a/config-ui/src/components/blueprints/StandardStackedList.jsx
+++ b/config-ui/src/components/blueprints/StandardStackedList.jsx
@@ -68,7 +68,7 @@ const StandardStackedList = (props) => {
                     onClick={() => onAdd(item)}
                     style={{ cursor: 'pointer' }}
                   >
-                    {item?.name || item}
+                    {item.title}
                   </label>
                 </div>
               </div>

--- a/config-ui/src/components/blueprints/StandardStackedList.jsx
+++ b/config-ui/src/components/blueprints/StandardStackedList.jsx
@@ -70,17 +70,20 @@ const StandardStackedList = (props) => {
                     style={{ cursor: 'pointer' }}
                   >
                     {item.shortTitle || item.icon
-                      ? <Popover
+                      ? (
+                        <Popover
                           className='docs-popover-portal-example-popover'
                           interactionKind={PopoverInteractionKind.HOVER_TARGET_ONLY}
-                        // content={<div style={{ padding: '5px' }}>{item.title}</div>}
-                          content={<div style={{ padding: '5px', 'justify-content': 'center', display: 'flex' }}>
-                            {item.icon && <img src={item.icon} style={{ maxWidth: '100%', overflow: 'hidden', width: '14px', height: '14px', borderRadius: '50%', marginRight: '2px' }}/>}
-                            {item.title}
-                          </div>}
+                          content={
+                            <div style={{ padding: '5px', 'justify-content': 'center', display: 'flex' }}>
+                              {item.icon && <img src={item.icon} style={{ maxWidth: '100%', overflow: 'hidden', width: '14px', height: '14px', borderRadius: '50%', marginRight: '2px' }}/>}
+                              {item.title}
+                            </div>
+                          }
                         >
                           {item.shortTitle || item.title}
                         </Popover>
+                        )
                       : item.title}
                   </label>
                 </div>

--- a/config-ui/src/components/blueprints/StandardStackedList.jsx
+++ b/config-ui/src/components/blueprints/StandardStackedList.jsx
@@ -15,8 +15,7 @@
  * limitations under the License.
  *
  */
-import React, { Fragment, useEffect, useState, useCallback } from 'react'
-import { CSSTransition } from 'react-transition-group'
+import React from 'react'
 import {
   Button,
   Icon,
@@ -24,6 +23,8 @@ import {
   Elevation,
   Card,
   Colors,
+  Popover,
+  PopoverInteractionKind,
 } from '@blueprintjs/core'
 
 const StandardStackedList = (props) => {
@@ -68,7 +69,19 @@ const StandardStackedList = (props) => {
                     onClick={() => onAdd(item)}
                     style={{ cursor: 'pointer' }}
                   >
-                    {item.title}
+                    {item.shortTitle || item.icon
+                      ? <Popover
+                          className='docs-popover-portal-example-popover'
+                          interactionKind={PopoverInteractionKind.HOVER_TARGET_ONLY}
+                        // content={<div style={{ padding: '5px' }}>{item.title}</div>}
+                          content={<div style={{ padding: '5px', 'justify-content': 'center', display: 'flex' }}>
+                            {item.icon && <img src={item.icon} style={{ maxWidth: '100%', overflow: 'hidden', width: '14px', height: '14px', borderRadius: '50%', marginRight: '2px' }}/>}
+                            {item.title}
+                          </div>}
+                        >
+                          {item.shortTitle || item.title}
+                        </Popover>
+                      : item.title}
                   </label>
                 </div>
               </div>

--- a/config-ui/src/components/blueprints/create-workflow/DataScopes.jsx
+++ b/config-ui/src/components/blueprints/create-workflow/DataScopes.jsx
@@ -113,22 +113,28 @@ const DataScopes = (props) => {
                   </h3>
                   <Divider className='section-divider' />
 
-                  {[Providers.GITLAB, Providers.GITHUB].includes(
+                  {[Providers.GITHUB].includes(
                     configuredConnection.provider
                   ) && (
                     <>
                       <h4>Projects *</h4>
-                      {configuredConnection.provider === Providers.GITHUB && (<p>Enter the project names you would like to sync.</p>)}
+                      <p>Enter the project names you would like to sync.</p>
                       <TagInput
                         id='project-id'
                         disabled={isRunning}
                         placeholder='username/repo, username/another-repo'
-                        values={projects[configuredConnection.id] || []}
+                        values={projects[configuredConnection.id]?.map(p => p.value) || []}
                         fill={true}
                         onChange={(values) =>
                           setProjects((p) => ({
                             ...p,
-                            [configuredConnection.id]: [...new Set(values)],
+                            [configuredConnection.id]: [...values.map((v, vIdx) => ({
+                              id: v,
+                              key: v,
+                              title: v,
+                              value: v,
+                              type: 'string'
+                            }))],
                           }))}
                         addOnPaste={true}
                         addOnBlur={true}

--- a/config-ui/src/components/blueprints/create-workflow/DataScopes.jsx
+++ b/config-ui/src/components/blueprints/create-workflow/DataScopes.jsx
@@ -15,29 +15,14 @@
  * limitations under the License.
  *
  */
-import React, { Fragment, useEffect, useState, useCallback, useMemo } from 'react'
-import {
-  Button,
-  Icon,
-  Intent,
-  TagInput,
-  Divider,
-  Elevation,
-  Card,
-  Colors,
-} from '@blueprintjs/core'
-import {
-  Providers,
-  ProviderTypes,
-  ProviderIcons,
-  ConnectionStatus,
-  ConnectionStatusLabels,
-} from '@/data/Providers'
-
+import React, { useEffect, useMemo } from 'react'
+import { Button, Card, Divider, Elevation, Intent, TagInput, } from '@blueprintjs/core'
+import { ProviderIcons, Providers, } from '@/data/Providers'
 import ConnectionTabs from '@/components/blueprints/ConnectionTabs'
 import BoardsSelector from '@/components/blueprints/BoardsSelector'
 import DataEntitiesSelector from '@/components/blueprints/DataEntitiesSelector'
 import NoData from '@/components/NoData'
+import GitlabProjectsSelector from '@/components/blueprints/GitlabProjectsSelector'
 
 const DataScopes = (props) => {
   const {
@@ -46,6 +31,9 @@ const DataScopes = (props) => {
     blueprintConnections = [],
     dataEntitiesList = [],
     boardsList = [],
+    fetchGitlabProjects = () => [],
+    isFetchingGitlab = false,
+    gitlabProjects = [],
     dataEntities = [],
     projects = [],
     boards = [],
@@ -67,10 +55,15 @@ const DataScopes = (props) => {
   } = props
 
   const selectedBoards = useMemo(() => boards[configuredConnection.id], [boards, configuredConnection?.id])
+  const selectedProjects = useMemo(() => projects[configuredConnection.id], [projects, configuredConnection?.id])
 
   useEffect(() => {
     console.log('>> OVER HERE!!!', selectedBoards)
   }, [selectedBoards])
+
+  useEffect(() => {
+    console.log('>> OVER HERE FOR Projects!!!', selectedProjects)
+  }, [selectedProjects])
 
   return (
     <div className='workflow-step workflow-step-data-scope' data-step={activeStep?.id}>
@@ -126,15 +119,10 @@ const DataScopes = (props) => {
                     <>
                       <h4>Projects *</h4>
                       {configuredConnection.provider === Providers.GITHUB && (<p>Enter the project names you would like to sync.</p>)}
-                      {configuredConnection.provider === Providers.GITLAB && (<p>Enter the project ids you would like to sync.</p>)}
                       <TagInput
                         id='project-id'
                         disabled={isRunning}
-                        placeholder={
-                          configuredConnection.provider === Providers.GITHUB
-                            ? 'username/repo, username/another-repo'
-                            : '1000000, 200000'
-                        }
+                        placeholder='username/repo, username/another-repo'
                         values={projects[configuredConnection.id] || []}
                         fill={true}
                         onChange={(values) =>
@@ -177,6 +165,25 @@ const DataScopes = (props) => {
                         onItemSelect={setBoards}
                         onClear={setBoards}
                         onRemove={setBoards}
+                        disabled={isSaving}
+                        configuredConnection={configuredConnection}
+                        isLoading={isFetching}
+                      />
+                    </>
+                  )}
+
+                  {[Providers.GITLAB].includes(configuredConnection.provider) && (
+                    <>
+                      <h4>Projects *</h4>
+                      <p>Select the project you would like to sync.</p>
+                      <GitlabProjectsSelector
+                        fetchGitlabProjects={fetchGitlabProjects}
+                        isFetchingGitlab={isFetchingGitlab}
+                        items={gitlabProjects}
+                        selectedItems={selectedProjects}
+                        onItemSelect={setProjects}
+                        onClear={setProjects}
+                        onRemove={setProjects}
                         disabled={isSaving}
                         configuredConnection={configuredConnection}
                         isLoading={isFetching}

--- a/config-ui/src/components/blueprints/create-workflow/DataScopes.jsx
+++ b/config-ui/src/components/blueprints/create-workflow/DataScopes.jsx
@@ -183,8 +183,8 @@ const DataScopes = (props) => {
                       <h4>Projects *</h4>
                       <p>Select the project you would like to sync.</p>
                       <GitlabProjectsSelector
-                        fetchGitlabProjects={fetchGitlabProjects}
-                        isFetchingGitlab={isFetchingGitlab}
+                        onFetch={fetchGitlabProjects}
+                        isFetching={isFetchingGitlab}
                         items={gitlabProjects}
                         selectedItems={selectedProjects}
                         onItemSelect={setProjects}

--- a/config-ui/src/components/blueprints/create-workflow/DataTransformations.jsx
+++ b/config-ui/src/components/blueprints/create-workflow/DataTransformations.jsx
@@ -101,8 +101,8 @@ const DataTransformations = (props) => {
 
   const [entityList, setEntityList] = useState(boardsAndProjects?.map((e, eIdx) => ({
     id: eIdx,
-    value: e?.value || e,
-    title: e?.title || e,
+    value: e?.value,
+    title: e?.title,
     entity: e,
     type: typeof e === 'object' ? 'board' : 'project'
   })))
@@ -308,7 +308,7 @@ const DataTransformations = (props) => {
                       {!useDropdownSelector && (
                         <>
                           <h4>Project</h4>
-                          <p style={{ color: '#292B3F' }}>{configuredProject || configuredBoard?.name || '< select a project >'}</p>
+                          <p style={{ color: '#292B3F' }}>{configuredProject?.title || configuredBoard?.title || '< select a project >'}</p>
                         </>
                       )}
                       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>

--- a/config-ui/src/config/gitlabApiProxy.js
+++ b/config-ui/src/config/gitlabApiProxy.js
@@ -17,7 +17,7 @@
  */
 // @todo: add string replacer for [:connectionId] or refactor this const
 const GITLAB_API_PROXY_ENDPOINT = '/api/plugins/gitlab/connections/[:connectionId:]/proxy/rest'
-const PROJECTS_ENDPOINT = `${GITLAB_API_PROXY_ENDPOINT}/projects?search=[:search:]&membership=1`
+const PROJECTS_ENDPOINT = `${GITLAB_API_PROXY_ENDPOINT}/projects?search=[:search:]&membership=[:membership:]`
 
 export {
   GITLAB_API_PROXY_ENDPOINT,

--- a/config-ui/src/config/gitlabApiProxy.js
+++ b/config-ui/src/config/gitlabApiProxy.js
@@ -15,17 +15,11 @@
  * limitations under the License.
  *
  */
-const JIRA_API_VERSION = 2
 // @todo: add string replacer for [:connectionId] or refactor this const
-const JIRA_API_PROXY_ENDPOINT = '/api/plugins/jira/connections/[:connectionId:]/proxy/rest'
-const ISSUE_TYPES_ENDPOINT = `${JIRA_API_PROXY_ENDPOINT}/api/${JIRA_API_VERSION}/issuetype`
-const ISSUE_FIELDS_ENDPOINT = `${JIRA_API_PROXY_ENDPOINT}/api/${JIRA_API_VERSION}/field`
-const BOARDS_ENDPOINT = `${JIRA_API_PROXY_ENDPOINT}/agile/1.0/board`
+const GITLAB_API_PROXY_ENDPOINT = '/api/plugins/gitlab/connections/[:connectionId:]/proxy/rest'
+const PROJECTS_ENDPOINT = `${GITLAB_API_PROXY_ENDPOINT}/projects?search=[:search:]&membership=1`
 
 export {
-  JIRA_API_VERSION,
-  JIRA_API_PROXY_ENDPOINT,
-  ISSUE_TYPES_ENDPOINT,
-  ISSUE_FIELDS_ENDPOINT,
-  BOARDS_ENDPOINT,
+  GITLAB_API_PROXY_ENDPOINT,
+  PROJECTS_ENDPOINT,
 }

--- a/config-ui/src/hooks/useBlueprintValidation.jsx
+++ b/config-ui/src/hooks/useBlueprintValidation.jsx
@@ -84,9 +84,9 @@ function useBlueprintValidation ({
     return Array.isArray(set) ? set.every(i => !isNaN(i)) : false
   }, [])
 
-  const validateRepositoryName = useCallback((set = []) => {
+  const validateRepositoryName = useCallback((projects = []) => {
     const repoRegExp = /([a-z0-9_-]){2,}\/([a-z0-9_-]){2,}$/gi
-    return set.every(i => i.match(repoRegExp))
+    return projects.every(p => p.value.match(repoRegExp))
   }, [])
 
   const valiateNonEmptySet = useCallback((set = []) => {
@@ -151,9 +151,6 @@ function useBlueprintValidation ({
           if (activeProvider?.id === Providers.GITLAB && projects[activeConnection?.id]?.length === 0) {
             errs.push('Projects: No Project IDs entered.')
           }
-          if (activeProvider?.id === Providers.GITLAB && !validateNumericSet(projects[activeConnection?.id])) {
-            errs.push('Projects: Only Numeric Project IDs are supported.')
-          }
 
           connections.forEach(c => {
             if (c.provider === Providers.JIRA && boards[c?.id]?.length === 0) {
@@ -167,9 +164,6 @@ function useBlueprintValidation ({
             }
             if (c.provider === Providers.GITLAB && projects[c?.id]?.length === 0) {
               errs.push(`${c.name} requires Project IDs`)
-            }
-            if (c.provider === Providers.GITLAB && !validateNumericSet(projects[c?.id])) {
-              errs.push(`${c.name} has invalid Project ID`)
             }
             if (entities[c?.id]?.length === 0) {
               errs.push(`${c.name} is missing Data Entities`)

--- a/config-ui/src/hooks/useDataScopesManager.jsx
+++ b/config-ui/src/hooks/useDataScopesManager.jsx
@@ -127,6 +127,7 @@ function useDataScopesManager ({ provider, blueprint, /* connection, */ settings
             ...newScope,
             options: {
               boardId: Number(b?.id),
+              title: b.title
               // @todo: verify initial value of since date for jira provider
               // since: new Date(),
             },
@@ -137,7 +138,8 @@ function useDataScopesManager ({ provider, blueprint, /* connection, */ settings
           newScope = projects[connection.id]?.map((p) => ({
             ...newScope,
             options: {
-              projectId: Number(p),
+              projectId: Number(p.value),
+              title: p.title
             },
             transformation: {},
           }))
@@ -154,8 +156,8 @@ function useDataScopesManager ({ provider, blueprint, /* connection, */ settings
           newScope = projects[connection.id]?.map((p) => ({
             ...newScope,
             options: {
-              owner: p.split('/')[0],
-              repo: p.split('/')[1],
+              owner: p.value.split('/')[0],
+              repo: p.value.split('/')[1],
             },
             transformation: { ...transformations[p] },
           }))

--- a/config-ui/src/hooks/useDataScopesManager.jsx
+++ b/config-ui/src/hooks/useDataScopesManager.jsx
@@ -126,7 +126,7 @@ function useDataScopesManager ({ provider, blueprint, /* connection, */ settings
           newScope = boards[connection.id]?.map((b) => ({
             ...newScope,
             options: {
-              boardId: Number(b?.id),
+              boardId: Number(b?.value),
               title: b.title
               // @todo: verify initial value of since date for jira provider
               // since: new Date(),

--- a/config-ui/src/hooks/useGitlab.jsx
+++ b/config-ui/src/hooks/useGitlab.jsx
@@ -54,12 +54,19 @@ const useGitlab = ({ apiProxyPath, projectsEndpoint }, activeConnection = null) 
     }
   }, [projectsEndpoint, activeConnection, apiProxyPath])
 
-  const createListData = (data = [], titleProperty = 'name_with_namespace', valueProperty = 'id') => {
+  const createListData = (
+    data = [],
+    titleProperty = 'name_with_namespace',
+    valueProperty = 'id',
+    iconProperty = 'avatar_url',
+  ) => {
     return data.map((d, dIdx) => ({
       id: d[valueProperty],
       key: d[valueProperty],
       title: d[titleProperty],
+      shortTitle: d.name,
       value: d[valueProperty],
+      icon: d[iconProperty],
       type: 'string'
     }))
   }

--- a/config-ui/src/hooks/useGitlab.jsx
+++ b/config-ui/src/hooks/useGitlab.jsx
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import { useEffect, useState, useCallback } from 'react'
+import request from '@/utils/request'
+import { ToastNotification } from '@/components/Toast'
+
+const useGitlab = ({ apiProxyPath, projectsEndpoint }, activeConnection = null) => {
+  const [isFetching, setIsFetching] = useState(false)
+  const [projects, setProjects] = useState([])
+  const [error, setError] = useState()
+
+  const fetchProjects = useCallback(async (search = '') => {
+    try {
+      if (apiProxyPath.includes('null')) {
+        throw new Error('Connection ID is Null')
+      }
+      setError(null)
+      setIsFetching(true)
+      const endpoint = projectsEndpoint
+        .replace('[:connectionId:]', activeConnection?.connectionId)
+        .replace('[:search:]', search)
+      const projectsResponse = await request.get(endpoint)
+      if (projectsResponse && projectsResponse.status === 200 && projectsResponse.data) {
+        setProjects(createListData(projectsResponse.data))
+      } else {
+        throw new Error('request projects fail')
+      }
+    } catch (e) {
+      setError(e)
+      ToastNotification.show({ message: e.message, intent: 'danger', icon: 'error' })
+    } finally {
+      setIsFetching(false)
+    }
+  }, [projectsEndpoint, activeConnection, apiProxyPath])
+
+  const createListData = (data = [], titleProperty = 'name_with_namespace', valueProperty = 'name') => {
+    return data.map((d, dIdx) => ({
+      id: d.id || dIdx,
+      key: d.key ? d.key : dIdx,
+      title: d[titleProperty],
+      value: d[valueProperty],
+      type: 'string'
+    }))
+  }
+
+  useEffect(() => {
+    console.log('>>> GITLAB API PROXY: FIELD SELECTOR PROJECTS DATA', projects)
+  }, [projects])
+
+  return {
+    isFetching,
+    fetchProjects,
+    projects,
+    error
+  }
+}
+
+export default useGitlab

--- a/config-ui/src/hooks/useGitlab.jsx
+++ b/config-ui/src/hooks/useGitlab.jsx
@@ -24,7 +24,7 @@ const useGitlab = ({ apiProxyPath, projectsEndpoint }, activeConnection = null) 
   const [projects, setProjects] = useState([])
   const [error, setError] = useState()
 
-  const fetchProjects = useCallback(async (search = '') => {
+  const fetchProjects = useCallback(async (search = '', onlyQueryMemberRepo = true) => {
     try {
       if (apiProxyPath.includes('null')) {
         throw new Error('Connection ID is Null')
@@ -34,6 +34,7 @@ const useGitlab = ({ apiProxyPath, projectsEndpoint }, activeConnection = null) 
       const endpoint = projectsEndpoint
         .replace('[:connectionId:]', activeConnection?.connectionId)
         .replace('[:search:]', search)
+        .replace('[:membership:]', onlyQueryMemberRepo ? 1 : 0)
       const projectsResponse = await request.get(endpoint)
       if (projectsResponse && projectsResponse.status === 200 && projectsResponse.data) {
         setProjects(createListData(projectsResponse.data))
@@ -48,10 +49,10 @@ const useGitlab = ({ apiProxyPath, projectsEndpoint }, activeConnection = null) 
     }
   }, [projectsEndpoint, activeConnection, apiProxyPath])
 
-  const createListData = (data = [], titleProperty = 'name_with_namespace', valueProperty = 'name') => {
+  const createListData = (data = [], titleProperty = 'name_with_namespace', valueProperty = 'id') => {
     return data.map((d, dIdx) => ({
-      id: d.id || dIdx,
-      key: d.key ? d.key : dIdx,
+      id: d[valueProperty],
+      key: d[valueProperty],
       title: d[titleProperty],
       value: d[valueProperty],
       type: 'string'

--- a/config-ui/src/hooks/useGitlab.jsx
+++ b/config-ui/src/hooks/useGitlab.jsx
@@ -31,15 +31,20 @@ const useGitlab = ({ apiProxyPath, projectsEndpoint }, activeConnection = null) 
       }
       setError(null)
       setIsFetching(true)
-      const endpoint = projectsEndpoint
-        .replace('[:connectionId:]', activeConnection?.connectionId)
-        .replace('[:search:]', search)
-        .replace('[:membership:]', onlyQueryMemberRepo ? 1 : 0)
-      const projectsResponse = await request.get(endpoint)
-      if (projectsResponse && projectsResponse.status === 200 && projectsResponse.data) {
-        setProjects(createListData(projectsResponse.data))
+      if (search.length > 2) {
+        // only search when type more than 2 chars
+        const endpoint = projectsEndpoint
+          .replace('[:connectionId:]', activeConnection?.connectionId)
+          .replace('[:search:]', search)
+          .replace('[:membership:]', onlyQueryMemberRepo ? 1 : 0)
+        const projectsResponse = await request.get(endpoint)
+        if (projectsResponse && projectsResponse.status === 200 && projectsResponse.data) {
+          setProjects(createListData(projectsResponse.data))
+        } else {
+          throw new Error('request projects fail')
+        }
       } else {
-        throw new Error('request projects fail')
+        setProjects([])
       }
     } catch (e) {
       setError(e)

--- a/config-ui/src/hooks/useJIRA.jsx
+++ b/config-ui/src/hooks/useJIRA.jsx
@@ -155,9 +155,8 @@ const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint, boardsEndpoint 
 
   const createListData = (data = [], titleProperty = 'name', valueProperty = 'name') => {
     return data.map((d, dIdx) => ({
-      ...d,
-      id: d.id || dIdx,
-      key: d.key ? d.key : dIdx,
+      id: d[valueProperty],
+      key: d[valueProperty],
       title: d[titleProperty],
       value: d[valueProperty],
       type: d.schema?.type || 'string'

--- a/config-ui/src/hooks/useJIRA.jsx
+++ b/config-ui/src/hooks/useJIRA.jsx
@@ -159,6 +159,7 @@ const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint, boardsEndpoint 
       key: d[valueProperty],
       title: d[titleProperty],
       value: d[valueProperty],
+      icon: d?.location?.avatarURI,
       type: d.schema?.type || 'string'
     }))
   }

--- a/config-ui/src/hooks/useJIRA.jsx
+++ b/config-ui/src/hooks/useJIRA.jsx
@@ -153,7 +153,7 @@ const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint, boardsEndpoint 
     activeConnection,
     apiProxyPath])
 
-  const createListData = (data = [], titleProperty = 'name', valueProperty = 'name') => {
+  const createListData = (data = [], titleProperty = 'name', valueProperty = 'id') => {
     return data.map((d, dIdx) => ({
       id: d[valueProperty],
       key: d[valueProperty],
@@ -174,7 +174,7 @@ const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint, boardsEndpoint 
   }, [fieldsResponse])
 
   useEffect(() => {
-    setBoards(boardsResponse ? createListData(boardsResponse, 'name', 'name') : [])
+    setBoards(boardsResponse ? createListData(boardsResponse, 'name', 'id') : [])
   }, [boardsResponse])
 
   useEffect(() => {

--- a/config-ui/src/pages/blueprints/blueprint-settings.jsx
+++ b/config-ui/src/pages/blueprints/blueprint-settings.jsx
@@ -72,8 +72,8 @@ import BlueprintDataScopesDialog from '@/components/blueprints/BlueprintDataScop
 import BlueprintNavigationLinks from '@/components/blueprints/BlueprintNavigationLinks'
 import DataScopesGrid from '@/components/blueprints/DataScopesGrid'
 import AdvancedJSON from '@/components/blueprints/create-workflow/AdvancedJSON'
-import useGitlab from "@/hooks/useGitlab";
-import { PROJECTS_ENDPOINT } from "@/config/gitlabApiProxy";
+import useGitlab from '@/hooks/useGitlab'
+import { PROJECTS_ENDPOINT } from '@/config/gitlabApiProxy'
 
 const BlueprintSettings = (props) => {
   // eslint-disable-next-line no-unused-vars
@@ -607,13 +607,28 @@ const BlueprintSettings = (props) => {
       : []
     // @todo: handle multi-stage
     const getAdvancedGithubProjects = (t, providerId) => [Providers.GITHUB].includes(providerId)
-      ? [`${t.options?.owner}/${t.options?.repo}`]
+      ? [{
+          id: `${t.options.owner}/${t.options?.repo}`,
+          key: `${t.options.owner}/${t.options?.repo}`,
+          value: `${t.options.owner}/${t.options?.repo}`,
+          title: `${t.options.owner}/${t.options?.repo}`,
+        }]
       : []
     const getAdvancedGitlabProjects = (t, providerId) => [Providers.GITLAB].includes(providerId)
-      ? [t.options?.projectId]
+      ? [{
+          id: t.options?.projectId,
+          key: t.options?.projectId,
+          value: t.options?.projectId,
+          title: t.options?.title || `Project ${t.options?.projectId}`,
+        }]
       : []
     const getAdvancedJiraBoards = (t, providerId) => [Providers.JIRA].includes(providerId)
-      ? [t.options?.boardId]
+      ? [{
+          id: t.options?.boardId,
+          key: t.options?.boardId,
+          value: t.options?.boardId,
+          title: t.options?.title || `Board ${t.options?.boardId}`,
+        }]
       : []
     // @todo: migrate to data scopes manager
     if (activeBlueprint?.id && activeBlueprint?.mode === BlueprintMode.NORMAL) {
@@ -684,8 +699,8 @@ const BlueprintSettings = (props) => {
           boardIds: [Providers.JIRA].includes(c.plugin)
             ? getAdvancedJiraBoards(c, c.plugin)
             : [],
-          boardList: [Providers.JIRA].includes(c.plugin)
-            ? getAdvancedJiraBoards(c, c.plugin).map(bId => `Board ${bId}`)
+          boardsList: [Providers.JIRA].includes(c.plugin)
+            ? getAdvancedJiraBoards(c, c.plugin)
             : [],
           transformations: {},
           // transformationStates: ['-'],

--- a/config-ui/src/pages/blueprints/blueprint-settings.jsx
+++ b/config-ui/src/pages/blueprints/blueprint-settings.jsx
@@ -651,7 +651,7 @@ const BlueprintSettings = (props) => {
             ? getGitlabProjects(c)
             : getGithubProjects(c),
           boards: [Providers.JIRA].includes(c.plugin)
-            ? c.scope.map((s) => `Board ${s.options?.boardId}`)
+            ? c.scope.map((s) => s.options?.title || `Board ${s.options?.boardId}`)
             : [],
           boardIds: [Providers.JIRA].includes(c.plugin)
             ? c.scope.map((s) => s.options?.boardId)
@@ -694,7 +694,7 @@ const BlueprintSettings = (props) => {
           entities: ['-'],
           entitityList: getDefaultEntities(c.plugin),
           boards: [Providers.JIRA].includes(c.plugin)
-            ? getAdvancedJiraBoards(c, c.plugin).map(bId => `Board ${bId}`)
+            ? getAdvancedJiraBoards(c, c.plugin).map(board => board.title)
             : [],
           boardIds: [Providers.JIRA].includes(c.plugin)
             ? getAdvancedJiraBoards(c, c.plugin)

--- a/config-ui/src/pages/blueprints/blueprint-settings.jsx
+++ b/config-ui/src/pages/blueprints/blueprint-settings.jsx
@@ -20,7 +20,7 @@ import { useParams, useHistory } from 'react-router-dom'
 import { ENVIRONMENT } from '@/config/environment'
 import dayjs from '@/utils/time'
 import {
-  API_PROXY_ENDPOINT,
+  JIRA_API_PROXY_ENDPOINT,
   ISSUE_TYPES_ENDPOINT,
   ISSUE_FIELDS_ENDPOINT,
   BOARDS_ENDPOINT,
@@ -288,7 +288,7 @@ const BlueprintSettings = (props) => {
     error: jiraProxyError,
   } = useJIRA(
     {
-      apiProxyPath: API_PROXY_ENDPOINT,
+      apiProxyPath: JIRA_API_PROXY_ENDPOINT,
       issuesEndpoint: ISSUE_TYPES_ENDPOINT,
       fieldsEndpoint: ISSUE_FIELDS_ENDPOINT,
       boardsEndpoint: BOARDS_ENDPOINT,

--- a/config-ui/src/pages/blueprints/blueprint-settings.jsx
+++ b/config-ui/src/pages/blueprints/blueprint-settings.jsx
@@ -73,7 +73,7 @@ import BlueprintNavigationLinks from '@/components/blueprints/BlueprintNavigatio
 import DataScopesGrid from '@/components/blueprints/DataScopesGrid'
 import AdvancedJSON from '@/components/blueprints/create-workflow/AdvancedJSON'
 import useGitlab from '@/hooks/useGitlab'
-import { PROJECTS_ENDPOINT } from '@/config/gitlabApiProxy'
+import { GITLAB_API_PROXY_ENDPOINT, PROJECTS_ENDPOINT } from '@/config/gitlabApiProxy'
 
 const BlueprintSettings = (props) => {
   // eslint-disable-next-line no-unused-vars
@@ -305,7 +305,7 @@ const BlueprintSettings = (props) => {
     error: gitlabProxyError,
   } = useGitlab(
     {
-      apiProxyPath: JIRA_API_PROXY_ENDPOINT,
+      apiProxyPath: GITLAB_API_PROXY_ENDPOINT,
       projectsEndpoint: PROJECTS_ENDPOINT,
     },
     configuredConnection
@@ -608,10 +608,10 @@ const BlueprintSettings = (props) => {
     // @todo: handle multi-stage
     const getAdvancedGithubProjects = (t, providerId) => [Providers.GITHUB].includes(providerId)
       ? [{
-          id: `${t.options.owner}/${t.options?.repo}`,
-          key: `${t.options.owner}/${t.options?.repo}`,
-          value: `${t.options.owner}/${t.options?.repo}`,
-          title: `${t.options.owner}/${t.options?.repo}`,
+          id: `${t.options?.owner}/${t.options?.repo}`,
+          key: `${t.options?.owner}/${t.options?.repo}`,
+          value: `${t.options?.owner}/${t.options?.repo}`,
+          title: `${t.options?.owner}/${t.options?.repo}`,
         }]
       : []
     const getAdvancedGitlabProjects = (t, providerId) => [Providers.GITLAB].includes(providerId)

--- a/config-ui/src/pages/blueprints/blueprint-settings.jsx
+++ b/config-ui/src/pages/blueprints/blueprint-settings.jsx
@@ -72,6 +72,8 @@ import BlueprintDataScopesDialog from '@/components/blueprints/BlueprintDataScop
 import BlueprintNavigationLinks from '@/components/blueprints/BlueprintNavigationLinks'
 import DataScopesGrid from '@/components/blueprints/DataScopesGrid'
 import AdvancedJSON from '@/components/blueprints/create-workflow/AdvancedJSON'
+import useGitlab from "@/hooks/useGitlab";
+import { PROJECTS_ENDPOINT } from "@/config/gitlabApiProxy";
 
 const BlueprintSettings = (props) => {
   // eslint-disable-next-line no-unused-vars
@@ -296,6 +298,19 @@ const BlueprintSettings = (props) => {
     configuredConnection
   )
 
+  const {
+    fetchProjects: fetchGitlabProjects,
+    projects: gitlabProjects,
+    isFetching: isFetchingGitlab,
+    error: gitlabProxyError,
+  } = useGitlab(
+    {
+      apiProxyPath: JIRA_API_PROXY_ENDPOINT,
+      projectsEndpoint: PROJECTS_ENDPOINT,
+    },
+    configuredConnection
+  )
+
   const handleBlueprintActivation = useCallback(
     (blueprint) => {
       if (blueprint.enable) {
@@ -454,7 +469,7 @@ const BlueprintSettings = (props) => {
               break
             case Providers.GITLAB:
               isValid = Array.isArray(projects[configuredConnection?.id]) &&
-              validateNumericSet(projects[configuredConnection?.id]) &&
+                projects[configuredConnection?.id]?.length > 0 &&
               entities[configuredConnection?.id]?.length > 0
               break
             case Providers.JIRA:
@@ -529,17 +544,13 @@ const BlueprintSettings = (props) => {
   }, [setConfiguredBoard])
 
   // @todo: lift higher to dsm hook
-  const getJiraMappedBoards = useCallback((boardIds = [], boardListItems = []) => {
-    return boardIds.map((bId, sIdx) => {
-      const boardObject = boardListItems.find(apiBoard => Number(apiBoard.id) === Number(bId))
+  const getJiraMappedBoards = useCallback((options = []) => {
+    return options.map(({ boardId, title }, sIdx) => {
       return {
-        ...boardObject,
-        id: boardObject?.id || bId || sIdx + 1,
-        key: sIdx,
-        value: boardObject?.name || `Board ${bId}`,
-        title: boardObject?.name || `Board ${bId}`,
-        type: boardObject?.type || 'scrum',
-        self: `https://${scopeConnection?.endpoint}agile/1.0/board/${bId}`
+        id: boardId,
+        key: boardId,
+        value: boardId,
+        title: title || `Board ${boardId}`,
       }
     })
   }, [scopeConnection?.endpoint])
@@ -579,10 +590,20 @@ const BlueprintSettings = (props) => {
   useEffect(() => {
     console.log('>>> ACTIVE BLUEPRINT ....', activeBlueprint)
     const getGithubProjects = (c) => [Providers.GITHUB].includes(c.plugin)
-      ? c.scope.map((s) => `${s.options.owner}/${s.options?.repo}`)
+      ? c.scope.map((s) => ({
+        id: `${s.options.owner}/${s.options?.repo}`,
+        key: `${s.options.owner}/${s.options?.repo}`,
+        value: `${s.options.owner}/${s.options?.repo}`,
+        title: `${s.options.owner}/${s.options?.repo}`,
+      }))
       : []
     const getGitlabProjects = (c) => [Providers.GITLAB].includes(c.plugin)
-      ? c.scope.map((s) => s.options?.projectId)
+      ? c.scope.map((s) => ({
+        id: s.options?.projectId,
+        key: s.options?.projectId,
+        value: s.options?.projectId,
+        title: s.options?.title || `Project ${s.options?.projectId}`,
+      }))
       : []
     // @todo: handle multi-stage
     const getAdvancedGithubProjects = (t, providerId) => [Providers.GITHUB].includes(providerId)
@@ -620,7 +641,7 @@ const BlueprintSettings = (props) => {
           boardIds: [Providers.JIRA].includes(c.plugin)
             ? c.scope.map((s) => s.options?.boardId)
             : [],
-          boardsList: allJiraResources?.boards ? getJiraMappedBoards(c.scope.map((s) => s.options?.boardId), allJiraResources?.boards) : [],
+          boardsList: getJiraMappedBoards(c.scope.map((s) => s.options)),
           transformations: c.scope.map((s) => ({ ...s.transformation })),
           transformationStates: c.scope.map((s) =>
             Object.values(s.transformation).some((v) => Array.isArray(v) ? v.length > 0 : (v && typeof v === 'object' ? Object.keys(v)?.length > 0 : v?.toString().length > 0))
@@ -1190,7 +1211,7 @@ const BlueprintSettings = (props) => {
                       blueprint={activeBlueprint}
                       onModify={modifyConnection}
                       mode={activeBlueprint?.mode}
-                      loading={isFetchingBlueprint || isFetchingJIRA}
+                      loading={isFetchingBlueprint || isFetchingJIRA || isFetchingGitlab}
                     />
                   </div>
                 )
@@ -1228,7 +1249,7 @@ const BlueprintSettings = (props) => {
                     onModify={() => modifySetting('plan')}
                     mode={activeBlueprint?.mode}
                     classNames={['advanced-mode-grid']}
-                    loading={isFetchingBlueprint || isFetchingJIRA}
+                    loading={isFetchingBlueprint || isFetchingJIRA || isFetchingGitlab}
                   />
                 </div>
                 )}
@@ -1355,6 +1376,10 @@ const BlueprintSettings = (props) => {
         fieldsList={jiraApiFields}
         isFetching={isFetchingBlueprint}
         isFetchingJIRA={isFetchingJIRA}
+        fetchGitlabProjects={fetchGitlabProjects}
+        gitlabProjects={gitlabProjects}
+        isFetchingGitlab={isFetchingGitlab}
+        gitlabProxyError={gitlabProxyError}
         setConfiguredProject={setConfiguredProject}
         setConfiguredBoard={setConfiguredBoard}
         setBoards={setBoards}

--- a/config-ui/src/pages/blueprints/create-blueprint.jsx
+++ b/config-ui/src/pages/blueprints/create-blueprint.jsx
@@ -70,7 +70,7 @@ import AdvancedJSON from '@/components/blueprints/create-workflow/AdvancedJSON'
 import { DEVLAKE_ENDPOINT } from '@/utils/config'
 import request from '@/utils/request'
 import useGitlab from '@/hooks/useGitlab'
-import { PROJECTS_ENDPOINT } from '@/config/gitlabApiProxy'
+import { GITLAB_API_PROXY_ENDPOINT, PROJECTS_ENDPOINT } from '@/config/gitlabApiProxy'
 
 // import ConnectionTabs from '@/components/blueprints/ConnectionTabs'
 
@@ -258,7 +258,7 @@ const CreateBlueprint = (props) => {
     error: gitlabProxyError,
   } = useGitlab(
     {
-      apiProxyPath: JIRA_API_PROXY_ENDPOINT,
+      apiProxyPath: GITLAB_API_PROXY_ENDPOINT,
       projectsEndpoint: PROJECTS_ENDPOINT,
     },
     configuredConnection

--- a/config-ui/src/pages/blueprints/create-blueprint.jsx
+++ b/config-ui/src/pages/blueprints/create-blueprint.jsx
@@ -20,7 +20,7 @@ import { CSSTransition } from 'react-transition-group'
 import { useHistory, useLocation, Link } from 'react-router-dom'
 import dayjs from '@/utils/time'
 import {
-  API_PROXY_ENDPOINT,
+  JIRA_API_PROXY_ENDPOINT,
   ISSUE_TYPES_ENDPOINT,
   ISSUE_FIELDS_ENDPOINT,
   BOARDS_ENDPOINT,
@@ -69,6 +69,8 @@ import AdvancedJSON from '@/components/blueprints/create-workflow/AdvancedJSON'
 
 import { DEVLAKE_ENDPOINT } from '@/utils/config'
 import request from '@/utils/request'
+import useGitlab from '@/hooks/useGitlab'
+import { PROJECTS_ENDPOINT } from '@/config/gitlabApiProxy'
 
 // import ConnectionTabs from '@/components/blueprints/ConnectionTabs'
 
@@ -241,10 +243,23 @@ const CreateBlueprint = (props) => {
     error: jiraProxyError,
   } = useJIRA(
     {
-      apiProxyPath: API_PROXY_ENDPOINT,
+      apiProxyPath: JIRA_API_PROXY_ENDPOINT,
       issuesEndpoint: ISSUE_TYPES_ENDPOINT,
       fieldsEndpoint: ISSUE_FIELDS_ENDPOINT,
       boardsEndpoint: BOARDS_ENDPOINT,
+    },
+    configuredConnection
+  )
+
+  const {
+    fetchProjects: fetchGitlabProjects,
+    projects: gitlabProjects,
+    isFetching: isFetchingGitlab,
+    error: gitlabProxyError,
+  } = useGitlab(
+    {
+      apiProxyPath: JIRA_API_PROXY_ENDPOINT,
+      projectsEndpoint: PROJECTS_ENDPOINT,
     },
     configuredConnection
   )
@@ -1034,6 +1049,9 @@ const CreateBlueprint = (props) => {
                       blueprintConnections={blueprintConnections}
                       dataEntitiesList={dataEntitiesList}
                       boardsList={boardsList}
+                      fetchGitlabProjects={fetchGitlabProjects}
+                      isFetchingGitlab={isFetchingGitlab}
+                      gitlabProjects={gitlabProjects}
                       boards={boards}
                       dataEntities={dataEntities}
                       projects={projects}
@@ -1046,6 +1064,7 @@ const CreateBlueprint = (props) => {
                       isSaving={isSaving}
                       isRunning={isRunning}
                       validationErrors={[...validationErrors, ...blueprintValidationErrors]}
+                      isFetching={isFetchingJIRA || isFetchingGitlab || isFetchingConnection}
                     />
                   )}
 
@@ -1058,7 +1077,6 @@ const CreateBlueprint = (props) => {
                       blueprintConnections={blueprintConnections}
                       dataEntities={dataEntities}
                       projects={projects}
-                      boardsList={boardsList}
                       boards={boards}
                       issueTypes={jiraApiIssueTypes}
                       fields={jiraApiFields}
@@ -1115,7 +1133,7 @@ const CreateBlueprint = (props) => {
               onPrev={prevStep}
               onSave={handleBlueprintSave}
               onSaveAndRun={handleBlueprintSaveAndRun}
-              isLoading={isSaving || isFetchingJIRA || isFetchingConnection || isTestingConnection}
+              isLoading={isSaving || isFetchingJIRA || isFetchingGitlab || isFetchingConnection || isTestingConnection}
               isValid={advancedMode ? isValidBlueprint && isValidPipeline : isValidBlueprint}
               canGoNext={canAdvanceNext}
             />

--- a/config-ui/src/pages/blueprints/create-blueprint.jsx
+++ b/config-ui/src/pages/blueprints/create-blueprint.jsx
@@ -365,7 +365,7 @@ const CreateBlueprint = (props) => {
     null
   )
 
-  const activeTransformation = useMemo(() => transformations[configuredProject || configuredBoard?.id], [transformations, configuredProject, configuredBoard?.id])
+  const activeTransformation = useMemo(() => transformations[configuredProject?.id || configuredBoard?.id], [transformations, configuredProject?.id, configuredBoard?.id])
 
   // eslint-disable-next-line no-unused-vars
   const isValidStep = useCallback((stepId) => { }, [])
@@ -477,7 +477,7 @@ const CreateBlueprint = (props) => {
     )
     setTransformations((existingTransformations) => ({
       ...existingTransformations,
-      [configuredProject]: {},
+      [configuredProject?.id]: {},
       [configuredBoard?.id]: {},
     }))
     setConfiguredProject(null)
@@ -814,10 +814,8 @@ const CreateBlueprint = (props) => {
     console.log('>> PROJECTS LIST', projects)
     console.log('>> BOARDS LIST', boards)
 
-    const projectTransformation = projects[configuredConnection?.id]
-    const boardTransformation = boards[configuredConnection?.id]?.map(
-      (b) => b.id
-    )
+    const projectTransformation = projects[configuredConnection?.id]?.map(p => p.id)
+    const boardTransformation = boards[configuredConnection?.id]?.map(b => b.id)
     if (projectTransformation) {
       setTransformations((cT) => ({
         ...projectTransformation.reduce(initializeTransformations, {}),

--- a/config-ui/src/pages/configure/settings/github.jsx
+++ b/config-ui/src/pages/configure/settings/github.jsx
@@ -51,12 +51,12 @@ export default function GithubSettings (props) {
 
   // eslint-disable-next-line no-unused-vars
   const handleSettingsChange = useCallback((setting) => {
-    onSettingsChange(setting, configuredProject)
+    onSettingsChange(setting, configuredProject?.id)
   }, [onSettingsChange, configuredProject])
 
   const handleAdditionalSettings = useCallback((setting) => {
     setEnableAdditionalCalculations(setting)
-    onSettingsChange({ refdiff: setting ? { tagsOrder: '', tagsPattern: '', tagsLimit: 10, } : null }, configuredProject)
+    onSettingsChange({ refdiff: setting ? { tagsOrder: '', tagsPattern: '', tagsLimit: 10, } : null }, configuredProject?.id)
   }, [setEnableAdditionalCalculations, configuredProject, onSettingsChange])
 
   useEffect(() => {
@@ -94,7 +94,7 @@ export default function GithubSettings (props) {
                   placeholder='severity/(.*)$'
                 // defaultValue={transformation?.issueSeverity}
                   value={transformation?.issueSeverity}
-                  onChange={(e) => onSettingsChange({ issueSeverity: e.target.value }, configuredProject)}
+                  onChange={(e) => onSettingsChange({ issueSeverity: e.target.value }, configuredProject?.id)}
                   disabled={isSaving || isSavingConnection}
                   className='input'
                   maxLength={255}
@@ -115,7 +115,7 @@ export default function GithubSettings (props) {
                   id='github-issue-component'
                   placeholder='component/(.*)$'
                   value={transformation?.issueComponent}
-                  onChange={(e) => onSettingsChange({ issueComponent: e.target.value }, configuredProject)}
+                  onChange={(e) => onSettingsChange({ issueComponent: e.target.value }, configuredProject?.id)}
                   disabled={isSaving || isSavingConnection}
                   className='input'
                   maxLength={255}
@@ -135,7 +135,7 @@ export default function GithubSettings (props) {
                   id='github-issue-priority'
                   placeholder='(highest|high|medium|low)$'
                   value={transformation?.issuePriority}
-                  onChange={(e) => onSettingsChange({ issuePriority: e.target.value }, configuredProject)}
+                  onChange={(e) => onSettingsChange({ issuePriority: e.target.value }, configuredProject?.id)}
                   disabled={isSaving || isSavingConnection}
                   className='input'
                   maxLength={255}
@@ -155,7 +155,7 @@ export default function GithubSettings (props) {
                   id='github-issue-requirement'
                   placeholder='(feat|feature|proposal|requirement)$'
                   value={transformation?.issueTypeRequirement}
-                  onChange={(e) => onSettingsChange({ issueTypeRequirement: e.target.value }, configuredProject)}
+                  onChange={(e) => onSettingsChange({ issueTypeRequirement: e.target.value }, configuredProject?.id)}
                   disabled={isSaving || isSavingConnection}
                   className='input'
                   maxLength={255}
@@ -175,7 +175,7 @@ export default function GithubSettings (props) {
                   id='github-issue-bug'
                   placeholder='(bug|broken)$'
                   value={transformation?.issueTypeBug}
-                  onChange={(e) => onSettingsChange({ issueTypeBug: e.target.value }, configuredProject)}
+                  onChange={(e) => onSettingsChange({ issueTypeBug: e.target.value }, configuredProject?.id)}
                   disabled={isSaving || isSavingConnection}
                   className='input'
                   maxLength={255}
@@ -195,7 +195,7 @@ export default function GithubSettings (props) {
                   id='github-issue-incident'
                   placeholder='(incident|p0|p1|p2)$'
                   value={transformation?.issueTypeIncident}
-                  onChange={(e) => onSettingsChange({ issueTypeIncident: e.target.value }, configuredProject)}
+                  onChange={(e) => onSettingsChange({ issueTypeIncident: e.target.value }, configuredProject?.id)}
                   disabled={isSaving || isSavingConnection}
                   className='input'
                   maxLength={255}
@@ -224,7 +224,7 @@ export default function GithubSettings (props) {
                   id='github-pr-type'
                   placeholder='type/(.*)$'
                   value={transformation?.prType}
-                  onChange={(e) => onSettingsChange({ prType: e.target.value }, configuredProject)}
+                  onChange={(e) => onSettingsChange({ prType: e.target.value }, configuredProject?.id)}
                   disabled={isSaving || isSavingConnection}
                   className='input'
                   maxLength={255}
@@ -244,7 +244,7 @@ export default function GithubSettings (props) {
                   id='github-pr-type'
                   placeholder='component/(.*)$'
                   value={transformation?.prComponent}
-                  onChange={(e) => onSettingsChange({ prComponent: e.target.value }, configuredProject)}
+                  onChange={(e) => onSettingsChange({ prComponent: e.target.value }, configuredProject?.id)}
                   disabled={isSaving || isSavingConnection}
                   className='input'
                   maxLength={255}
@@ -297,7 +297,7 @@ export default function GithubSettings (props) {
                 id='github-pr-body'
                 className='textarea'
                 placeholder='(?mi)(fix|close|resolve|fixes|closes|resolves|fixed|closed|resolved)[\s]*.*(((and )?(#|https:\/\/github.com\/%s\/%s\/issues\/)\d+[ ]*)+)'
-                onChange={(e) => onSettingsChange({ prBodyClosePattern: e.target.value }, configuredProject)}
+                onChange={(e) => onSettingsChange({ prBodyClosePattern: e.target.value }, configuredProject?.id)}
                 disabled={isSaving || isSavingConnection}
                 fill
                 rows={2}
@@ -327,7 +327,7 @@ export default function GithubSettings (props) {
                     fill={true}
                     placeholder='10'
                     allowNumericCharactersOnly={true}
-                    onValueChange={(tagsLimitNumeric) => onSettingsChange({ refdiff: { ...transformation?.refdiff, tagsLimit: tagsLimitNumeric } }, configuredProject)}
+                    onValueChange={(tagsLimitNumeric) => onSettingsChange({ refdiff: { ...transformation?.refdiff, tagsLimit: tagsLimitNumeric } }, configuredProject?.id)}
                     value={transformation?.refdiff?.tagsLimit}
                   />
                 </FormGroup>
@@ -342,7 +342,7 @@ export default function GithubSettings (props) {
                     id='refdiff-tags-pattern'
                     placeholder='(regex)$'
                     value={transformation?.refdiff?.tagsPattern}
-                    onChange={(e) => onSettingsChange({ refdiff: { ...transformation?.refdiff, tagsPattern: e.target.value } }, configuredProject)}
+                    onChange={(e) => onSettingsChange({ refdiff: { ...transformation?.refdiff, tagsPattern: e.target.value } }, configuredProject?.id)}
                     disabled={isSaving || isSavingConnection}
                     className='input'
                     maxLength={255}
@@ -359,7 +359,7 @@ export default function GithubSettings (props) {
                     id='refdiff-tags-order'
                     placeholder='reverse semver'
                     value={transformation?.refdiff?.tagsOrder}
-                    onChange={(e) => onSettingsChange({ refdiff: { ...transformation?.refdiff, tagsOrder: e.target.value } }, configuredProject)}
+                    onChange={(e) => onSettingsChange({ refdiff: { ...transformation?.refdiff, tagsOrder: e.target.value } }, configuredProject?.id)}
                     disabled={isSaving || isSavingConnection}
                     className='input'
                     maxLength={255}


### PR DESCRIPTION
# Summary

Add more user-friend project selector for project choosing when add blueprint for gitlab.

### Does this close any open issues?
Closes #2861

### Screenshots
![image](https://user-images.githubusercontent.com/3294100/188368879-39d7121a-4188-46f6-974a-f96a9b5a1cfe.png)
![image](https://user-images.githubusercontent.com/3294100/188369073-ad299085-de63-40fe-9996-78dd7c69851d.png)

![image](https://user-images.githubusercontent.com/3294100/187961224-617a628b-ed11-4576-94cf-448625b390eb.png)
Gitlab has so many public projects. So add a checkbox to control if display these projects which user is a member of.
![image](https://user-images.githubusercontent.com/3294100/188351345-e1eb4f24-74af-4997-850f-c5b52cdb7433.png)
![image](https://user-images.githubusercontent.com/3294100/188368618-c21ae72a-7279-4cc1-bbbe-c001cf46e2ae.png)
![image](https://user-images.githubusercontent.com/3294100/188368703-f782e860-e0c1-427d-8f30-fc91310b2f3b.png)

