### PR TITLE
Unit test migration helper

### DIFF
--- a/helpers/migrationhelper/migrationhelper.go
+++ b/helpers/migrationhelper/migrationhelper.go
@@ -196,12 +196,13 @@ func TransformTable[S any, D any](
 	// rollback for error
 	defer func() {
 		if err != nil {
-			err = db.RenameTable(tmpTableName, tableName)
-			if err != nil {
+			err1 := db.RenameTable(tmpTableName, tableName)
+			if err1 != nil {
 				msg := fmt.Sprintf(
-					"fail to rollback table [%s] to [%s], you may have to do it manually",
+					"fail to rollback table [%s] to [%s]:[%s], you may have to do it manually",
 					tmpTableName,
 					tableName,
+					err1.Error(),
 				)
 				err = errors.Default.Wrap(err, msg)
 			}
@@ -216,11 +217,12 @@ func TransformTable[S any, D any](
 	// rollback for error
 	defer func() {
 		if err != nil {
-			err = db.DropTables(tableName)
-			if err != nil {
+			err1 := db.DropTables(tableName)
+			if err1 != nil {
 				msg := fmt.Sprintf(
-					"fail to drop table [%s], you may have to do it manually",
+					"fail to drop table [%s]:[%s], you may have to do it manually",
 					tableName,
+					err1.Error(),
 				)
 				err = errors.Default.Wrap(err, msg)
 			}

--- a/helpers/migrationhelper/migrationhelper_test.go
+++ b/helpers/migrationhelper/migrationhelper_test.go
@@ -1,0 +1,494 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationhelper
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"reflect"
+	"testing"
+
+	"github.com/apache/incubator-devlake/errors"
+	"github.com/apache/incubator-devlake/helpers/unithelper"
+	"github.com/apache/incubator-devlake/mocks"
+	"github.com/apache/incubator-devlake/plugins/core"
+	"github.com/apache/incubator-devlake/plugins/core/dal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+const TestTableNameSrc string = "test_src"
+const TestColumeName string = "id"
+
+type TestSrcTable struct {
+	Id        string `gorm:"type:varchar(255)"`
+	Name      string `gorm:"type:varchar(255)"`
+	CommitSha string `gorm:"type:varchar(40)"`
+}
+
+type TestDstTable struct {
+	Id        string `gorm:"type:varchar(255)"`
+	Name      string `gorm:"type:text"`
+	CommitSha string `gorm:"type:varchar(40)"`
+}
+
+var _ core.MigrationScript = (*TestScript)(nil)
+
+type TestScript struct{}
+
+func (*TestScript) Up(basicRes core.BasicRes) errors.Error {
+	return nil
+}
+
+func (*TestScript) Version() uint64 {
+	return 110100100116102
+}
+
+func (*TestScript) Name() string {
+	return "This is only the test script for unit test"
+}
+
+var TestError errors.Error = errors.Default.New("TestError")
+
+func TestTransformTable(t *testing.T) {
+	mockRows := new(mocks.Rows)
+	mockRows.On("Next").Return(true).Times(3)
+	mockRows.On("Next").Return(false).Once()
+	mockRows.On("Close").Return(nil).Twice()
+
+	mockDal := new(mocks.Dal)
+	mockDal.On("Cursor", mock.Anything).Return(mockRows, nil).Once()
+	mockDal.On("GetPrimaryKeyFields", mock.Anything).Return(
+		[]reflect.StructField{
+			{Name: "Id", Type: reflect.TypeOf("")},
+		},
+	)
+	// create the test data
+	mockDal.On("Fetch", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		dst := args.Get(1).(*TestSrcTable)
+		dst.Name = "test1"
+		dst.CommitSha = "85d898dab1984d744f99a3a9127aefd43632e000f3ef48c29d0c5b043cf251ed"
+		dst.Id = dst.Name + dst.CommitSha
+	}).Return(nil).Once()
+	mockDal.On("Fetch", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		dst := args.Get(1).(*TestSrcTable)
+		dst.Name = "test2"
+		dst.CommitSha = "85d898dab1984d744f99a3a9127aefd43632e000f3ef48c29d0c5b043cf251ed"
+		dst.Id = dst.Name + dst.CommitSha
+	}).Return(nil).Once()
+	mockDal.On("Fetch", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		dst := args.Get(1).(*TestSrcTable)
+		dst.Name = "test3"
+		dst.CommitSha = "57ef3d346f24f386216563752b0c447a35c041e0b7143f929dc4de27742e3307"
+		dst.Id = dst.Name + dst.CommitSha
+	}).Return(nil).Once()
+
+	// checking if it Create Drop and Rename the right table
+	mockDal.On("AutoMigrate", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		_, ok := args.Get(0).(*TestDstTable)
+		assert.Equal(t, ok, true)
+	}).Return(nil).Once()
+	mockDal.On("DropTables", mock.Anything).Run(func(args mock.Arguments) {
+		tmpname, ok := args.Get(0).([]interface{})[0].(string)
+		assert.Equal(t, ok, true)
+		assert.NotEqual(t, TestTableNameSrc, tmpname)
+	}).Return(nil).Once()
+	mockDal.On("RenameTable", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		oldname, ok := args.Get(0).(string)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, TestTableNameSrc, oldname)
+		tmpname, ok := args.Get(1).(string)
+		assert.Equal(t, ok, true)
+		assert.NotEqual(t, oldname, tmpname)
+	}).Return(nil).Once()
+
+	// checking the test data
+	mockDal.On("CreateOrUpdate", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		dts := args.Get(0).([]*TestDstTable)
+		assert.Equal(t, dts[0].Name, "test1")
+		assert.Equal(t, dts[0].CommitSha, "85d898dab1984d744f99a3a9127aefd43632e000f3ef48c29d0c5b043cf251ed")
+		assert.Equal(t, dts[0].Id, "1b4f0e9851971998e732078544c96b36c3d01cedf7caa332359d6f1d8356701485d898dab1984d744f99a3a9127aefd43632e000f3ef48c29d0c5b043cf251ed")
+		assert.Equal(t, dts[1].Name, "test2")
+		assert.Equal(t, dts[1].CommitSha, "85d898dab1984d744f99a3a9127aefd43632e000f3ef48c29d0c5b043cf251ed")
+		assert.Equal(t, dts[1].Id, "60303ae22b998861bce3b28f33eec1be758a213c86c93c076dbe9f558c11c75285d898dab1984d744f99a3a9127aefd43632e000f3ef48c29d0c5b043cf251ed")
+		assert.Equal(t, dts[2].Name, "test3")
+		assert.Equal(t, dts[2].CommitSha, "57ef3d346f24f386216563752b0c447a35c041e0b7143f929dc4de27742e3307")
+		assert.Equal(t, dts[2].Id, "fd61a03af4f77d870fc21e05e7e80678095c92d808cfb3b5c279ee04c74aca1357ef3d346f24f386216563752b0c447a35c041e0b7143f929dc4de27742e3307")
+	}).Return(nil).Once()
+
+	mockLog := unithelper.DummyLogger()
+	mockRes := new(mocks.BasicRes)
+
+	mockRes.On("GetDal").Return(mockDal)
+	mockRes.On("GetLogger").Return(mockLog)
+
+	err := TransformTable(mockRes, &TestScript{}, TestTableNameSrc,
+		func(src *TestSrcTable) (*TestDstTable, errors.Error) {
+			shaName := sha256.New()
+			shaName.Write([]byte(src.Name))
+			return &TestDstTable{
+				Id:        hex.EncodeToString(shaName.Sum(nil)) + src.CommitSha,
+				Name:      src.Name,
+				CommitSha: src.CommitSha,
+			}, nil
+		})
+
+	assert.Nil(t, err)
+}
+
+func TestTransformTable_RollBack(t *testing.T) {
+	mockRows := new(mocks.Rows)
+	mockRows.On("Next").Return(true).Once()
+	mockRows.On("Close").Return(nil).Twice()
+
+	mockDal := new(mocks.Dal)
+	mockDal.On("Cursor", mock.Anything).Return(mockRows, nil).Once()
+	mockDal.On("GetPrimaryKeyFields", mock.Anything).Return(
+		[]reflect.StructField{
+			{Name: "Id", Type: reflect.TypeOf("")},
+		},
+	)
+
+	// retruen the error when fetch for rollback
+	mockDal.On("Fetch", mock.Anything, mock.Anything).Return(TestError).Once()
+
+	// checking if it AutoMigrate and Rename the right table
+	mockDal.On("AutoMigrate", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		_, ok := args.Get(0).(*TestDstTable)
+		assert.Equal(t, ok, true)
+	}).Return(nil).Once()
+	mockDal.On("RenameTable", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		oldname, ok := args.Get(0).(string)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, TestTableNameSrc, oldname)
+		tmpname, ok := args.Get(1).(string)
+		assert.Equal(t, ok, true)
+		assert.NotEqual(t, oldname, tmpname)
+	}).Return(nil).Once()
+
+	// checking if Rename and Drop RollBack working with rigth table
+	mockDal.On("RenameTable", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		tmpname, ok := args.Get(0).(string)
+		assert.Equal(t, ok, true)
+		assert.NotEqual(t, TestTableNameSrc, tmpname)
+		oldname, ok := args.Get(1).(string)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, oldname, TestTableNameSrc)
+	}).Return(nil).Once()
+	mockDal.On("DropTables", mock.Anything).Run(func(args mock.Arguments) {
+		oldname, ok := args.Get(0).([]interface{})[0].(string)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, oldname, TestTableNameSrc)
+	}).Return(nil).Once()
+
+	mockLog := unithelper.DummyLogger()
+	mockRes := new(mocks.BasicRes)
+
+	mockRes.On("GetDal").Return(mockDal)
+	mockRes.On("GetLogger").Return(mockLog)
+
+	err := TransformTable(mockRes, &TestScript{}, TestTableNameSrc,
+		func(src *TestSrcTable) (*TestDstTable, errors.Error) {
+			shaName := sha256.New()
+			shaName.Write([]byte(src.Name))
+			return &TestDstTable{
+				Id:        hex.EncodeToString(shaName.Sum(nil)) + src.CommitSha,
+				Name:      src.Name,
+				CommitSha: src.CommitSha,
+			}, nil
+		})
+
+	assert.Equal(t, err.Unwrap().Error(), TestError.Unwrap().Error())
+}
+
+func TestTransformColumns(t *testing.T) {
+	mockRows := new(mocks.Rows)
+	mockRows.On("Next").Return(true).Times(3)
+	mockRows.On("Next").Return(false).Once()
+	mockRows.On("Close").Return(nil).Twice()
+
+	mockDal := new(mocks.Dal)
+	mockDal.On("Cursor", mock.Anything).Return(mockRows, nil).Once()
+	mockDal.On("GetPrimaryKeyFields", mock.Anything).Return(
+		[]reflect.StructField{
+			{Name: "Id", Type: reflect.TypeOf("")},
+		},
+	)
+	// create the test data
+	mockDal.On("Fetch", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		dst := args.Get(1).(*TestSrcTable)
+		dst.Name = "test1"
+		dst.CommitSha = "85d898dab1984d744f99a3a9127aefd43632e000f3ef48c29d0c5b043cf251ed"
+		dst.Id = dst.Name + dst.CommitSha
+	}).Return(nil).Once()
+	mockDal.On("Fetch", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		dst := args.Get(1).(*TestSrcTable)
+		dst.Name = "test2"
+		dst.CommitSha = "85d898dab1984d744f99a3a9127aefd43632e000f3ef48c29d0c5b043cf251ed"
+		dst.Id = dst.Name + dst.CommitSha
+	}).Return(nil).Once()
+	mockDal.On("Fetch", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		dst := args.Get(1).(*TestSrcTable)
+		dst.Name = "test3"
+		dst.CommitSha = "57ef3d346f24f386216563752b0c447a35c041e0b7143f929dc4de27742e3307"
+		dst.Id = dst.Name + dst.CommitSha
+	}).Return(nil).Once()
+
+	// checking if it Create Drop and Rename the right table
+	mockDal.On("AutoMigrate", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		_, ok := args.Get(0).(*TestDstTable)
+		assert.Equal(t, ok, true)
+	}).Return(nil).Once()
+	mockDal.On("DropColumns", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		tableName, ok := args.Get(0).(string)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, TestTableNameSrc, tableName)
+		tmpcolumnNames, ok := args.Get(1).([]string)
+		assert.Equal(t, ok, true)
+		assert.NotEqual(t, TestColumeName, tmpcolumnNames[0])
+	}).Return(nil).Once()
+	mockDal.On("RenameColumn", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		tableName, ok := args.Get(0).(string)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, tableName, TestTableNameSrc)
+		columnName, ok := args.Get(1).(string)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, columnName, TestColumeName)
+		tmpColumnName, ok := args.Get(2).(string)
+		assert.Equal(t, ok, true)
+		assert.NotEqual(t, columnName, tmpColumnName)
+	}).Return(nil).Once()
+
+	// checking the test data
+	mockDal.On("CreateOrUpdate", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		dts := args.Get(0).([]*TestDstTable)
+		assert.Equal(t, dts[0].Name, "test1")
+		assert.Equal(t, dts[0].CommitSha, "85d898dab1984d744f99a3a9127aefd43632e000f3ef48c29d0c5b043cf251ed")
+		assert.Equal(t, dts[0].Id, "1b4f0e9851971998e732078544c96b36c3d01cedf7caa332359d6f1d8356701485d898dab1984d744f99a3a9127aefd43632e000f3ef48c29d0c5b043cf251ed")
+		assert.Equal(t, dts[1].Name, "test2")
+		assert.Equal(t, dts[1].CommitSha, "85d898dab1984d744f99a3a9127aefd43632e000f3ef48c29d0c5b043cf251ed")
+		assert.Equal(t, dts[1].Id, "60303ae22b998861bce3b28f33eec1be758a213c86c93c076dbe9f558c11c75285d898dab1984d744f99a3a9127aefd43632e000f3ef48c29d0c5b043cf251ed")
+		assert.Equal(t, dts[2].Name, "test3")
+		assert.Equal(t, dts[2].CommitSha, "57ef3d346f24f386216563752b0c447a35c041e0b7143f929dc4de27742e3307")
+		assert.Equal(t, dts[2].Id, "fd61a03af4f77d870fc21e05e7e80678095c92d808cfb3b5c279ee04c74aca1357ef3d346f24f386216563752b0c447a35c041e0b7143f929dc4de27742e3307")
+	}).Return(nil).Once()
+
+	mockLog := unithelper.DummyLogger()
+	mockRes := new(mocks.BasicRes)
+
+	mockRes.On("GetDal").Return(mockDal)
+	mockRes.On("GetLogger").Return(mockLog)
+
+	err := TransformColumns(mockRes, &TestScript{}, TestTableNameSrc,
+		[]string{
+			TestColumeName,
+		},
+		func(src *TestSrcTable) (*TestDstTable, errors.Error) {
+			shaName := sha256.New()
+			shaName.Write([]byte(src.Name))
+			return &TestDstTable{
+				Id:        hex.EncodeToString(shaName.Sum(nil)) + src.CommitSha,
+				Name:      src.Name,
+				CommitSha: src.CommitSha,
+			}, nil
+		})
+
+	assert.Nil(t, err)
+}
+
+func TestTransformColumns_RollBack(t *testing.T) {
+	mockRows := new(mocks.Rows)
+	mockRows.On("Next").Return(true).Once()
+	mockRows.On("Close").Return(nil).Twice()
+
+	mockDal := new(mocks.Dal)
+	mockDal.On("Cursor", mock.Anything).Return(mockRows, nil).Once()
+	mockDal.On("GetPrimaryKeyFields", mock.Anything).Return(
+		[]reflect.StructField{
+			{Name: "Id", Type: reflect.TypeOf("")},
+		},
+	)
+
+	// retruen the error when fetch for rollback
+	mockDal.On("Fetch", mock.Anything, mock.Anything).Return(TestError).Once()
+
+	// checking if it AutoMigrate and Rename the right table
+	mockDal.On("AutoMigrate", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		_, ok := args.Get(0).(*TestDstTable)
+		assert.Equal(t, ok, true)
+	}).Return(nil).Once()
+	mockDal.On("RenameColumn", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		tableName, ok := args.Get(0).(string)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, tableName, TestTableNameSrc)
+		columnName, ok := args.Get(1).(string)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, columnName, TestColumeName)
+		tmpColumnName, ok := args.Get(2).(string)
+		assert.Equal(t, ok, true)
+		assert.NotEqual(t, columnName, tmpColumnName)
+	}).Return(nil).Once()
+
+	// checking if Rename and Drop RollBack working with rigth table
+	mockDal.On("RenameColumn", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		tableName, ok := args.Get(0).(string)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, tableName, TestTableNameSrc)
+		columnName, ok := args.Get(2).(string)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, columnName, TestColumeName)
+		tmpColumnName, ok := args.Get(1).(string)
+		assert.Equal(t, ok, true)
+		assert.NotEqual(t, columnName, tmpColumnName)
+	}).Return(nil).Once()
+	mockDal.On("DropColumns", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		tableName, ok := args.Get(0).(string)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, TestTableNameSrc, tableName)
+		tmpcolumnNames, ok := args.Get(1).([]string)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, TestColumeName, tmpcolumnNames[0])
+	}).Return(nil).Once()
+
+	mockLog := unithelper.DummyLogger()
+	mockRes := new(mocks.BasicRes)
+
+	mockRes.On("GetDal").Return(mockDal)
+	mockRes.On("GetLogger").Return(mockLog)
+
+	err := TransformColumns(mockRes, &TestScript{}, TestTableNameSrc,
+		[]string{
+			TestColumeName,
+		},
+		func(src *TestSrcTable) (*TestDstTable, errors.Error) {
+			shaName := sha256.New()
+			shaName.Write([]byte(src.Name))
+			return &TestDstTable{
+				Id:        hex.EncodeToString(shaName.Sum(nil)) + src.CommitSha,
+				Name:      src.Name,
+				CommitSha: src.CommitSha,
+			}, nil
+		})
+
+	assert.Equal(t, err.Unwrap().Error(), TestError.Unwrap().Error())
+}
+
+func TestChangeColumnsType(t *testing.T) {
+	mockDal := new(mocks.Dal)
+
+	// checking if it Create Drop and Rename the right table
+	mockDal.On("AutoMigrate", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		_, ok := args.Get(0).(*TestDstTable)
+		assert.Equal(t, ok, true)
+	}).Return(nil).Once()
+	mockDal.On("DropColumns", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		tableName, ok := args.Get(0).(string)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, TestTableNameSrc, tableName)
+		tmpcolumnNames, ok := args.Get(1).([]string)
+		assert.Equal(t, ok, true)
+		assert.NotEqual(t, TestColumeName, tmpcolumnNames[0])
+	}).Return(nil).Once()
+	mockDal.On("RenameColumn", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		tableName, ok := args.Get(0).(string)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, tableName, TestTableNameSrc)
+		columnName, ok := args.Get(1).(string)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, columnName, TestColumeName)
+		tmpColumnName, ok := args.Get(2).(string)
+		assert.Equal(t, ok, true)
+		assert.NotEqual(t, columnName, tmpColumnName)
+	}).Return(nil).Once()
+
+	mockLog := unithelper.DummyLogger()
+	mockRes := new(mocks.BasicRes)
+
+	mockRes.On("GetDal").Return(mockDal)
+	mockRes.On("GetLogger").Return(mockLog)
+
+	err := ChangeColumnsType[TestDstTable](mockRes, &TestScript{}, TestTableNameSrc,
+		[]string{
+			TestColumeName,
+		},
+		func(tmpColumnParams []interface{}) errors.Error {
+			assert.Equal(t, len(tmpColumnParams), 1)
+			cp, ok := (tmpColumnParams[0]).(dal.ClauseColumn)
+			assert.Equal(t, ok, true)
+			assert.NotEqual(t, TestColumeName, cp.Name)
+			return nil
+		})
+
+	assert.Nil(t, err)
+}
+
+func TestChangeColumnsType_Rollback(t *testing.T) {
+	mockDal := new(mocks.Dal)
+
+	// checking if it AutoMigrate and Rename the right table
+	mockDal.On("AutoMigrate", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		_, ok := args.Get(0).(*TestDstTable)
+		assert.Equal(t, ok, true)
+	}).Return(nil).Once()
+	mockDal.On("RenameColumn", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		tableName, ok := args.Get(0).(string)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, tableName, TestTableNameSrc)
+		columnName, ok := args.Get(1).(string)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, columnName, TestColumeName)
+		tmpColumnName, ok := args.Get(2).(string)
+		assert.Equal(t, ok, true)
+		assert.NotEqual(t, columnName, tmpColumnName)
+	}).Return(nil).Once()
+
+	// checking if Rename and Drop RollBack working with rigth table
+	mockDal.On("RenameColumn", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		tableName, ok := args.Get(0).(string)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, tableName, TestTableNameSrc)
+		columnName, ok := args.Get(2).(string)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, columnName, TestColumeName)
+		tmpColumnName, ok := args.Get(1).(string)
+		assert.Equal(t, ok, true)
+		assert.NotEqual(t, columnName, tmpColumnName)
+	}).Return(nil).Once()
+	mockDal.On("DropColumns", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		tableName, ok := args.Get(0).(string)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, TestTableNameSrc, tableName)
+		tmpcolumnNames, ok := args.Get(1).([]string)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, TestColumeName, tmpcolumnNames[0])
+	}).Return(nil).Once()
+
+	mockLog := unithelper.DummyLogger()
+	mockRes := new(mocks.BasicRes)
+
+	mockRes.On("GetDal").Return(mockDal)
+	mockRes.On("GetLogger").Return(mockLog)
+
+	err := ChangeColumnsType[TestDstTable](mockRes, &TestScript{}, TestTableNameSrc,
+		[]string{
+			TestColumeName,
+		},
+		func(tmpColumnParams []interface{}) errors.Error {
+			return TestError
+		})
+
+	assert.Equal(t, err.Unwrap().Error(), TestError.Unwrap().Error())
+}

