### PR TITLE
fix: overwrite startDate with the value of activatedDate

### DIFF
--- a/plugins/jira/tasks/apiv2models/sprint.go
+++ b/plugins/jira/tasks/apiv2models/sprint.go
@@ -29,13 +29,14 @@ type Sprint struct {
 	State         string     `json:"state"`
 	Name          string     `json:"name"`
 	StartDate     *time.Time `json:"startDate"`
+	ActivatedDate *time.Time `json:"activatedDate"`
 	EndDate       *time.Time `json:"endDate"`
 	CompleteDate  *time.Time `json:"completeDate"`
 	OriginBoardID uint64     `json:"originBoardId"`
 }
 
 func (s Sprint) ToToolLayer(connectionId uint64) *models.JiraSprint {
-	return &models.JiraSprint{
+	sprint := &models.JiraSprint{
 		ConnectionId:  connectionId,
 		SprintId:      s.ID,
 		Self:          s.Self,
@@ -46,4 +47,8 @@ func (s Sprint) ToToolLayer(connectionId uint64) *models.JiraSprint {
 		CompleteDate:  s.CompleteDate,
 		OriginBoardID: s.OriginBoardID,
 	}
+	if s.ActivatedDate != nil {
+		sprint.StartDate = s.ActivatedDate
+	}
+	return sprint
 }


### PR DESCRIPTION

# Summary
fix #3250 [Bug][Jira] sprint start date is wrong when using jira server
Overwrite startDate with the value of activatedDate if it is available

### Does this close any open issues?
Closes #3250 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
