### PR TITLE
refactor: webpack & eslint - disable autofix on startup compile

### DIFF
--- a/config-ui/webpack.config.js
+++ b/config-ui/webpack.config.js
@@ -129,7 +129,8 @@ module.exports = (env = {}) => {
         ],
       }),
       new ESLintPlugin({
-        fix: true,
+        // Do NOT auto-fix w/ eslint on webpack startup!
+        fix: false,
         context: path.resolve(__dirname, './'),
         exclude: ['dist', 'packages', 'cypress', 'config', 'node_modules']
       }),


### PR DESCRIPTION
### 📦  Config-UI / **Webpack**

- [x] `Refactor` Disable ESLint _autofix_ on Webpack startup

This PR turns **OFF** the **ESLint** _autofix_ setting for **Webpack** which was appropriate during early stages of development. With recent changes to the Global ESLint  & adopting Prettier configuration, however, this creates an undesirable situation for developers with older versions of `main` when trying to rebase or update, Webpack's ESLint's auto-fix will try to enforce the new standards while the server is starting or re-compile if it is running already running, which will automatically try to write changes to local files which will cause workflow conflicts.

```js
...
...
      new ESLintPlugin({
        // Do NOT auto-fix w/ eslint on webpack startup!
        fix: false,
        context: path.resolve(__dirname, './'),
        exclude: ['dist', 'packages', 'cypress', 'config', 'node_modules']
      }),
...
...
```

### Does this close any open issues?
Closes #3152


