### PR TITLE
fix: config-ui: disable run now if pipeline created or running

### DIFF
--- a/config-ui/src/pages/blueprints/blueprint-detail.jsx
+++ b/config-ui/src/pages/blueprints/blueprint-detail.jsx
@@ -494,7 +494,9 @@ const BlueprintDetail = (props) => {
                     onClick={runBlueprint}
                     disabled={
                       !activeBlueprint?.enable ||
-                      currentRun?.status === TaskStatus.RUNNING
+                      [TaskStatus.CREATED, TaskStatus.RUNNING].includes(
+                        currentRun?.status
+                      )
                     }
                   />
                 </div>


### PR DESCRIPTION
### Config-UI / Blueprints / Blueprint Detail

- [x] Disable Run Now if Pipeline status is `CREATED` or `RUNNING`

### Description

This PR applies an update to the **Run Now** action for a **Blueprint** so that it's button state is Disabled when the current pipeline run is either `TASK_CREATED` or `TASK_RUNNING` state. This will prevent the user from running duplicate pipelines while the backend is still waiting to execute the last requested job.

### Does this close any open issues?
Closes #3237
