### PR TITLE
fix: use issueType.Name as issue.Type

### DIFF
--- a/plugins/jira/tasks/issue_extractor.go
+++ b/plugins/jira/tasks/issue_extractor.go
@@ -59,11 +59,7 @@ func ExtractIssues(taskCtx core.SubTaskContext) error {
 		return err
 	}
 	for _, issueType := range issueTypes {
-		if issueType.UntranslatedName == "" {
-			typeIdMapping[issueType.Id] = issueType.Name
-		} else {
-			typeIdMapping[issueType.Id] = issueType.UntranslatedName
-		}
+		typeIdMapping[issueType.Id] = issueType.Name
 	}
 
 	stdTypeMappings := make(map[string]string)


### PR DESCRIPTION
# Summary

fix #3441 [Bug][jira] Different behavior of issue type mapping in v0.12 and v0.14
In the version v0.12, the value of `issueType.Name` is assigned to `issue.Type`, only if `UntranslatedName` is not empty.
```go
if issueType.UntranslatedName == "" {
    typeIdMapping[issueType.Id] = issueType.Name
} else {
    typeIdMapping[issueType.Id] = issueType.UntranslatedName
}
```
However, in the version v0.14, the value of `issueType.Name` is assigned to `issue.Type`, no matter the value of `UntranslatedName`

### Does this close any open issues?
Closes #3441 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
