### PR TITLE
fix: pipeline showed succeeded when tasks actually failed

### DIFF
--- a/runner/run_pipeline.go
+++ b/runner/run_pipeline.go
@@ -18,8 +18,10 @@ limitations under the License.
 package runner
 
 import (
-	"github.com/apache/incubator-devlake/errors"
+	"fmt"
 	"time"
+
+	"github.com/apache/incubator-devlake/errors"
 
 	"github.com/apache/incubator-devlake/models"
 	"github.com/apache/incubator-devlake/plugins/core"
@@ -47,6 +49,9 @@ func RunPipeline(
 	err = db.Where("pipeline_id = ?", dbPipeline.ID).Order("pipeline_row, pipeline_col").Find(&tasks).Error
 	if err != nil {
 		return errors.Convert(err)
+	}
+	if len(tasks) != dbPipeline.TotalTasks {
+		return errors.Internal.New(fmt.Sprintf("expected total tasks to be %v, got %v", dbPipeline.TotalTasks, len(tasks)))
 	}
 	// convert to 2d array
 	taskIds := make([][]uint64, 0)

--- a/services/init.go
+++ b/services/init.go
@@ -19,8 +19,10 @@ package services
 
 import (
 	"context"
-	"github.com/apache/incubator-devlake/errors"
+	"sync"
 	"time"
+
+	"github.com/apache/incubator-devlake/errors"
 
 	"github.com/apache/incubator-devlake/config"
 	"github.com/apache/incubator-devlake/logger"
@@ -38,6 +40,7 @@ var db *gorm.DB
 var cronManager *cron.Cron
 var log core.Logger
 var migrationRequireConfirmation bool
+var cronLocker sync.Mutex
 
 const failToCreateCronJob = "created cron job failed"
 

--- a/services/pipeline.go
+++ b/services/pipeline.go
@@ -167,9 +167,11 @@ func RunPipelineInQueue(pipelineMaxParallel int64) {
 		globalPipelineLog.Info("get lock and wait pipeline")
 		dbPipeline := &models.DbPipeline{}
 		for {
+			cronLocker.Lock()
 			db.Where("status = ?", models.TASK_CREATED).
 				Not(startedPipelineIds).
 				Order("id ASC").Limit(1).Find(dbPipeline)
+			cronLocker.Unlock()
 			if dbPipeline.ID != 0 {
 				break
 			}

--- a/services/pipeline_helper.go
+++ b/services/pipeline_helper.go
@@ -29,6 +29,8 @@ import (
 
 // CreateDbPipeline returns a NewPipeline
 func CreateDbPipeline(newPipeline *models.NewPipeline) (*models.DbPipeline, errors.Error) {
+	cronLocker.Lock()
+	defer cronLocker.Unlock()
 	planByte, err := errors.Convert01(json.Marshal(newPipeline.Plan))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Summary

for the following `pipeline`, and `tasks`, we should be seeing `finish_tasks` to be `0` or `2`, however, we got `1`, which means the `RunPipelineInQueue` function loaded an incomplete list of tasks!
```
{
  "id": 1,
  "createdAt": "2022-09-29T22:36:05.997327+08:00",
  "updatedAt": "2022-09-29T22:45:15.69865+08:00",
  "name": "MY BLUEPRINT 1664462165990",
  "blueprintId": 1,
  "plan": [
    [
      {
        "plugin": "github",
        "subtasks": [
        ],
        "options": {
        }
      },
      {
        "plugin": "gitextractor",
        "subtasks": null,
        "options": {
        }
      }
    ],
    [
      {
        "plugin": "dora",
        "subtasks": null,
        "options": {
        }
      }
    ],
    [
      {
        "plugin": "dora",
        "subtasks": null,
        "options": {
        }
      }
    ]
  ],
  "totalTasks": 4,
  "finishedTasks": 1,
  "beganAt": "2022-09-29T22:36:06.108868+08:00",
  "finishedAt": "2022-09-29T22:45:15.698184+08:00",
  "status": "TASK_COMPLETED",
  "message": "",
  "spentSeconds": 549,
  "stage": 1,
  "ID": 1
}


{
    "count": 4,
    "tasks": [
        {
            "id": 4,
            "createdAt": "2022-09-29T22:36:06.141486+08:00",
            "updatedAt": "2022-09-29T22:53:33.774872+08:00",
            "plugin": "dora",
            "subtasks": null,
            "options": {
            },
            "status": "TASK_FAILED",
            "message": "",
            "progress": 0,
            "progressDetail": null,
            "failedSubTask": "",
            "pipelineId": 1,
            "pipelineRow": 3,
            "pipelineCol": 1,
            "beganAt": null,
            "finishedAt": null,
            "spentSeconds": 0
        },
        {
            "id": 3,
            "createdAt": "2022-09-29T22:36:06.12198+08:00",
            "updatedAt": "2022-09-29T22:53:33.774872+08:00",
            "plugin": "dora",
            "subtasks": null,
            "options": {
            },
            "status": "TASK_FAILED",
            "message": "",
            "progress": 0,
            "progressDetail": null,
            "failedSubTask": "",
            "pipelineId": 1,
            "pipelineRow": 2,
            "pipelineCol": 1,
            "beganAt": null,
            "finishedAt": null,
            "spentSeconds": 0
        },
        {
            "id": 2,
            "createdAt": "2022-09-29T22:36:06.104173+08:00",
            "updatedAt": "2022-09-29T22:53:33.774872+08:00",
            "plugin": "gitextractor",
            "subtasks": null,
            "options": {
            },
            "status": "TASK_FAILED",
            "message": "",
            "progress": 0,
            "progressDetail": null,
            "failedSubTask": "",
            "pipelineId": 1,
            "pipelineRow": 1,
            "pipelineCol": 2,
            "beganAt": null,
            "finishedAt": null,
            "spentSeconds": 0
        },
        {
            "id": 1,
            "createdAt": "2022-09-29T22:36:06.067101+08:00",
            "updatedAt": "2022-09-29T22:45:15.689271+08:00",
            "plugin": "github",
            "subtasks": [
            ],
            "options": {
            },
            "status": "TASK_COMPLETED",
            "message": "",
            "progress": 1,
            "progressDetail": null,
            "failedSubTask": "",
            "pipelineId": 1,
            "pipelineRow": 1,
            "pipelineCol": 1,
            "beganAt": "2022-09-29T22:36:06.161708+08:00",
            "finishedAt": "2022-09-29T22:45:15.688601+08:00",
            "spentSeconds": 549
        }
    ]
}


```

### Does this close any open issues?
Closes #3271 


