### PR TITLE
fix: gitextractor supports socks5 proxy

### DIFF
--- a/plugins/gitextractor/gitextractor.go
+++ b/plugins/gitextractor/gitextractor.go
@@ -18,15 +18,15 @@ limitations under the License.
 package main
 
 import (
-	"github.com/apache/incubator-devlake/errors"
-	"github.com/apache/incubator-devlake/plugins/helper"
 	"strings"
 
+	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/plugins/core"
 	"github.com/apache/incubator-devlake/plugins/gitextractor/models"
 	"github.com/apache/incubator-devlake/plugins/gitextractor/parser"
 	"github.com/apache/incubator-devlake/plugins/gitextractor/store"
 	"github.com/apache/incubator-devlake/plugins/gitextractor/tasks"
+	"github.com/apache/incubator-devlake/plugins/helper"
 )
 
 var _ core.PluginMeta = (*GitExtractor)(nil)

--- a/plugins/gitextractor/parser/clone.go
+++ b/plugins/gitextractor/parser/clone.go
@@ -56,7 +56,7 @@ func (l *GitRepoCreator) CloneOverHTTP(repoId, url, user, password, proxy string
 	return withTempDirectory(func(dir string) (*GitRepo, error) {
 		cloneOptions := &git.CloneOptions{Bare: true}
 		if proxy != "" {
-			cloneOptions.FetchOptions.ProxyOptions.Type = git.ProxyTypeSpecified
+			cloneOptions.FetchOptions.ProxyOptions.Type = git.ProxyTypeAuto
 			cloneOptions.FetchOptions.ProxyOptions.Url = proxy
 		}
 		if user != "" {

--- a/plugins/gitextractor/parser/clone.go
+++ b/plugins/gitextractor/parser/clone.go
@@ -20,10 +20,10 @@ package parser
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/apache/incubator-devlake/errors"
 	"net"
 	"os"
 
+	"github.com/apache/incubator-devlake/errors"
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	git "github.com/libgit2/git2go/v33"

--- a/plugins/gitextractor/parser/repo.go
+++ b/plugins/gitextractor/parser/repo.go
@@ -22,6 +22,10 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+
 	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/models/domainlayer"
 	"github.com/apache/incubator-devlake/models/domainlayer/code"
@@ -29,9 +33,6 @@ import (
 	"github.com/apache/incubator-devlake/plugins/core/dal"
 	"github.com/apache/incubator-devlake/plugins/gitextractor/models"
 	git "github.com/libgit2/git2go/v33"
-	"regexp"
-	"sort"
-	"strconv"
 )
 
 type GitRepo struct {

--- a/plugins/gitextractor/parser/repo_creator.go
+++ b/plugins/gitextractor/parser/repo_creator.go
@@ -19,10 +19,9 @@ package parser
 
 import (
 	"github.com/apache/incubator-devlake/errors"
-	git "github.com/libgit2/git2go/v33"
-
 	"github.com/apache/incubator-devlake/plugins/core"
 	"github.com/apache/incubator-devlake/plugins/gitextractor/models"
+	git "github.com/libgit2/git2go/v33"
 )
 
 const (

--- a/plugins/gitextractor/tasks/git_repo_collector.go
+++ b/plugins/gitextractor/tasks/git_repo_collector.go
@@ -46,9 +46,6 @@ func (o GitExtractorOptions) Valid() errors.Error {
 	if !(strings.HasPrefix(o.Url, "http") || strings.HasPrefix(url, "git@") || strings.HasPrefix(o.Url, "/")) {
 		return errors.BadInput.New("wrong url")
 	}
-	if o.Proxy != "" && !strings.HasPrefix(o.Proxy, "http://") {
-		return errors.BadInput.New("only support http proxy")
-	}
 	return nil
 }
 

--- a/plugins/gitextractor/tasks/git_repo_collector.go
+++ b/plugins/gitextractor/tasks/git_repo_collector.go
@@ -18,11 +18,11 @@ limitations under the License.
 package tasks
 
 import (
-	"github.com/apache/incubator-devlake/errors"
-	"github.com/apache/incubator-devlake/plugins/gitextractor/parser"
 	"strings"
 
+	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/plugins/core"
+	"github.com/apache/incubator-devlake/plugins/gitextractor/parser"
 )
 
 type GitExtractorOptions struct {


### PR DESCRIPTION
# Summary
fix #3235 [Bug][gitextractor] gitextractor does not support socks5 proxy

### Does this close any open issues?
Closes #3235 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
