### PR TITLE
fix: return 200 if no pending migration script

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -56,7 +56,7 @@ func CreateApiService() {
 	// Wait for user confirmation if db migration is needed
 	router.GET("/proceed-db-migration", func(ctx *gin.Context) {
 		if !services.MigrationRequireConfirmation() {
-			shared.ApiOutputError(ctx, errors.BadInput.New("no pending migration"))
+			shared.ApiOutputSuccess(ctx, nil, http.StatusOK)
 			return
 		}
 		err := services.ExecuteMigration()


### PR DESCRIPTION
# Summary

fix #3225 
Equipped with this fix, the API `/proceed-db-migration` would return 200, if no pending migration script.
### Does this close any open issues?
Closes #3225 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
