### PR TITLE
feat:  Support BasicAuth configs in devlake helm charts

### DIFF
--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -97,6 +97,9 @@ Some useful parameters for the chart, you could also check them in values.yaml
 | ui.image.repository  | repository for ui's image | mericodev/config-ui  |
 | ui.image.tag  | image tag for ui's image | latest  |
 | ui.image.pullPolicy  | pullPolicy for ui's image | Always  |
+| ui.basicAuth.enabled  | If the basic auth in ui is enabled | false  |
+| ui.basicAuth.user  | The user name for the basic auth | "admin"  |
+| ui.basicAuth.password  | The password for the basic auth | "admin"  |
 | service.type  | Service type for exposed service | NodePort  |
 | service.uiPort  | Service port for config ui | 32001  |
 | service.ingress.enabled  | If enable ingress  |  false  |

--- a/deployment/helm/templates/configmaps.yaml
+++ b/deployment/helm/templates/configmaps.yaml
@@ -25,4 +25,7 @@ data:
   MYSQL_DATABASE: "{{ .Values.mysql.database }}"
   MYSQL_ROOT_PASSWORD: "{{ .Values.mysql.rootPassword }}"
   LOGGING_DIR: "{{ .Values.lake.loggingDir }}"
-
+{{- if .Values.ui.basicAuth.enabled }}
+  ADMIN_USER: "{{ .Values.ui.basicAuth.user }}"
+  ADMIN_PASS: "{{ .Values.ui.basicAuth.password }}"
+{{- end }}

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -118,6 +118,10 @@ ui:
 
   affinity: {}
 
+  basicAuth:
+    enabled: false
+    user: admin
+    password: admin
 
 # alpine image for some init containers
 alpine:


### PR DESCRIPTION


### ⚠️ Pre Checklist


# Summary

Add configs: ui.admin.enabled/user/password to enable BasicAuth of config ui in helm charts

### Does this close any open issues?
Closes xx

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
