### PR TITLE
feat(jenkins): add param datasource as jenkins to dora options

### DIFF
--- a/plugins/github/api/blueprint.go
+++ b/plugins/github/api/blueprint.go
@@ -163,7 +163,7 @@ func processScope(subtaskMetas []core.SubTaskMeta, connectionId uint64, scopeEle
 		doraOption := make(map[string]interface{})
 		doraOption["repoId"] = didgen.NewDomainIdGenerator(&models.GithubRepo{}).Generate(connectionId, apiRepo.GithubId)
 		doraOption["tasks"] = []string{"EnrichTaskEnv"}
-		doraOption["transformation"] = doraRules
+		doraOption["transformationRules"] = doraRules
 		plan[j] = core.PipelineStage{
 			{
 				Plugin:  "dora",

--- a/plugins/github/api/blueprint_test.go
+++ b/plugins/github/api/blueprint_test.go
@@ -19,24 +19,17 @@ package api
 
 import (
 	"encoding/json"
-	"github.com/apache/incubator-devlake/config"
-	"github.com/apache/incubator-devlake/logger"
 	"github.com/apache/incubator-devlake/mocks"
 	"github.com/apache/incubator-devlake/models/common"
 	"github.com/apache/incubator-devlake/plugins/core"
 	"github.com/apache/incubator-devlake/plugins/github/models"
 	"github.com/apache/incubator-devlake/plugins/github/tasks"
 	"github.com/apache/incubator-devlake/plugins/helper"
-	"github.com/apache/incubator-devlake/runner"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func TestProcessScope(t *testing.T) {
-	cfg := config.GetConfig()
-	log := logger.Global.Nested("github")
-	db, _ := runner.NewGormDb(cfg, log)
-	Init(cfg, log, db)
 	connection := &models.GithubConnection{
 		RestConnection: helper.RestConnection{
 			BaseConnection: helper.BaseConnection{
@@ -89,6 +82,6 @@ func TestProcessScope(t *testing.T) {
 	}
 	planJson, err1 := json.Marshal(plan)
 	assert.Nil(t, err1)
-	expectPlan := `[[{"plugin":"github","subtasks":[],"options":{"connectionId":1,"owner":"test","repo":"testRepo","transformationRules":{"prType":"hey,man,wasup"}}},{"plugin":"gitextractor","subtasks":null,"options":{"proxy":"","repoId":"github:GithubRepo:1:123","url":"//git:123@HttpUrlToRepo"}}],[{"plugin":"refdiff","subtasks":null,"options":{"tagsLimit":10,"tagsOrder":"reverse semver","tagsPattern":"pattern"}}],[{"plugin":"dora","subtasks":null,"options":{"repoId":"github:GithubRepo:1:123","tasks":["EnrichTaskEnv"],"transformation":{"environment":"pattern","environmentRegex":"xxxx"}}}]]`
+	expectPlan := `[[{"plugin":"github","subtasks":[],"options":{"connectionId":1,"owner":"test","repo":"testRepo","transformationRules":{"prType":"hey,man,wasup"}}},{"plugin":"gitextractor","subtasks":null,"options":{"proxy":"","repoId":"github:GithubRepo:1:123","url":"//git:123@HttpUrlToRepo"}}],[{"plugin":"refdiff","subtasks":null,"options":{"tagsLimit":10,"tagsOrder":"reverse semver","tagsPattern":"pattern"}}],[{"plugin":"dora","subtasks":null,"options":{"repoId":"github:GithubRepo:1:123","tasks":["EnrichTaskEnv"],"transformationRules":{"environment":"pattern","environmentRegex":"xxxx"}}}]]`
 	assert.Equal(t, expectPlan, string(planJson))
 }

--- a/plugins/gitlab/api/blueprint.go
+++ b/plugins/gitlab/api/blueprint.go
@@ -164,7 +164,7 @@ func processScope(subtaskMetas []core.SubTaskMeta, connectionId uint64, scopeEle
 		doraOption := make(map[string]interface{})
 		doraOption["repoId"] = didgen.NewDomainIdGenerator(&models.GitlabProject{}).Generate(connectionId, apiRepo.GitlabId)
 		doraOption["tasks"] = []string{"EnrichTaskEnv"}
-		doraOption["transformation"] = doraRules
+		doraOption["transformationRules"] = doraRules
 		plan[j] = core.PipelineStage{
 			{
 				Plugin:  "dora",

--- a/plugins/gitlab/api/blueprint_test.go
+++ b/plugins/gitlab/api/blueprint_test.go
@@ -19,24 +19,17 @@ package api
 
 import (
 	"encoding/json"
-	"github.com/apache/incubator-devlake/config"
-	"github.com/apache/incubator-devlake/logger"
 	"github.com/apache/incubator-devlake/mocks"
 	"github.com/apache/incubator-devlake/models/common"
 	"github.com/apache/incubator-devlake/plugins/core"
 	"github.com/apache/incubator-devlake/plugins/gitlab/models"
 	"github.com/apache/incubator-devlake/plugins/gitlab/tasks"
 	"github.com/apache/incubator-devlake/plugins/helper"
-	"github.com/apache/incubator-devlake/runner"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func TestProcessScope(t *testing.T) {
-	cfg := config.GetConfig()
-	log := logger.Global.Nested("gitlab")
-	db, _ := runner.NewGormDb(cfg, log)
-	Init(cfg, log, db)
 	connection := &models.GitlabConnection{
 		RestConnection: helper.RestConnection{
 			BaseConnection: helper.BaseConnection{
@@ -88,6 +81,6 @@ func TestProcessScope(t *testing.T) {
 	}
 	planJson, err1 := json.Marshal(plan)
 	assert.Nil(t, err1)
-	expectPlan := `[[{"plugin":"gitlab","subtasks":[],"options":{"connectionId":1,"projectId":123,"transformationRules":{"prType":"hey,man,wasup"}}},{"plugin":"gitextractor","subtasks":null,"options":{"proxy":"","repoId":"gitlab:GitlabProject:1:123","url":"//git:123@HttpUrlToRepo"}}],[{"plugin":"refdiff","subtasks":null,"options":{"tagsLimit":10,"tagsOrder":"reverse semver","tagsPattern":"pattern"}}],[{"plugin":"dora","subtasks":null,"options":{"repoId":"gitlab:GitlabProject:1:123","tasks":["EnrichTaskEnv"],"transformation":{"environment":"pattern","environmentRegex":"xxxx"}}}]]`
+	expectPlan := `[[{"plugin":"gitlab","subtasks":[],"options":{"connectionId":1,"projectId":123,"transformationRules":{"prType":"hey,man,wasup"}}},{"plugin":"gitextractor","subtasks":null,"options":{"proxy":"","repoId":"gitlab:GitlabProject:1:123","url":"//git:123@HttpUrlToRepo"}}],[{"plugin":"refdiff","subtasks":null,"options":{"tagsLimit":10,"tagsOrder":"reverse semver","tagsPattern":"pattern"}}],[{"plugin":"dora","subtasks":null,"options":{"repoId":"gitlab:GitlabProject:1:123","tasks":["EnrichTaskEnv"],"transformationRules":{"environment":"pattern","environmentRegex":"xxxx"}}}]]`
 	assert.Equal(t, expectPlan, string(planJson))
 }

--- a/plugins/jenkins/api/blueprint.go
+++ b/plugins/jenkins/api/blueprint.go
@@ -73,7 +73,8 @@ func MakePipelinePlan(subtaskMetas []core.SubTaskMeta, connectionId uint64, scop
 			}
 			doraOption := make(map[string]interface{})
 			doraOption["tasks"] = []string{"EnrichTaskEnv"}
-			doraOption["transformation"] = doraRules
+			doraOption["dataSource"] = []string{"jenkins"}
+			doraOption["transformationRules"] = doraRules
 			plan[j] = core.PipelineStage{
 				{
 					Plugin:  "dora",


### PR DESCRIPTION
# Summary

add a param named `datasourse` and set it to `jenkins` in jenkins blueprint when make pipeline

### Does this close any open issues?
relate to #3127 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
