### PR TITLE
fix(dora): change condition when selecting prs

### DIFF
--- a/plugins/dora/tasks/change_lead_time_calculator.go
+++ b/plugins/dora/tasks/change_lead_time_calculator.go
@@ -33,15 +33,9 @@ import (
 
 func CalculateChangeLeadTime(taskCtx core.SubTaskContext) errors.Error {
 	db := taskCtx.GetDal()
-	repoIdList := make([]string, 0)
-	repoClause := dal.From(&code.Repo{})
-	err := db.Pluck("id", &repoIdList, repoClause)
-	if err != nil {
-		return err
-	}
 	clauses := []dal.Clause{
 		dal.From(&code.PullRequest{}),
-		dal.Where("merged_date IS NOT NULL and head_repo_id in ?", repoIdList),
+		dal.Where("merged_date IS NOT NULL"),
 	}
 	cursor, err := db.Cursor(clauses...)
 	if err != nil {


### PR DESCRIPTION
# Summary

we once used pr.head_repo_id to filter prs, this is wrong.
So now we change to select all merged prs

### Does this close any open issues?
closes #3397

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
