### PR TITLE
fix: duration only cal how long beganAt to now when status is running or created

### DIFF
--- a/config-ui/src/pages/blueprints/blueprint-detail.jsx
+++ b/config-ui/src/pages/blueprints/blueprint-detail.jsx
@@ -336,7 +336,7 @@ const BlueprintDetail = (props) => {
         duration:
           p.beganAt && p.finishedAt
             ? dayjs(p.beganAt).from(p.finishedAt, true)
-            : p.beganAt
+            : p.beganAt && [TaskStatus.RUNNING, TaskStatus.CREATED].includes(p?.status)
             ? dayjs(p.beganAt).toNow(true)
             : ' - '
       }))


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->
duration only cal how long beganAt to now when status is running or created
![image](https://user-images.githubusercontent.com/3294100/193070035-fbf7b630-699f-499c-a8ce-94edb51185dc.png)


### Does this close any open issues?
Closes #3263