### PR TITLE
fix: fix the docker image name in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ build-config-ui-image:
 	cd config-ui; docker build -t $(IMAGE_REPO)/devlake-config-ui:$(TAG) --file ./Dockerfile .
 
 build-grafana-image:
-	cd grafana; docker build -t $(IMAGE_REPO)/devlake-grafana:$(TAG) --file ./Dockerfile .
+	cd grafana; docker build -t $(IMAGE_REPO)/devlake-dashboard:$(TAG) --file ./Dockerfile .
 
 build-images: build-server-image build-config-ui-image build-grafana-image
 
@@ -65,7 +65,7 @@ push-config-ui-image: build-config-ui-image
 	docker push $(IMAGE_REPO)/devlake-config-ui:$(TAG)
 
 push-grafana-image: build-grafana-image
-        docker push $(IMAGE_REPO)/devlake-grafana:$(TAG)
+        docker push $(IMAGE_REPO)/devlake-dashboard:$(TAG)
 
 push-images: push-server-image push-config-ui-image push-grafana-image
 


### PR DESCRIPTION
# Summary
fix #3004 ([Bug][docker] the docker image name should keep consistent )

rename the `grafana` image name `devlake-grafana` in `Makefile` to `devlake-dashboard`  to keep consistent with the one in `.github/workflows/build.yml`

### Does this close any open issues?
Closes #3004 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
