### PR TITLE
fix: display curl in the webhook page

### DIFF
--- a/config-ui/src/pages/connections/incoming-webhook/add-modal.jsx
+++ b/config-ui/src/pages/connections/incoming-webhook/add-modal.jsx
@@ -142,7 +142,7 @@ export const AddModal = ({ onSubmit, onCancel }) => {
               <h3>Deployment</h3>
               <p>POST to register a deployment</p>
               <div className='block'>
-                <span style={{ flex: '1 0' }}>{record.postDeploymentsCurl}</span>
+                <span>{record.postDeploymentsCurl}</span>
                 <CopyToClipboard text={record.postDeploymentsCurl}>
                   <CopyIcon width={16} height={16} />
                 </CopyToClipboard>

--- a/config-ui/src/pages/connections/incoming-webhook/add-modal.jsx
+++ b/config-ui/src/pages/connections/incoming-webhook/add-modal.jsx
@@ -54,10 +54,10 @@ export const AddModal = ({ onSubmit, onCancel }) => {
     setRecord({
       postIssuesEndpoint: `${postUrlPrefix}${res.postIssuesEndpoint}`,
       closeIssuesEndpoint: `${postUrlPrefix}${res.closeIssuesEndpoint}`,
-      postDeploymentsCurl: `curl ${postUrlPrefix}${res.postPipelineDeployTaskEndpoint} -X 'POST' -d "{
-  \\"repo_url\\":\\"$CIRCLE_REPOSITORY_URL\\",
-  \\"commit_sha\\":\\"$CIRCLE_SHA1\\",
-  \\"start_time\\":\\"$start_time\\"
+      postDeploymentsCurl: `curl ${postUrlPrefix}${r.postPipelineDeployTaskEndpoint} -X 'POST' -d "{
+  \\"repo_url\\":\\"you need fill your repo URL or other unique string here\\",
+  \\"commit_sha\\":\\"the sha of deployment commit\\",
+  \\"start_time\\":\\"Optional, Format should be 2020-01-01T12:00:00+00:00\\"
 }"`
     })
   }

