### PR TITLE
fix(config-ui): webhook id is the interface return value

### DIFF
--- a/config-ui/src/pages/connections/incoming-webhook/index.jsx
+++ b/config-ui/src/pages/connections/incoming-webhook/index.jsx
@@ -129,9 +129,9 @@ export const IncomingWebhook = () => {
                 {loading ? (
                   <div>Loading</div>
                 ) : (
-                  data.map((it, i) => (
+                  data.map((it) => (
                     <S.Grid key={it.id}>
-                      <li>{i + 1}</li>
+                      <li>{it.id}</li>
                       <li>{it.name}</li>
                       <li>
                         <Button


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

webhook id is the interface return value.

### Does this close any open issues?
Closes #3284

### Screenshots
![screenshot-20220930-121121](https://user-images.githubusercontent.com/37237996/193188690-cd29f2ec-f9e7-40fa-a0af-894bab910e7f.png)

### Other Information
Nothing.