--- a/helpers/migrationhelper/migrationhelper_test.go
+++ b/helpers/migrationhelper/migrationhelper_test.go
@@ -224,10 +224,10 @@ func TestTransformTable_RollBack(t *testing.T) {
 			}, nil
 		})
 
-	assert.Equal(t, err.Unwrap().Error(), TestError.Unwrap().Error())
+	assert.Contains(t, err.Unwrap().Error(), TestError.Unwrap().Error())
 }
 
-func TestCopyTableColumn(t *testing.T) {
+func TestCopyTableColumns(t *testing.T) {
 	mockRows := new(mocks.Rows)
 
 	mockRows.On("Next").Return(true).Times(3)
@@ -306,7 +306,7 @@ func TestCopyTableColumn(t *testing.T) {
 	mockRes.On("GetDal").Return(mockDal)
 	mockRes.On("GetLogger").Return(mockLog)
 
-	err := CopyTableColumn(mockRes, TestTableNameSrc, TestTableNameDst,
+	err := CopyTableColumns(mockRes, TestTableNameSrc, TestTableNameDst,
 		func(src *TestSrcTable) (*TestDstTable, errors.Error) {
 			shaName := sha256.New()
 			shaName.Write([]byte(src.Name))
@@ -320,7 +320,7 @@ func TestCopyTableColumn(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestCopyTableColumn_RollBack(t *testing.T) {
+func TestCopyTableColumns_RollBack(t *testing.T) {
 	mockRows := new(mocks.Rows)
 	mockRows.On("Next").Return(true).Once()
 	mockRows.On("Close").Return(nil).Twice()
@@ -377,7 +377,7 @@ func TestCopyTableColumn_RollBack(t *testing.T) {
 	mockRes.On("GetDal").Return(mockDal)
 	mockRes.On("GetLogger").Return(mockLog)
 
-	err := CopyTableColumn(mockRes, TestTableNameSrc, TestTableNameDst,
+	err := CopyTableColumns(mockRes, TestTableNameSrc, TestTableNameDst,
 		func(src *TestSrcTable) (*TestDstTable, errors.Error) {
 			shaName := sha256.New()
 			shaName.Write([]byte(src.Name))
@@ -388,7 +388,7 @@ func TestCopyTableColumn_RollBack(t *testing.T) {
 			}, nil
 		})
 
-	assert.Equal(t, err.Unwrap().Error(), TestError.Unwrap().Error())
+	assert.Contains(t, err.Unwrap().Error(), TestError.Unwrap().Error())
 }
 
 func TestTransformColumns(t *testing.T) {
@@ -560,7 +560,7 @@ func TestTransformColumns_RollBack(t *testing.T) {
 			}, nil
 		})
 
-	assert.Equal(t, err.Unwrap().Error(), TestError.Unwrap().Error())
+	assert.Contains(t, err.Unwrap().Error(), TestError.Unwrap().Error())
 }
 
 func TestChangeColumnsType(t *testing.T) {
@@ -667,5 +667,5 @@ func TestChangeColumnsType_Rollback(t *testing.T) {
 			return TestError
 		})
 
-	assert.Equal(t, err.Unwrap().Error(), TestError.Unwrap().Error())
+	assert.Contains(t, err.Unwrap().Error(), TestError.Unwrap().Error())
 }

--- a/impl/dalgorm/dalgorm.go
+++ b/impl/dalgorm/dalgorm.go
@@ -19,6 +19,7 @@ package dalgorm
 
 import (
 	"database/sql"
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -120,7 +121,7 @@ func (d *Dalgorm) AutoMigrate(entity interface{}, clauses ...dal.Clause) errors.
 }
 
 // Cursor returns a database cursor, cursor is especially useful when handling big amount of rows of data
-func (d *Dalgorm) Cursor(clauses ...dal.Clause) (*sql.Rows, errors.Error) {
+func (d *Dalgorm) Cursor(clauses ...dal.Clause) (dal.Rows, errors.Error) {
 	return errors.Convert01(buildTx(d.db, clauses).Rows())
 }
 
@@ -130,8 +131,12 @@ func (d *Dalgorm) CursorTx(clauses ...dal.Clause) *gorm.DB {
 }
 
 // Fetch loads row data from `cursor` into `dst`
-func (d *Dalgorm) Fetch(cursor *sql.Rows, dst interface{}) errors.Error {
-	return errors.Convert(d.db.ScanRows(cursor, dst))
+func (d *Dalgorm) Fetch(cursor dal.Rows, dst interface{}) errors.Error {
+	if rows, ok := cursor.(*sql.Rows); ok {
+		return errors.Convert(d.db.ScanRows(rows, dst))
+	} else {
+		return errors.Default.New(fmt.Sprintf("can not support type %s to be a dal.Rows interface", reflect.TypeOf(cursor).String()))
+	}
 }
 
 // All loads matched rows from database to `dst`, USE IT WITH COUTIOUS!!

--- a/models/migrationscripts/20220913_fix_commitfile_id_toolong.go
+++ b/models/migrationscripts/20220913_fix_commitfile_id_toolong.go
@@ -73,6 +73,7 @@ func (script *fixCommitFileIdTooLong) Up(basicRes core.BasicRes) errors.Error {
 	if err != nil {
 		return err
 	}
+
 	// migrate related table
 	return migrationhelper.TransformTable(
 		basicRes,

--- a/models/migrationscripts/20221109_modfiy_commits_diffs.go
+++ b/models/migrationscripts/20221109_modfiy_commits_diffs.go
@@ -76,7 +76,7 @@ func (script *modifyCommitsDiffs) Up(basicRes core.BasicRes) errors.Error {
 	}
 
 	// copy data
-	err = migrationhelper.CopyTableColumn(
+	err = migrationhelper.CopyTableColumns(
 		basicRes,
 		RefsCommitsDiff20221109{}.TableName(),
 		CommitsDiff20221109{}.TableName(),

--- a/plugins/core/dal/dal.go
+++ b/plugins/core/dal/dal.go
@@ -76,9 +76,9 @@ type Dal interface {
 	// Exec executes raw sql query
 	Exec(query string, params ...interface{}) errors.Error
 	// Cursor returns a database cursor, cursor is especially useful when handling big amount of rows of data
-	Cursor(clauses ...Clause) (*sql.Rows, errors.Error)
+	Cursor(clauses ...Clause) (Rows, errors.Error)
 	// Fetch loads row data from `cursor` into `dst`
-	Fetch(cursor *sql.Rows, dst interface{}) errors.Error
+	Fetch(cursor Rows, dst interface{}) errors.Error
 	// All loads matched rows from database to `dst`, USE IT WITH CAUTIOUS!!
 	All(dst interface{}, clauses ...Clause) errors.Error
 	// First loads first matched row from database to `dst`, error will be returned if no records were found
@@ -119,6 +119,34 @@ type Dal interface {
 	DropIndexes(table string, indexes ...string) errors.Error
 	// Dialect returns the dialect of current database
 	Dialect() string
+}
+
+type Rows interface {
+	// Next prepares the next result row for reading with the Scan method. It
+	// returns true on success, or false if there is no next result row or an error
+	// happened while preparing it. Err should be consulted to distinguish between
+	// the two cases.
+	//
+	// Every call to Scan, even the first one, must be preceded by a call to Next.
+	Next() bool
+
+	// Close closes the Rows, preventing further enumeration. If Next is called
+	// and returns false and there are no further result sets,
+	// the Rows are closed automatically and it will suffice to check the
+	// result of Err. Close is idempotent and does not affect the result of Err.
+	Close() error
+
+	// Scan copies the columns in the current row into the values pointed at by dest.
+	// The number of values in dest must be the same as the number of columns in Rows.
+	Scan(dest ...any) error
+
+	// Columns returns the column names.
+	// Columns returns an error if the rows are closed.
+	Columns() ([]string, error)
+
+	// ColumnTypes returns column information such as column type, length,
+	// and nullable. Some information may not be available from some drivers.
+	ColumnTypes() ([]*sql.ColumnType, error)
 }
 
 // GetColumnNames returns table Column Names in database

--- a/plugins/core/dal/dal.go
+++ b/plugins/core/dal/dal.go
@@ -28,6 +28,17 @@ type Tabler interface {
 	TableName() string
 }
 
+// Default Table is working for the Tabler interface witch only need TableName
+type DefaultTabler struct {
+	Name string
+}
+
+var _ Tabler = (*DefaultTabler)(nil)
+
+func (d DefaultTabler) TableName() string {
+	return d.Name
+}
+
 // Clause represents SQL Clause
 type Clause struct {
 	Type string

--- a/plugins/dora/tasks/cicd_task_env_enricher.go
+++ b/plugins/dora/tasks/cicd_task_env_enricher.go
@@ -18,7 +18,6 @@ limitations under the License.
 package tasks
 
 import (
-	"database/sql"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -63,7 +62,7 @@ func EnrichTasksEnv(taskCtx core.SubTaskContext) (err errors.Error) {
 	// 	return errors.Default.Wrap(errRegexp, "Regexp compile testingPattern failed")
 	// }
 
-	var cursor *sql.Rows
+	var cursor dal.Rows
 	if len(prefix) == 0 {
 		cursor, err = db.Cursor(
 			dal.From(&devops.CICDTask{}),

--- a/plugins/helper/data_convertor.go
+++ b/plugins/helper/data_convertor.go
@@ -18,11 +18,12 @@ limitations under the License.
 package helper
 
 import (
-	"database/sql"
-	"github.com/apache/incubator-devlake/errors"
 	"reflect"
 
+	"github.com/apache/incubator-devlake/errors"
+
 	"github.com/apache/incubator-devlake/plugins/core"
+	"github.com/apache/incubator-devlake/plugins/core/dal"
 )
 
 // DataConvertHandler Accept row from source cursor, return list of entities that need to be stored
@@ -41,7 +42,7 @@ type DataConverterArgs struct {
 	RawDataSubTaskArgs
 	// Domain layer entity Id prefix, i.e. `jira:JiraIssue:1`, `github:GithubIssue`
 	InputRowType reflect.Type
-	Input        *sql.Rows
+	Input        dal.Rows
 	Convert      DataConvertHandler
 	BatchSize    int
 }

--- a/plugins/helper/iterator.go
+++ b/plugins/helper/iterator.go
@@ -18,10 +18,10 @@ limitations under the License.
 package helper
 
 import (
-	"database/sql"
-	"github.com/apache/incubator-devlake/errors"
 	"reflect"
 	"time"
+
+	"github.com/apache/incubator-devlake/errors"
 
 	"github.com/apache/incubator-devlake/plugins/core/dal"
 )
@@ -36,18 +36,18 @@ type Iterator interface {
 // DalCursorIterator FIXME ...
 type DalCursorIterator struct {
 	db        dal.Dal
-	cursor    *sql.Rows
+	cursor    dal.Rows
 	elemType  reflect.Type
 	batchSize int
 }
 
 // NewDalCursorIterator FIXME ...
-func NewDalCursorIterator(db dal.Dal, cursor *sql.Rows, elemType reflect.Type) (*DalCursorIterator, errors.Error) {
+func NewDalCursorIterator(db dal.Dal, cursor dal.Rows, elemType reflect.Type) (*DalCursorIterator, errors.Error) {
 	return NewBatchedDalCursorIterator(db, cursor, elemType, -1)
 }
 
 // NewBatchedDalCursorIterator FIXME ...
-func NewBatchedDalCursorIterator(db dal.Dal, cursor *sql.Rows, elemType reflect.Type, batchSize int) (*DalCursorIterator, errors.Error) {
+func NewBatchedDalCursorIterator(db dal.Dal, cursor dal.Rows, elemType reflect.Type, batchSize int) (*DalCursorIterator, errors.Error) {
 	return &DalCursorIterator{
 		db:        db,
 		cursor:    cursor,

--- a/plugins/jira/models/migrationscripts/20220716_add_init_tables.go
+++ b/plugins/jira/models/migrationscripts/20220716_add_init_tables.go
@@ -85,10 +85,15 @@ func (script *addInitTables20220716) Up(basicRes core.BasicRes) errors.Error {
 	if encKey == "" {
 		return errors.BadInput.New("jira v0.11 invalid encKey")
 	}
-	err = migrationhelper.TransformTable(
+
+	err = migrationhelper.TransformColumns(
 		basicRes,
 		script,
 		"_tool_jira_connections",
+		[]string{
+			"rate_limit",
+			"basic_auth_encoded",
+		},
 		func(old *jiraConnection20220716Before) (*jiraConnection20220716After, errors.Error) {
 			conn := &jiraConnection20220716After{}
 			conn.ID = old.ID

--- a/plugins/starrocks/tasks.go
+++ b/plugins/starrocks/tasks.go
@@ -226,7 +226,7 @@ func loadData(starrocks *sql.DB, c core.SubTaskContext, starrocksTable, starrock
 	offset := 0
 	var err error
 	for {
-		var rows *sql.Rows
+		var rows dal.Rows
 		var data []map[string]interface{}
 		// select data from db
 		rows, err = db.Cursor(


### PR DESCRIPTION
# Summary
Add dal.Rows interface for the mocking of *sql.Rows..
Add TestTransformTable
Add TestTransformTable_RollBack
Add TestTransformColumns
Add TestTransformColumns_RollBack
Add TestChangeColumnsType
Add TestChangeColumnsType_Rollback
Add TestCopyTableColumns
Add TestCopyTableColumns_RollBack
Fix the error lost on Transform rollback.
Fix the error about migration script fixCommitFileIdTooLong use the wrong table name.

### Does this close any open issues?
Closes #3332 
Closes #3333 
Closes #3714 
Closes #3724
Closes #3725 
Closes #3735
Closes #3739 
Closes #3741 
### Screenshots
![image](https://user-images.githubusercontent.com/2921251/201089379-8cab5580-b0d9-4945-b2a6-dd00280747d5.png)
![image](https://user-images.githubusercontent.com/2921251/201089414-1e33c355-80d2-4073-905e-3b1ed60b96af.png)
![image](https://user-images.githubusercontent.com/2921251/201089449-365a1f05-64e9-477d-86b2-40781c6c95f8.png)
![image](https://user-images.githubusercontent.com/2921251/201089478-825ed443-6e71-4780-8565-306ab9c92b40.png)
![image](https://user-images.githubusercontent.com/2921251/201089521-f5ca8b92-0f6c-454f-9f13-afabf6499588.png)
![image](https://user-images.githubusercontent.com/2921251/201089561-22abd052-c596-4240-9e1f-8c97160c3b3e.png)
![image](https://user-images.githubusercontent.com/2921251/201662548-ac75f1b8-cc09-4c7e-b7b7-f2b0e76cc103.png)
![image](https://user-images.githubusercontent.com/2921251/201662690-a407e89f-7981-48ae-878a-efd1f2ecd598.png)