--- a/config-ui/src/pages/connections/incoming-webhook/add-modal.jsx
+++ b/config-ui/src/pages/connections/incoming-webhook/add-modal.jsx
@@ -54,7 +54,7 @@ export const AddModal = ({ onSubmit, onCancel }) => {
     setRecord({
       postIssuesEndpoint: `${postUrlPrefix}${res.postIssuesEndpoint}`,
       closeIssuesEndpoint: `${postUrlPrefix}${res.closeIssuesEndpoint}`,
-      postDeploymentsCurl: `curl ${postUrlPrefix}${r.postPipelineDeployTaskEndpoint} -X 'POST' -d "{
+      postDeploymentsCurl: `curl ${postUrlPrefix}${res.postPipelineDeployTaskEndpoint} -X 'POST' -d "{
   \\"repo_url\\":\\"you need fill your repo URL or other unique string here\\",
   \\"commit_sha\\":\\"the sha of deployment commit\\",
   \\"start_time\\":\\"Optional, Format should be 2020-01-01T12:00:00+00:00\\"

--- a/config-ui/src/pages/connections/incoming-webhook/add-modal.jsx
+++ b/config-ui/src/pages/connections/incoming-webhook/add-modal.jsx
@@ -54,7 +54,11 @@ export const AddModal = ({ onSubmit, onCancel }) => {
     setRecord({
       postIssuesEndpoint: `${postUrlPrefix}${res.postIssuesEndpoint}`,
       closeIssuesEndpoint: `${postUrlPrefix}${res.closeIssuesEndpoint}`,
-      postDeploymentsEndpoint: `${postUrlPrefix}${res.postPipelineDeployTaskEndpoint}`
+      postDeploymentsCurl: `curl ${postUrlPrefix}${res.postPipelineDeployTaskEndpoint} -X 'POST' -d "{
+  \\"repo_url\\":\\"$CIRCLE_REPOSITORY_URL\\",
+  \\"commit_sha\\":\\"$CIRCLE_SHA1\\",
+  \\"start_time\\":\\"$start_time\\"
+}"`
     })
   }
 
@@ -138,8 +142,8 @@ export const AddModal = ({ onSubmit, onCancel }) => {
               <h3>Deployment</h3>
               <p>POST to register a deployment</p>
               <div className='block'>
-                <span>{record.postDeploymentsEndpoint}</span>
-                <CopyToClipboard text={record.postDeploymentsEndpoint}>
+                <span style={{ flex: '1 0' }}>{record.postDeploymentsCurl}</span>
+                <CopyToClipboard text={record.postDeploymentsCurl}>
                   <CopyIcon width={16} height={16} />
                 </CopyToClipboard>
               </div>

--- a/config-ui/src/pages/connections/incoming-webhook/add-modal.jsx
+++ b/config-ui/src/pages/connections/incoming-webhook/add-modal.jsx
@@ -55,9 +55,9 @@ export const AddModal = ({ onSubmit, onCancel }) => {
       postIssuesEndpoint: `${postUrlPrefix}${res.postIssuesEndpoint}`,
       closeIssuesEndpoint: `${postUrlPrefix}${res.closeIssuesEndpoint}`,
       postDeploymentsCurl: `curl ${postUrlPrefix}${res.postPipelineDeployTaskEndpoint} -X 'POST' -d "{
-  \\"repo_url\\":\\"you need fill your repo URL or other unique string here\\",
   \\"commit_sha\\":\\"the sha of deployment commit\\",
-  \\"start_time\\":\\"Optional, Format should be 2020-01-01T12:00:00+00:00\\"
+  \\"repo_url\\":\\"the repo URL of the deployment commit\\",
+  \\"start_time\\":\\"Optional, eg. 2020-01-01T12:00:00+00:00\\"
 }"`
     })
   }

--- a/config-ui/src/pages/connections/incoming-webhook/index.jsx
+++ b/config-ui/src/pages/connections/incoming-webhook/index.jsx
@@ -53,7 +53,11 @@ export const IncomingWebhook = () => {
             ...r,
             postIssuesEndpoint: `${postUrlPrefix}${r.postIssuesEndpoint}`,
             closeIssuesEndpoint: `${postUrlPrefix}${r.closeIssuesEndpoint}`,
-            postDeploymentsEndpoint: `${postUrlPrefix}${r.postPipelineDeployTaskEndpoint}`
+            postDeploymentsCurl: `curl ${postUrlPrefix}${r.postPipelineDeployTaskEndpoint} -X 'POST' -d "{
+  \\"repo_url\\":\\"$CIRCLE_REPOSITORY_URL\\",
+  \\"commit_sha\\":\\"$CIRCLE_SHA1\\",
+  \\"start_time\\":\\"$start_time\\"
+}"`
           }
         : existingRecord
     )

--- a/config-ui/src/pages/connections/incoming-webhook/index.jsx
+++ b/config-ui/src/pages/connections/incoming-webhook/index.jsx
@@ -54,9 +54,9 @@ export const IncomingWebhook = () => {
             postIssuesEndpoint: `${postUrlPrefix}${r.postIssuesEndpoint}`,
             closeIssuesEndpoint: `${postUrlPrefix}${r.closeIssuesEndpoint}`,
             postDeploymentsCurl: `curl ${postUrlPrefix}${r.postPipelineDeployTaskEndpoint} -X 'POST' -d "{
-  \\"repo_url\\":\\"you need fill your repo URL or other unique string here\\",
   \\"commit_sha\\":\\"the sha of deployment commit\\",
-  \\"start_time\\":\\"Optional, Format should be 2020-01-01T12:00:00+00:00\\"
+  \\"repo_url\\":\\"the repo URL of the deployment commit\\",
+  \\"start_time\\":\\"Optional, eg. 2020-01-01T12:00:00+00:00\\"
 }"`
           }
         : existingRecord

--- a/config-ui/src/pages/connections/incoming-webhook/index.jsx
+++ b/config-ui/src/pages/connections/incoming-webhook/index.jsx
@@ -54,9 +54,9 @@ export const IncomingWebhook = () => {
             postIssuesEndpoint: `${postUrlPrefix}${r.postIssuesEndpoint}`,
             closeIssuesEndpoint: `${postUrlPrefix}${r.closeIssuesEndpoint}`,
             postDeploymentsCurl: `curl ${postUrlPrefix}${r.postPipelineDeployTaskEndpoint} -X 'POST' -d "{
-  \\"repo_url\\":\\"$CIRCLE_REPOSITORY_URL\\",
-  \\"commit_sha\\":\\"$CIRCLE_SHA1\\",
-  \\"start_time\\":\\"$start_time\\"
+  \\"repo_url\\":\\"you need fill your repo URL or other unique string here\\",
+  \\"commit_sha\\":\\"the sha of deployment commit\\",
+  \\"start_time\\":\\"Optional, Format should be 2020-01-01T12:00:00+00:00\\"
 }"`
           }
         : existingRecord

--- a/config-ui/src/pages/connections/incoming-webhook/styled.js
+++ b/config-ui/src/pages/connections/incoming-webhook/styled.js
@@ -144,7 +144,6 @@ export const FormWrapper = styled.div`
       align-items: center;
       justify-content: space-between;
       padding: 10px;
-      height: auto;
       background-color: #f0f4fe;
 
       & > span {

--- a/config-ui/src/pages/connections/incoming-webhook/styled.js
+++ b/config-ui/src/pages/connections/incoming-webhook/styled.js
@@ -143,9 +143,13 @@ export const FormWrapper = styled.div`
       display: flex;
       align-items: center;
       justify-content: space-between;
-      padding: 0 10px;
-      height: 38px;
+      padding: 10px;
+      height: auto;
       background-color: #f0f4fe;
+
+      & > span {
+        flex: 1 0;
+      }
 
       & > svg {
         cursor: pointer;

--- a/config-ui/src/pages/connections/incoming-webhook/view-or-edit-modal.jsx
+++ b/config-ui/src/pages/connections/incoming-webhook/view-or-edit-modal.jsx
@@ -119,7 +119,7 @@ export const ViewOrEditModal = ({ record, onSubmit, onCancel }) => {
           <h3>Deployment</h3>
           <p>POST to register a deployment</p>
           <div className='block'>
-            <span style={{ flex: '1 0' }}>{record.postDeploymentsCurl}</span>
+            <span>{record.postDeploymentsCurl}</span>
             <CopyToClipboard text={record.postDeploymentsCurl}>
               <CopyIcon width={16} height={16} />
             </CopyToClipboard>

--- a/config-ui/src/pages/connections/incoming-webhook/view-or-edit-modal.jsx
+++ b/config-ui/src/pages/connections/incoming-webhook/view-or-edit-modal.jsx
@@ -119,8 +119,8 @@ export const ViewOrEditModal = ({ record, onSubmit, onCancel }) => {
           <h3>Deployment</h3>
           <p>POST to register a deployment</p>
           <div className='block'>
-            <span>{record.postDeploymentsEndpoint}</span>
-            <CopyToClipboard text={record.postDeploymentsEndpoint}>
+            <span style={{ flex: '1 0' }}>{record.postDeploymentsCurl}</span>
+            <CopyToClipboard text={record.postDeploymentsCurl}>
               <CopyIcon width={16} height={16} />
             </CopyToClipboard>
           </div>


### PR DESCRIPTION
# Summary

display curl in the webhook page

![kBKVYCqVbG](https://user-images.githubusercontent.com/3294100/195393165-b0966b00-4ce9-48aa-b2b0-8043d848b3fa.jpg)

The text copied is:
```
curl http://localhost:4000/api/plugins/webhook/1/deployments -X 'POST' -d "{
  \"repo_url\":\"$CIRCLE_REPOSITORY_URL\",
  \"commit_sha\":\"$CIRCLE_SHA1\",
  \"start_time\":\"$start_time\"
}"
```