### PR TITLE
fix: deployTagPattern is missing in jenkins build converter

### DIFF
--- a/plugins/jenkins/tasks/build_cicd_convertor.go
+++ b/plugins/jenkins/tasks/build_cicd_convertor.go
@@ -18,17 +18,18 @@ limitations under the License.
 package tasks
 
 import (
-	"github.com/apache/incubator-devlake/errors"
-	"github.com/apache/incubator-devlake/models/domainlayer/didgen"
-	"github.com/apache/incubator-devlake/plugins/jenkins/models"
 	"reflect"
+	"regexp"
 	"time"
 
+	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/models/domainlayer"
 	"github.com/apache/incubator-devlake/models/domainlayer/devops"
+	"github.com/apache/incubator-devlake/models/domainlayer/didgen"
 	"github.com/apache/incubator-devlake/plugins/core"
 	"github.com/apache/incubator-devlake/plugins/core/dal"
 	"github.com/apache/incubator-devlake/plugins/helper"
+	"github.com/apache/incubator-devlake/plugins/jenkins/models"
 )
 
 var ConvertBuildsToCICDMeta = core.SubTaskMeta{
@@ -39,9 +40,17 @@ var ConvertBuildsToCICDMeta = core.SubTaskMeta{
 	DomainTypes:      []string{core.DOMAIN_TYPE_CICD},
 }
 
-func ConvertBuildsToCICD(taskCtx core.SubTaskContext) errors.Error {
+func ConvertBuildsToCICD(taskCtx core.SubTaskContext) (err errors.Error) {
 	db := taskCtx.GetDal()
 	data := taskCtx.GetData().(*JenkinsTaskData)
+	var deployTagRegexp *regexp.Regexp
+	deploymentPattern := data.Options.DeploymentPattern
+	if len(deploymentPattern) > 0 {
+		deployTagRegexp, err = errors.Convert01(regexp.Compile(deploymentPattern))
+		if err != nil {
+			return errors.Default.Wrap(err, "regexp compile deploymentPattern failed")
+		}
+	}
 
 	clauses := []dal.Clause{
 		dal.From("_tool_jenkins_builds"),
@@ -124,9 +133,13 @@ func ConvertBuildsToCICD(taskCtx core.SubTaskContext) errors.Error {
 					StartedDate:  jenkinsBuild.StartTime,
 					FinishedDate: jenkinsPipelineFinishedDate,
 				}
+				if deployTagRegexp != nil {
+					if deployFlag := deployTagRegexp.FindString(jenkinsBuild.JobName); deployFlag != "" {
+						jenkinsTask.Type = devops.DEPLOYMENT
+					}
+				}
 
 				jenkinsTask.PipelineId = buildIdGen.Generate(jenkinsBuild.ConnectionId, jenkinsBuild.FullDisplayName)
-
 				jenkinsTask.RawDataOrigin = jenkinsBuild.RawDataOrigin
 				results = append(results, jenkinsTask)
 


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [ ] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.



# Summary

fix: deployTagPattern is missing in jenkins build converter

### Does this close any open issues?
Closes #3220 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
