### PR TITLE
fix(config-ui): extra settings cause the incorrect cursor

### DIFF
--- a/config-ui/src/pages/configure/settings/github.jsx
+++ b/config-ui/src/pages/configure/settings/github.jsx
@@ -442,7 +442,6 @@ export default function GithubSettings(props) {
                 fill
                 rows={2}
                 growVertically={false}
-                autoFocus
               />
             </FormGroup>
           </div>


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

since **autoFoucs** is set for the **TextArea**, the cursor will be tracked to the **TextArea** when the page is initially entered.

### Does this close any open issues?
Closes #3243

### Screenshots
![screenshot-20220929-103635](https://user-images.githubusercontent.com/37237996/192925899-1fc9f852-ad60-4a03-b769-ce672400919c.png)

### Other Information
Nothing.
