### PR TITLE
fix(config-ui): use `id` instead of `key` as jira server `fields` has no `key`

### DIFF
--- a/config-ui/src/hooks/useJIRA.jsx
+++ b/config-ui/src/hooks/useJIRA.jsx
@@ -171,7 +171,7 @@ const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint, boardsEndpoint 
   }, [issueTypesResponse])
 
   useEffect(() => {
-    setFields(fieldsResponse ? createListData(fieldsResponse, 'name', 'key') : [])
+    setFields(fieldsResponse ? createListData(fieldsResponse, 'name', 'id') : [])
   }, [fieldsResponse])
 
   useEffect(() => {


### PR DESCRIPTION
# Summary

use `id` instead of `key` when we are creating ListData for `fieldsResponse` in `config-ui/src/hooks/useJIRA.jsx`
I checked, in jira cloud, value of `id` is same to value of `key` in /fields response

### Does this close any open issues?
closes #2930

### Screenshots
cloud:
![image](https://user-images.githubusercontent.com/39366025/188042919-c71d19b7-a616-4c77-9189-c389a3418e51.png)

server:
![image](https://user-images.githubusercontent.com/39366025/188042974-375a5eab-f69c-47a4-b2a9-2a2cb11b402c.png)


### Other Information
Any other information that is important to this PR.
