### PR TITLE
fix: config-ui: prevent autofill of passwords on new connection form

### DIFF
--- a/config-ui/src/pages/configure/connections/ConnectionForm.jsx
+++ b/config-ui/src/pages/configure/connections/ConnectionForm.jsx
@@ -516,7 +516,7 @@ export default function ConnectionForm(props) {
                                 }
                                 className='input personal-token-input'
                                 fill
-                                autoComplete='false'
+                                autoComplete='new-password'
                               />
                             </div>
                             {tokenTests[patIdx] && (
@@ -595,7 +595,7 @@ export default function ConnectionForm(props) {
                   <InputGroup
                     id='connection-token'
                     type='password'
-                    autoComplete='false'
+                    autoComplete='new-password'
                     inputRef={connectionTokenRef}
                     disabled={isTesting || isSaving || isLocked}
                     placeholder={
@@ -716,7 +716,7 @@ export default function ConnectionForm(props) {
                   id='connection-password'
                   tabIndex={1}
                   type='password'
-                  autoComplete='false'
+                  autoComplete='new-password'
                   inputRef={connectionPasswordRef}
                   disabled={isTesting || isSaving || isLocked}
                   placeholder='Enter Password'

--- a/config-ui/src/pages/configure/connections/ConnectionForm.jsx
+++ b/config-ui/src/pages/configure/connections/ConnectionForm.jsx
@@ -677,7 +677,7 @@ export default function ConnectionForm(props) {
                 <InputGroup
                   id='connection-username'
                   tabIndex={0}
-                  autoComplete='false'
+                  autoComplete='new-password'
                   inputRef={connectionUsernameRef}
                   disabled={isTesting || isSaving || isLocked}
                   placeholder='Enter Username'


### PR DESCRIPTION
### Config-UI / Data Connections / **New Connection**

- [x] `Fix` set `autoComplete` to `new-password` mode for  **Username** & **Password** Type fields


### Description

This PR applies an update to **Username** & **Password** Type fields on the **Connection Form** so that the `autoComplete` attribute is properly respected. This will prevent certain browsers like Firefox from forcibly entering default values for login and password fields when creating a new connection.

For additional reference on how autoComplete attribute is used, please see https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion

### Does this close any open issues?
Closes #3241

### Screenshots
<img width="1133" alt="Screen Shot 2022-09-28 at 2 41 17 PM" src="https://user-images.githubusercontent.com/1742233/192862924-db21f794-f234-40ad-9270-45992012f4fc.png">

