### PR TITLE
fix: set PageSize from 100 to 30

### DIFF
--- a/plugins/github/tasks/cicd_run_collector.go
+++ b/plugins/github/tasks/cicd_run_collector.go
@@ -52,7 +52,7 @@ func CollectRuns(taskCtx core.SubTaskContext) errors.Error {
 			Table: RAW_RUN_TABLE,
 		},
 		ApiClient:   data.ApiClient,
-		PageSize:    100,
+		PageSize:    30,
 		Incremental: false,
 		UrlTemplate: "repos/{{ .Params.Owner }}/{{ .Params.Repo }}/actions/runs",
 		Query: func(reqData *helper.RequestData) (url.Values, errors.Error) {


### PR DESCRIPTION
# Summary
fix #3199 [Bug][GitHub] the sub-task `collectRuns` gets a 403 error
It turns out that hitting the secondary rate limits caused the bug.
It's fixed by setting the `PageSize` from 100 to a smaller number 30.

### Does this close any open issues?
Closes #3199 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
