### PR TITLE
feat: add cicd commits for bitbucket

### DIFF
--- a/plugins/bitbucket/models/migrationscripts/20221014_add_RepoId_CommitSha_field_pipeline_tables.go
+++ b/plugins/bitbucket/models/migrationscripts/20221014_add_RepoId_CommitSha_field_pipeline_tables.go
@@ -1,3 +1,20 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package migrationscripts
 
 import (

--- a/plugins/bitbucket/models/migrationscripts/20221014_add_repoId_commitsha_field_pipeline_tables.go
+++ b/plugins/bitbucket/models/migrationscripts/20221014_add_repoId_commitsha_field_pipeline_tables.go
@@ -1,0 +1,51 @@
+package migrationscripts
+
+import (
+	"context"
+	"time"
+
+	"github.com/apache/incubator-devlake/errors"
+	"github.com/apache/incubator-devlake/models/migrationscripts/archived"
+	"gorm.io/gorm"
+)
+
+type Task20221014 struct {
+	ConnectionId        uint64 `gorm:"primaryKey"`
+	BitbucketId         string `gorm:"primaryKey"`
+	Status              string `gorm:"type:varchar(100)"`
+	Result              string `gorm:"type:varchar(100)"`
+	RefName             string `gorm:"type:varchar(255)"`
+	RepoId              string `gorm:"type:varchar(255)"`
+	CommitSha           string `gorm:"type:varchar(255)"`
+	WebUrl              string `gorm:"type:varchar(255)"`
+	DurationInSeconds   uint64
+	BitbucketCreatedOn  *time.Time
+	BitbucketCompleteOn *time.Time
+	archived.NoPKModel
+}
+
+func (Task20221014) TableName() string {
+	return "_tool_bitbucket_pipelines"
+}
+
+type addRepoIdAndCommitShaField struct{}
+
+func (*addRepoIdAndCommitShaField) Up(ctx context.Context, db *gorm.DB) errors.Error {
+	err := db.Migrator().AddColumn(Task20221014{}, "repo_id")
+	if err != nil {
+		return errors.Convert(err)
+	}
+	err = db.Migrator().AddColumn(Task20221014{}, "commit_sha")
+	if err != nil {
+		return errors.Convert(err)
+	}
+	return nil
+}
+
+func (*addRepoIdAndCommitShaField) Version() uint64 {
+	return 20221014114623
+}
+
+func (*addRepoIdAndCommitShaField) Name() string {
+	return "add column `repo_id` and `commit_sha` at _tool_bitbucket_pipelines"
+}

--- a/plugins/bitbucket/models/migrationscripts/register.go
+++ b/plugins/bitbucket/models/migrationscripts/register.go
@@ -27,5 +27,6 @@ func All() []migration.Script {
 		new(addInitTables),
 		new(addPipeline20220914),
 		new(addDeployment20221013),
+		new(addRepoIdAndCommitShaField),
 	}
 }

--- a/plugins/bitbucket/models/pipeline.go
+++ b/plugins/bitbucket/models/pipeline.go
@@ -28,6 +28,8 @@ type BitbucketPipeline struct {
 	Status            string `gorm:"type:varchar(100)"`
 	Result            string `gorm:"type:varchar(100)"`
 	RefName           string `gorm:"type:varchar(255)"`
+	RepoId            string `gorm:"type:varchar(255)"`
+	CommitSha         string `gorm:"type:varchar(255)"`
 	WebUrl            string `gorm:"type:varchar(255)"`
 	DurationInSeconds uint64
 

--- a/plugins/bitbucket/tasks/pipeline_convertor.go
+++ b/plugins/bitbucket/tasks/pipeline_convertor.go
@@ -70,7 +70,15 @@ func ConvertPipelines(taskCtx core.SubTaskContext) errors.Error {
 			if bitbucketPipeline.BitbucketCreatedOn != nil {
 				createdAt = *bitbucketPipeline.BitbucketCreatedOn
 			}
-
+			results := make([]interface{}, 0, 2)
+			domainPipelineCommit := &devops.CiCDPipelineCommit{
+				PipelineId: pipelineIdGen.Generate(data.Options.ConnectionId, bitbucketPipeline.BitbucketId),
+				RepoId: didgen.NewDomainIdGenerator(&bitbucketModels.BitbucketRepo{}).
+					Generate(bitbucketPipeline.ConnectionId, bitbucketPipeline.RepoId),
+				CommitSha: bitbucketPipeline.CommitSha,
+				Branch:    bitbucketPipeline.RefName,
+				RepoUrl:   bitbucketPipeline.WebUrl,
+			}
 			domainPipeline := &devops.CICDPipeline{
 				DomainEntity: domainlayer.DomainEntity{
 					Id: pipelineIdGen.Generate(data.Options.ConnectionId, bitbucketPipeline.BitbucketId),
@@ -93,10 +101,8 @@ func ConvertPipelines(taskCtx core.SubTaskContext) errors.Error {
 				DurationSec:  bitbucketPipeline.DurationInSeconds,
 				FinishedDate: bitbucketPipeline.BitbucketCompleteOn,
 			}
-
-			return []interface{}{
-				domainPipeline,
-			}, nil
+			results = append(results, domainPipelineCommit, domainPipeline)
+			return results, nil
 		},
 	})
 

--- a/plugins/bitbucket/tasks/pipeline_extractor.go
+++ b/plugins/bitbucket/tasks/pipeline_extractor.go
@@ -114,9 +114,11 @@ func ExtractApiPipelines(taskCtx core.SubTaskContext) errors.Error {
 			bitbucketPipeline := &models.BitbucketPipeline{
 				ConnectionId:        data.Options.ConnectionId,
 				BitbucketId:         bitbucketApiPipeline.Uuid,
-				WebUrl:              bitbucketApiPipeline.Links.Self.Href,
+				WebUrl:              bitbucketApiPipeline.Target.Commit.Links.Html.Href,
 				Status:              bitbucketApiPipeline.State.Name,
 				RefName:             bitbucketApiPipeline.Target.RefName,
+				CommitSha:           bitbucketApiPipeline.Target.Commit.Hash,
+				RepoId:              bitbucketApiPipeline.Repo.FullName,
 				DurationInSeconds:   bitbucketApiPipeline.DurationInSeconds,
 				BitbucketCreatedOn:  bitbucketApiPipeline.CreatedOn,
 				BitbucketCompleteOn: bitbucketApiPipeline.CompletedOn,


### PR DESCRIPTION
# Summary

add cicd commits for bitbucket

### Does this close any open issues?
Closes #3439 

### Screenshots
`cicd_pipeline_commits` table
According to the latest CiCDPipelineCommit definition, there is no repo field anymore，so the field `repo` is null
<img width="1042" alt="Screen Shot 2022-10-14 at 12 21 18" src="https://user-images.githubusercontent.com/47466847/195761761-4b504d75-6d87-4d9a-addc-e9de98b53be2.png">
### Other Information


Any other information that is important to this PR.
