### PR TITLE
fix: search jira account by key instead of username

### DIFF
--- a/plugins/jira/tasks/account_collector.go
+++ b/plugins/jira/tasks/account_collector.go
@@ -60,8 +60,7 @@ func CollectAccounts(taskCtx core.SubTaskContext) errors.Error {
 	queryKey := "accountId"
 	urlTemplate := "api/2/user"
 	if data.JiraServerInfo.DeploymentType == models.DeploymentServer {
-		queryKey = "username"
-		urlTemplate = "api/2/user/search"
+		queryKey = "key"
 	}
 
 	collector, err := helper.NewApiCollector(helper.ApiCollectorArgs{
@@ -83,23 +82,14 @@ func CollectAccounts(taskCtx core.SubTaskContext) errors.Error {
 			return query, nil
 		},
 		ResponseParser: func(res *http.Response) ([]json.RawMessage, errors.Error) {
-			if data.JiraServerInfo.DeploymentType == models.DeploymentServer {
-				var results []json.RawMessage
-				err := helper.UnmarshalResponse(res, &results)
-				if err != nil {
-					return nil, err
-				}
-
-				return results, nil
-			} else {
-				var result json.RawMessage
-				err := helper.UnmarshalResponse(res, &result)
-				if err != nil {
-					return nil, err
-				}
-				return []json.RawMessage{result}, nil
+			var result json.RawMessage
+			err := helper.UnmarshalResponse(res, &result)
+			if err != nil {
+				return nil, err
 			}
+			return []json.RawMessage{result}, nil
 		},
+		AfterResponse: ignoreHTTPStatus404,
 	})
 	if err != nil {
 		logger.Error(err, "collect account error")


### PR DESCRIPTION
# Summary

fix #3184 
Using `key` instead of `username` as a query keyword while collecting Jira accounts.

### Does this close any open issues?
Closes #3184 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
