### PR TITLE
fix: most PRs don't have deploy time after dora.calculateChangeLeadTime subtask

### DIFF
--- a/plugins/github/github.go
+++ b/plugins/github/github.go
@@ -45,23 +45,25 @@ func main() {
 	issueTypeBug := cmd.Flags().String("issueTypeBug", "^(bug|failure|error)$", "issue type bug")
 	issueTypeIncident := cmd.Flags().String("issueTypeIncident", "", "issue type incident")
 	issueTypeRequirement := cmd.Flags().String("issueTypeRequirement", "^(feat|feature|proposal|requirement)$", "issue type requirement")
-	deployTagPattern := cmd.Flags().String("deployTagPattern", "(?i)deploy", "deploy tag name")
+	deploymentPattern := cmd.Flags().String("deploymentPattern", "(?i)deploy", "deploy tag name")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		runner.DirectRun(cmd, args, PluginEntry, map[string]interface{}{
-			"connectionId":         *connectionId,
-			"owner":                *owner,
-			"repo":                 *repo,
-			"prType":               *prType,
-			"prComponent":          *prComponent,
-			"prBodyClosePattern":   *prBodyClosePattern,
-			"issueSeverity":        *issueSeverity,
-			"issuePriority":        *issuePriority,
-			"issueComponent":       *issueComponent,
-			"issueTypeBug":         *issueTypeBug,
-			"issueTypeIncident":    *issueTypeIncident,
-			"issueTypeRequirement": *issueTypeRequirement,
-			"deployTagPattern":     *deployTagPattern,
+			"connectionId": *connectionId,
+			"owner":        *owner,
+			"repo":         *repo,
+			"transformationRules": map[string]interface{}{
+				"prType":               *prType,
+				"prComponent":          *prComponent,
+				"prBodyClosePattern":   *prBodyClosePattern,
+				"issueSeverity":        *issueSeverity,
+				"issuePriority":        *issuePriority,
+				"issueComponent":       *issueComponent,
+				"issueTypeBug":         *issueTypeBug,
+				"issueTypeIncident":    *issueTypeIncident,
+				"issueTypeRequirement": *issueTypeRequirement,
+				"deploymentPattern":    *deploymentPattern,
+			},
 		})
 	}
 	runner.RunCmd(cmd)


### PR DESCRIPTION
# Summary

With this fix, most PRs would have deploy time except those yet to be deployed
![image](https://user-images.githubusercontent.com/61080/195340770-38f9f66f-6b89-4a6e-80ac-d4c34bf90d3d.png)

**HOWEVER, IT DOESN'T SOLVE ALL PROBLEMS**
Previously, we presume that `deployment.environment` could be deduced by the `cicd_task.name`, which is fundamentally wrong judge by our own repo's data.
The following screenshot shows our github action jobs for `testing/production`, the name for both environments are identical, we can not tell the difference by looking at the `job.name` solely.
![image](https://user-images.githubusercontent.com/61080/195341897-20e08e42-f4e3-404f-a302-2cb79dbd2bf7.png)



### Does this close any open issues?
Closes #3376