### PR TITLE
feat(tapd): add proxy to forward api to tapd

### DIFF
--- a/plugins/tapd/api/proxy.go
+++ b/plugins/tapd/api/proxy.go
@@ -1,0 +1,73 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/apache/incubator-devlake/errors"
+	"io"
+	"time"
+
+	"github.com/apache/incubator-devlake/plugins/core"
+	"github.com/apache/incubator-devlake/plugins/helper"
+	"github.com/apache/incubator-devlake/plugins/tapd/models"
+)
+
+const (
+	TimeOut = 10 * time.Second
+)
+
+func Proxy(input *core.ApiResourceInput) (*core.ApiResourceOutput, errors.Error) {
+	connection := &models.TapdConnection{}
+	err := connectionHelper.First(connection, input.Params)
+	if err != nil {
+		return nil, err
+	}
+	apiClient, err := helper.NewApiClient(
+		context.TODO(),
+		connection.Endpoint,
+		map[string]string{
+			"Authorization": fmt.Sprintf("Basic %v", connection.GetEncodedToken()),
+		},
+		30*time.Second,
+		connection.Proxy,
+		basicRes,
+	)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := apiClient.Get(input.Params["path"], input.Query, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := errors.Convert01(io.ReadAll(resp.Body))
+	if err != nil {
+		return nil, err
+	}
+	// verify response body is json
+	var tmp interface{}
+	err = errors.Convert(json.Unmarshal(body, &tmp))
+	if err != nil {
+		return nil, err
+	}
+	return &core.ApiResourceOutput{Status: resp.StatusCode, Body: json.RawMessage(body)}, nil
+}

--- a/plugins/tapd/impl/impl.go
+++ b/plugins/tapd/impl/impl.go
@@ -234,6 +234,9 @@ func (plugin Tapd) ApiResources() map[string]map[string]core.ApiResourceHandler 
 			"DELETE": api.DeleteConnection,
 			"GET":    api.GetConnection,
 		},
+		"connections/:connectionId/proxy/rest/*path": {
+			"GET": api.Proxy,
+		},
 	}
 }
 


### PR DESCRIPTION
# Summary

Requests with path`/plugins/tapd/connections/:connectionId/proxy/*path` would route to `api.Proxy` handler

for example:
Request to http://your_devlake_host/plugins/tapd/connections/1/proxy/rest/story_categories?workspace=1
would forward to
https://api.tapd.cn/story_categories?workspace=1

![image](https://user-images.githubusercontent.com/39366025/192574011-af72760d-0d4a-4364-838f-a6630d1ebf35.png)


### Does this close any open issues?
closes #3194


### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
