### PR TITLE
fix: add array checks to all chosen tags for jira boards

### DIFF
--- a/config-ui/src/components/blueprints/BoardsSelector.jsx
+++ b/config-ui/src/components/blueprints/BoardsSelector.jsx
@@ -18,6 +18,8 @@
 import React, { useEffect, useMemo } from 'react'
 import { Intent, MenuItem } from '@blueprintjs/core'
 import { MultiSelect, Select } from '@blueprintjs/select'
+import JiraBoard from '@/models/JiraBoard'
+
 const BoardsSelector = (props) => {
   const {
     boards = [],
@@ -112,7 +114,7 @@ const BoardsSelector = (props) => {
                       ...rT,
                       [configuredConnection.id]: [
                         ...rT[configuredConnection.id],
-                        item
+                        new JiraBoard(item)
                       ]
                     }
                   : { ...rT }

--- a/config-ui/src/components/blueprints/create-workflow/DataTransformations.jsx
+++ b/config-ui/src/components/blueprints/create-workflow/DataTransformations.jsx
@@ -102,7 +102,7 @@ const DataTransformations = (props) => {
 
   useEffect(() => {
     setInitializeTransformations(transformations)
-  }, [transformations])
+  }, [])
 
   const isTransformationSupported = useMemo(
     () =>

--- a/config-ui/src/components/blueprints/create-workflow/DataTransformations.jsx
+++ b/config-ui/src/components/blueprints/create-workflow/DataTransformations.jsx
@@ -102,7 +102,7 @@ const DataTransformations = (props) => {
 
   useEffect(() => {
     setInitializeTransformations(transformations)
-  }, [])
+  }, [transformations])
 
   const isTransformationSupported = useMemo(
     () =>

--- a/config-ui/src/hooks/useJIRA.jsx
+++ b/config-ui/src/hooks/useJIRA.jsx
@@ -232,7 +232,7 @@ const useJIRA = (
     data = [],
     titleProperty,
     idProperty,
-    valueProperty,
+    valueProperty
   ) => {
     return data.map((d, dIdx) => ({
       id: d[idProperty],

--- a/config-ui/src/pages/blueprints/blueprint-detail.jsx
+++ b/config-ui/src/pages/blueprints/blueprint-detail.jsx
@@ -336,7 +336,8 @@ const BlueprintDetail = (props) => {
         duration:
           p.beganAt && p.finishedAt
             ? dayjs(p.beganAt).from(p.finishedAt, true)
-            : p.beganAt && [TaskStatus.RUNNING, TaskStatus.CREATED].includes(p?.status)
+            : p.beganAt &&
+              [TaskStatus.RUNNING, TaskStatus.CREATED].includes(p?.status)
             ? dayjs(p.beganAt).toNow(true)
             : ' - '
       }))

--- a/config-ui/src/pages/configure/settings/jira.jsx
+++ b/config-ui/src/pages/configure/settings/jira.jsx
@@ -155,9 +155,15 @@ export default function JiraSettings(props) {
   const [incidentTags, setIncidentTags] = useState(savedIncidentTags)
   const allChosenTagsInThisBoard = useMemo(
     () => [
-      ...requirementTags[configuredBoard?.id],
-      ...bugTags[configuredBoard?.id],
-      ...incidentTags[configuredBoard?.id]
+      ...(Array.isArray(requirementTags[configuredBoard?.id])
+        ? requirementTags[configuredBoard?.id]
+        : []),
+      ...(Array.isArray(bugTags[configuredBoard?.id])
+        ? bugTags[configuredBoard?.id]
+        : []),
+      ...(Array.isArray(incidentTags[configuredBoard?.id])
+        ? incidentTags[configuredBoard?.id]
+        : [])
     ],
     [configuredBoard?.id, requirementTags, bugTags, incidentTags]
   )
@@ -349,11 +355,15 @@ export default function JiraSettings(props) {
                 itemRenderer={(item, { handleClick, modifiers }) => (
                   <MenuItem
                     active={modifiers.active}
-                    disabled={allChosenTagsInThisBoard?.some(t => t.value === item.value)}
+                    disabled={allChosenTagsInThisBoard?.some(
+                      (t) => t.value === item.value
+                    )}
                     key={item.value}
                     onClick={handleClick}
                     text={
-                      requirementTags[configuredBoard?.id]?.some(t => t.value === item.value) ? (
+                      requirementTags[configuredBoard?.id]?.some(
+                        (t) => t.value === item.value
+                      ) ? (
                         <>
                           <img src={item.iconUrl} width={12} height={12} />{' '}
                           {item.title}{' '}
@@ -368,9 +378,9 @@ export default function JiraSettings(props) {
                     }
                     style={{
                       marginBottom: '2px',
-                      fontWeight: requirementTags[
-                        configuredBoard?.id
-                      ]?.some(t => t.value === item.value)
+                      fontWeight: requirementTags[configuredBoard?.id]?.some(
+                        (t) => t.value === item.value
+                      )
                         ? 700
                         : 'normal'
                     }}
@@ -397,7 +407,9 @@ export default function JiraSettings(props) {
                 onItemSelect={(item) => {
                   // setRequirementTags((rT) => !rT.includes(item) ? [...rT, item] : [...rT])
                   setRequirementTags((rT) =>
-                    !rT[configuredBoard?.id]?.some(t => t.value === item.value)
+                    !rT[configuredBoard?.id]?.some(
+                      (t) => t.value === item.value
+                    )
                       ? {
                           ...rT,
                           [configuredBoard?.id]: [
@@ -478,11 +490,15 @@ export default function JiraSettings(props) {
                 itemRenderer={(item, { handleClick, modifiers }) => (
                   <MenuItem
                     active={modifiers.active}
-                    disabled={allChosenTagsInThisBoard?.some(t => t.value === item.value)}
+                    disabled={allChosenTagsInThisBoard?.some(
+                      (t) => t.value === item.value
+                    )}
                     key={item.value}
                     onClick={handleClick}
                     text={
-                      bugTags[configuredBoard?.id]?.some(t => t.value === item.value) ? (
+                      bugTags[configuredBoard?.id]?.some(
+                        (t) => t.value === item.value
+                      ) ? (
                         <>
                           <img src={item.iconUrl} width={12} height={12} />{' '}
                           {item.title}{' '}
@@ -497,7 +513,9 @@ export default function JiraSettings(props) {
                     }
                     style={{
                       marginBottom: '2px',
-                      fontWeight: bugTags[configuredBoard?.id]?.some(t => t.value === item.value)
+                      fontWeight: bugTags[configuredBoard?.id]?.some(
+                        (t) => t.value === item.value
+                      )
                         ? 700
                         : 'normal'
                     }}
@@ -524,7 +542,9 @@ export default function JiraSettings(props) {
                 onItemSelect={(item) => {
                   // setBugTags((bT) => !bT.includes(item) ? [...bT, item] : [...bT])
                   setBugTags((bT) =>
-                    !bT[configuredBoard?.id]?.some(t => t.value === item.value)
+                    !bT[configuredBoard?.id]?.some(
+                      (t) => t.value === item.value
+                    )
                       ? {
                           ...bT,
                           [configuredBoard?.id]: [
@@ -611,11 +631,15 @@ export default function JiraSettings(props) {
                 itemRenderer={(item, { handleClick, modifiers }) => (
                   <MenuItem
                     active={modifiers.active}
-                    disabled={allChosenTagsInThisBoard?.some(t => t.value === item.value)}
+                    disabled={allChosenTagsInThisBoard?.some(
+                      (t) => t.value === item.value
+                    )}
                     key={item.value}
                     onClick={handleClick}
                     text={
-                      incidentTags[configuredBoard?.id]?.some(t => t.value === item.value) ? (
+                      incidentTags[configuredBoard?.id]?.some(
+                        (t) => t.value === item.value
+                      ) ? (
                         <>
                           <img src={item.iconUrl} width={12} height={12} />{' '}
                           {item.title}{' '}
@@ -630,7 +654,9 @@ export default function JiraSettings(props) {
                     }
                     style={{
                       marginBottom: '2px',
-                      fontWeight: incidentTags[configuredBoard?.id]?.some(t => t.value === item.value)
+                      fontWeight: incidentTags[configuredBoard?.id]?.some(
+                        (t) => t.value === item.value
+                      )
                         ? 700
                         : 'normal'
                     }}
@@ -657,7 +683,9 @@ export default function JiraSettings(props) {
                 onItemSelect={(item) => {
                   // setIncidentTags((iT) => !iT.includes(item) ? [...iT, item] : [...iT])
                   setIncidentTags((iT) =>
-                    !iT[configuredBoard?.id]?.some(t => t.value === item.value)
+                    !iT[configuredBoard?.id]?.some(
+                      (t) => t.value === item.value
+                    )
                       ? {
                           ...iT,
                           [configuredBoard?.id]: [


### PR DESCRIPTION
### 📦  Config-UI / Blueprints / JIRA Boards & Transformations

- [x] `Fix` Add `Array.isArray` check to All Chosen Board Tags Memoization
- [x] `Fix` Wrap Boards Selector `Item` with `JiraBoard` Model so `type` (`variant`) is detected
- [x] `Chore` Run ESLint
- [x] `Chore` Test JIRA Create and Modify Workflow

### Description

This PR applies required updates to **JIRA Boards** Logic so that when "saved" board tags are retrieved, to only _spread_ the saved tags array if one exists, since re-configuring board selections will create a scenario where saved tags may be non-existent for retrieval. Additionally during Blueprint Modification Workflow and JIRA Board re-selection, the newly selected board must be wrapped with `JiraBoard` Data Model so the variant type is properly detected.

### Does this close any open issues?
Closes #3274
