### PR TITLE
fix: tell error correctly when duplicate name

### DIFF
--- a/config-ui/src/hooks/useConnectionManager.jsx
+++ b/config-ui/src/hooks/useConnectionManager.jsx
@@ -262,7 +262,7 @@ function useConnectionManager(
           setIsSaving(false)
           setSaveComplete(saveResponse.success ? new Connection(s.data) : false)
           if (!saveResponse.success) {
-            notifyConnectionSaveFailure(s.data || s.message)
+            notifyConnectionSaveFailure(s?.data?.message || s.message)
           }
         } catch (e) {
           saveResponse.errors.push(e.message)


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->
tell error correctly when duplicate name

![image](https://user-images.githubusercontent.com/3294100/193075759-1a966ff5-632d-4c5d-a2a4-5c9a0be12dde.png)


### Does this close any open issues?
related #2892
