### PR TITLE
fix: change bitbucket ratelimit

### DIFF
--- a/plugins/bitbucket/tasks/api_client.go
+++ b/plugins/bitbucket/tasks/api_client.go
@@ -21,12 +21,9 @@ import (
 	"fmt"
 	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/plugins/bitbucket/models"
-	"net/http"
-	"strconv"
-	"time"
-
 	"github.com/apache/incubator-devlake/plugins/core"
 	"github.com/apache/incubator-devlake/plugins/helper"
+	"net/http"
 )
 
 func CreateApiClient(taskCtx core.TaskContext, connection *models.BitbucketConnection) (*helper.ApiAsyncClient, error) {
@@ -52,20 +49,6 @@ func CreateApiClient(taskCtx core.TaskContext, connection *models.BitbucketConne
 	// create rate limit calculator
 	rateLimiter := &helper.ApiRateLimitCalculator{
 		UserRateLimitPerHour: connection.RateLimitPerHour,
-		Method:               http.MethodGet,
-		DynamicRateLimit: func(res *http.Response) (int, time.Duration, error) {
-			rateLimitHeader := res.Header.Get("X-Request-Count")
-			if rateLimitHeader == "" {
-				// use default
-				return 0, 0, nil
-			}
-			rateLimit, err := strconv.Atoi(rateLimitHeader)
-			if err != nil {
-				return 0, 0, errors.Default.Wrap(err, "failed to parse X-Request-Count header")
-			}
-
-			return rateLimit, 1 * time.Minute, nil
-		},
 	}
 	asyncApiClient, err := helper.CreateAsyncApiClient(
 		taskCtx,


### PR DESCRIPTION
The value of bitbucket ratelimit varies by api.

https://support.atlassian.com/bitbucket-cloud/docs/api-request-limits/
<img width="781" alt="Screen Shot 2022-09-07 at 21 20 26" src="https://user-images.githubusercontent.com/47466847/188888591-586bbd59-b248-4a1f-8cc6-54cf222146e4.png">
