### PR TITLE
fix: task failure caused by 404

### DIFF
--- a/plugins/helper/api_client.go
+++ b/plugins/helper/api_client.go
@@ -265,7 +265,11 @@ func (apiClient *ApiClient) Do(
 	// after receive
 	if apiClient.afterResponse != nil {
 		err = apiClient.afterResponse(res)
-		if err != nil && err != ErrIgnoreAndContinue {
+		if err == ErrIgnoreAndContinue {
+			res.Body.Close()
+			return res, err
+		}
+		if err != nil {
 			res.Body.Close()
 			return nil, errors.Default.Wrap(err, fmt.Sprintf("error running afterRequest for %s", req.URL.String()), errors.UserMessage("error after making API call"))
 		}


### PR DESCRIPTION
# Summary
fix #2960 [Bug][gitihub] collect account failed by not found user
In the case of `err == ErrIgnoreAndContinue`, the `err` should not be wrapped, because on the caller side, the expression `err == ErrIgnoreAndContinue`  would evaluate as false.
```go
if apiClient.afterResponse != nil {
		err = apiClient.afterResponse(res)
		if err != nil && err != ErrIgnoreAndContinue {
			res.Body.Close()
			return nil, errors.Default.Wrap(err, fmt.Sprintf("error running afterRequest for %s", req.URL.String()), errors.UserMessage("error after making API call"))
		}
	}
```
### Does this close any open issues?
Closes #2960 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
