### PR TITLE
fix: let workflow `check-Apache-license-header` work

### DIFF
--- a/.github/workflows/asf-header-check.yml
+++ b/.github/workflows/asf-header-check.yml
@@ -27,4 +27,4 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check License Header
-        uses: apache/skywalking-eyes/header@v0.4.0
+        uses: apache/skywalking-eyes@v0.4.0

--- a/.github/workflows/asf-header-check.yml
+++ b/.github/workflows/asf-header-check.yml
@@ -26,5 +26,8 @@ jobs:
     name: check Apache license header
     runs-on: ubuntu-20.04
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
       - name: Check License Header
         uses: apache/skywalking-eyes@main

--- a/.github/workflows/asf-header-check.yml
+++ b/.github/workflows/asf-header-check.yml
@@ -27,4 +27,4 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check License Header
-        uses: apache/skywalking-eyes@v0.4.0
+        uses: apache/skywalking-eyes@main

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -29,6 +29,7 @@ header:
     - 'logs'
     - 'mocks'
     - 'vendor'
+    - '.env.example'
     - '**/*.log'
     - '**/env.example'
     - '**/*.csv'

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -1,3 +1,20 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package errors
 
 import (

--- a/generator/template/migrationscripts/archived/connection.go-template
+++ b/generator/template/migrationscripts/archived/connection.go-template
@@ -1,0 +1,16 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/


### PR DESCRIPTION
### 1. check-Apache-license-header was activated
### 2. By the way, added the apache license header to the files that need to be added.
<img width="1046" alt="Screen Shot 2022-09-09 at 22 30 09" src="https://user-images.githubusercontent.com/47466847/189373976-a99dab37-7ee2-42ee-93de-767e153ff806.png">
