### PR TITLE
fix(config-ui): adjust the transform rule button text 'Go Back' to 'Finish', and remove the tooltip for button

### DIFF
--- a/config-ui/src/components/blueprints/create-workflow/DataTransformations.jsx
+++ b/config-ui/src/components/blueprints/create-workflow/DataTransformations.jsx
@@ -439,20 +439,14 @@ const DataTransformations = (props) => {
                       >
                         {enableGoBack &&
                           (configuredProject || configuredBoard) && (
-                            <Tooltip
-                              position={Position.TOP}
+                            <Button
+                              text='Finish'
                               intent={Intent.PRIMARY}
-                              content='Close Editor to Continue'
-                            >
-                              <Button
-                                text='Go Back'
-                                intent={Intent.PRIMARY}
-                                small
-                                outlined
-                                onClick={() => onSave()}
-                                style={{ marginLeft: '5px' }}
-                              />
-                            </Tooltip>
+                              small
+                              outlined
+                              onClick={() => onSave()}
+                              style={{ marginLeft: '5px' }}
+                            />
                           )}
                       </div>
                     </div>


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

adjust the transform rule button text "Go Back" to "Finish", and remove the tooltip for the button.

### Does this close any open issues?
Closes #3187 

### Screenshots
![screenshot-20220926-140049](https://user-images.githubusercontent.com/37237996/192204117-c9972d02-3a19-406e-b6d7-ae377a145740.png)

### Other Information
Any other information that is important to this PR.
