### PR TITLE
fix: cycle import of api and api/blueprints

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -100,5 +100,3 @@ func CreateApiService() {
 		panic(err)
 	}
 }
-
-const BadRequestBody = "bad request body format"

--- a/api/blueprints/blueprints.go
+++ b/api/blueprints/blueprints.go
@@ -18,12 +18,11 @@ limitations under the License.
 package blueprints
 
 import (
-	"github.com/apache/incubator-devlake/api"
-	"github.com/apache/incubator-devlake/errors"
 	"net/http"
 	"strconv"
 
 	"github.com/apache/incubator-devlake/api/shared"
+	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/models"
 	"github.com/apache/incubator-devlake/services"
 	"github.com/gin-gonic/gin"
@@ -43,7 +42,7 @@ func Post(c *gin.Context) {
 
 	err := c.ShouldBind(blueprint)
 	if err != nil {
-		shared.ApiOutputError(c, errors.BadInput.Wrap(err, api.BadRequestBody, errors.AsUserMessage()))
+		shared.ApiOutputError(c, errors.BadInput.Wrap(err, shared.BadRequestBody, errors.AsUserMessage()))
 		return
 	}
 
@@ -68,7 +67,7 @@ func Index(c *gin.Context) {
 	var query services.BlueprintQuery
 	err := c.ShouldBindQuery(&query)
 	if err != nil {
-		shared.ApiOutputError(c, errors.BadInput.Wrap(err, api.BadRequestBody, errors.AsUserMessage()))
+		shared.ApiOutputError(c, errors.BadInput.Wrap(err, shared.BadRequestBody, errors.AsUserMessage()))
 		return
 	}
 	blueprints, count, err := services.GetBlueprints(&query)
@@ -168,7 +167,7 @@ func Patch(c *gin.Context) {
 	var body map[string]interface{}
 	err = c.ShouldBind(&body)
 	if err != nil {
-		shared.ApiOutputError(c, errors.BadInput.Wrap(err, api.BadRequestBody, errors.AsUserMessage()))
+		shared.ApiOutputError(c, errors.BadInput.Wrap(err, shared.BadRequestBody, errors.AsUserMessage()))
 		return
 	}
 	blueprint, err := services.PatchBlueprint(id, body)

--- a/api/pipelines/pipelines.go
+++ b/api/pipelines/pipelines.go
@@ -18,14 +18,13 @@ limitations under the License.
 package pipelines
 
 import (
-	"github.com/apache/incubator-devlake/api"
-	"github.com/apache/incubator-devlake/errors"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
 
 	"github.com/apache/incubator-devlake/api/shared"
+	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/models"
 	"github.com/apache/incubator-devlake/services"
 	"github.com/gin-gonic/gin"
@@ -96,7 +95,7 @@ func Index(c *gin.Context) {
 	var query services.PipelineQuery
 	err := c.ShouldBindQuery(&query)
 	if err != nil {
-		shared.ApiOutputError(c, errors.BadInput.Wrap(err, api.BadRequestBody, errors.AsUserMessage()))
+		shared.ApiOutputError(c, errors.BadInput.Wrap(err, shared.BadRequestBody, errors.AsUserMessage()))
 		return
 	}
 	pipelines, count, err := services.GetPipelines(&query)

--- a/api/push/push.go
+++ b/api/push/push.go
@@ -19,11 +19,10 @@ package push
 
 import (
 	"fmt"
-	"github.com/apache/incubator-devlake/api"
-	"github.com/apache/incubator-devlake/errors"
 	"net/http"
 
 	"github.com/apache/incubator-devlake/api/shared"
+	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/services"
 	"github.com/gin-gonic/gin"
 )
@@ -53,7 +52,7 @@ func Post(c *gin.Context) {
 	var rowsToInsert []map[string]interface{}
 	err = c.ShouldBindJSON(&rowsToInsert)
 	if err != nil {
-		shared.ApiOutputError(c, errors.BadInput.Wrap(err, api.BadRequestBody, errors.AsUserMessage()))
+		shared.ApiOutputError(c, errors.BadInput.Wrap(err, shared.BadRequestBody, errors.AsUserMessage()))
 		return
 	}
 	rowsAffected, err := services.InsertRow(tableName, rowsToInsert)

--- a/api/shared/api_output.go
+++ b/api/shared/api_output.go
@@ -26,6 +26,8 @@ import (
 	"net/http"
 )
 
+const BadRequestBody = "bad request body format"
+
 type ApiBody struct {
 	Success bool   `json:"success"`
 	Message string `json:"message"`

--- a/api/task/task.go
+++ b/api/task/task.go
@@ -18,12 +18,11 @@ limitations under the License.
 package task
 
 import (
-	"github.com/apache/incubator-devlake/api"
-	"github.com/apache/incubator-devlake/errors"
 	"net/http"
 	"strconv"
 
 	"github.com/apache/incubator-devlake/api/shared"
+	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/services"
 	"github.com/gin-gonic/gin"
 )
@@ -58,7 +57,7 @@ func Index(c *gin.Context) {
 	var query services.TaskQuery
 	err := c.ShouldBindQuery(&query)
 	if err != nil {
-		shared.ApiOutputError(c, errors.BadInput.Wrap(err, api.BadRequestBody, errors.AsUserMessage()))
+		shared.ApiOutputError(c, errors.BadInput.Wrap(err, shared.BadRequestBody, errors.AsUserMessage()))
 		return
 	}
 	err = c.ShouldBindUri(&query)


### PR DESCRIPTION
# Summary

fix #3024 ([Bug][framework] compile error)
The error was caused by a cycle of dependency. It's fixed by moving the constant `BadRequestBody` defined in the package `api` to the package `api/shared`

### Does this close any open issues?
Closes #3024

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
