### PR TITLE
fix: more friendly error message for duplicated connection name

### DIFF
--- a/api/router.go
+++ b/api/router.go
@@ -19,7 +19,6 @@ package api
 
 import (
 	"fmt"
-	"github.com/apache/incubator-devlake/errors"
 	"net/http"
 	"strings"
 
@@ -96,14 +95,14 @@ func handlePluginCall(pluginName string, handler core.ApiResourceHandler) func(c
 			} else {
 				err = c.ShouldBindJSON(&input.Body)
 				if err != nil && err.Error() != "EOF" {
-					shared.ApiOutputError(c, errors.Default.Wrap(err, fmt.Sprintf("could not bind input of plugin %s to JSON", pluginName)))
+					shared.ApiOutputError(c, err)
 					return
 				}
 			}
 		}
 		output, err := handler(input)
 		if err != nil {
-			shared.ApiOutputError(c, errors.BadInput.Wrap(err, fmt.Sprintf("error executing the requested resource for plugin %s", pluginName)))
+			shared.ApiOutputError(c, err)
 		} else if output != nil {
 			status := output.Status
 			if status < http.StatusContinue {

--- a/api/shared/api_output.go
+++ b/api/shared/api_output.go
@@ -19,19 +19,19 @@ package shared
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/logger"
 	"github.com/apache/incubator-devlake/models"
 	"github.com/gin-gonic/gin"
-	"net/http"
 )
 
 const BadRequestBody = "bad request body format"
 
 type ApiBody struct {
-	Success bool     `json:"success"`
-	Message string   `json:"message"`
-	Causes  []string `json:"causes"`
+	Success bool   `json:"success"`
+	Message string `json:"message"`
 }
 
 type ResponsePipelines struct {
@@ -47,7 +47,6 @@ func ApiOutputError(c *gin.Context, err error) {
 		c.JSON(e.GetType().GetHttpCode(), &ApiBody{
 			Success: false,
 			Message: messages.Get(),
-			Causes:  messages.Causes(),
 		})
 	} else {
 		logger.Global.Error(err, "HTTP %d error (native)", http.StatusInternalServerError)

--- a/api/shared/api_output.go
+++ b/api/shared/api_output.go
@@ -30,8 +30,9 @@ import (
 const BadRequestBody = "bad request body format"
 
 type ApiBody struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
+	Success bool     `json:"success"`
+	Message string   `json:"message"`
+	Causes  []string `json:"causes"`
 }
 
 type ResponsePipelines struct {
@@ -47,6 +48,7 @@ func ApiOutputError(c *gin.Context, err error) {
 		c.JSON(e.GetType().GetHttpCode(), &ApiBody{
 			Success: false,
 			Message: messages.Get(),
+			Causes:  messages.Causes(),
 		})
 	} else {
 		logger.Global.Error(err, "HTTP %d error (native)", http.StatusInternalServerError)

--- a/plugins/helper/connection.go
+++ b/plugins/helper/connection.go
@@ -166,7 +166,7 @@ func (c *ConnectionApiHelper) save(connection interface{}) errors.Error {
 	err := c.db.CreateOrUpdate(connection)
 	if err != nil {
 		if strings.Contains(err.Error(), "duplicate") {
-			return errors.BadInput.New("duplicated Connection Name")
+			return errors.BadInput.Wrap(err, "duplicated Connection Name")
 		}
 		return err
 	}

--- a/plugins/helper/connection.go
+++ b/plugins/helper/connection.go
@@ -166,7 +166,7 @@ func (c *ConnectionApiHelper) save(connection interface{}) errors.Error {
 	err := c.db.CreateOrUpdate(connection)
 	if err != nil {
 		if strings.Contains(err.Error(), "duplicate") {
-			return errors.Default.New("duplicated Connection Name")
+			return errors.BadInput.New("duplicated Connection Name")
 		}
 		return err
 	}

--- a/plugins/helper/connection.go
+++ b/plugins/helper/connection.go
@@ -23,6 +23,7 @@ import (
 	"github.com/apache/incubator-devlake/errors"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"github.com/apache/incubator-devlake/models/common"
 	"github.com/apache/incubator-devlake/plugins/core"
@@ -164,6 +165,9 @@ func (c *ConnectionApiHelper) save(connection interface{}) errors.Error {
 
 	err := c.db.CreateOrUpdate(connection)
 	if err != nil {
+		if strings.Contains(err.Error(), "duplicate") {
+			return errors.Default.New("duplicated Connection Name")
+		}
 		return err
 	}
 


### PR DESCRIPTION
# Summary

fix #2892 [Bug][backend-framework] duplicate name when adding connection should have the right message

### Does this close any open issues?
Closes #2892 

### Screenshots
![image](https://user-images.githubusercontent.com/8455907/193181461-7a200fac-ef1b-43b6-972d-2c55cd6ca5d1.png)


### Other Information
Any other information that is important to this PR.
