### PR TITLE
fix(config-ui): incorrect value to get when transformation does not exist

### DIFF
--- a/config-ui/src/hooks/useDataScopesManager.jsx
+++ b/config-ui/src/hooks/useDataScopesManager.jsx
@@ -543,7 +543,7 @@ function useDataScopesManager({
       boardsList: boardsList,
       transformations: c.scope.map((s) => ({ ...s.transformation })),
       transformationStates: c.scope.map((s) =>
-        Object.values(s.transformation).some((v) =>
+        Object.values(s.transformation ?? {}).some((v) =>
           Array.isArray(v)
             ? v.length > 0
             : v && typeof v === 'object'


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

Using the api to create a blueprint without setting the transformation-related content will cause the failure to obtain this configuration and cause the page to report an error.

### Does this close any open issues?
Closes #3313

### Screenshots
![screenshot-20221009-163608](https://user-images.githubusercontent.com/37237996/194746652-a46e8512-b2c5-4fa3-9724-7c917e6d2574.png)


### Other Information
Nothing.
