### PR TITLE
fix: remove invalid test case TestReadConfig

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,14 +25,6 @@ import (
 	"testing"
 )
 
-func TestReadConfig(t *testing.T) {
-	DbUrl := "mysql://merico:merico@mysql:3306/lake?charset=utf8mb4&parseTime=True"
-	v := GetConfig()
-	currentDbUrl := v.GetString("DB_URL")
-	logrus.Infof("current db url: %s\n", currentDbUrl)
-	assert.Equal(t, currentDbUrl == DbUrl, true)
-}
-
 func TestWriteConfig(t *testing.T) {
 	filename := ".env"
 	cwd, _ := os.Getwd()


### PR DESCRIPTION
# Summary

The `TestReadConfig` is highly coupled with an external setting, which is out of the scope of the test case.
This makes it an ineffectual test case.