### PR TITLE
refactor: add providerId to entity type data models

### DIFF
--- a/config-ui/src/components/blueprints/create-workflow/DataTransformations.jsx
+++ b/config-ui/src/components/blueprints/create-workflow/DataTransformations.jsx
@@ -30,6 +30,7 @@ import { integrationsData } from '@/data/integrations'
 import { ProviderIcons, Providers } from '@/data/Providers'
 import { DataEntityTypes } from '@/data/DataEntities'
 import { DEFAULT_DATA_ENTITIES } from '@/data/BlueprintWorkflow'
+import { Variants } from '@/data/Variants'
 
 import ConnectionTabs from '@/components/blueprints/ConnectionTabs'
 import NoData from '@/components/NoData'
@@ -120,10 +121,10 @@ const DataTransformations = (props) => {
     if (useDropdownSelector) {
       console.log('>>>>> PROJECT / BOARD ENTITY SELECTED!', activeEntity)
       switch (activeEntity?.type) {
-        case 'board':
+        case Variants.BOARD:
           addBoardTransformation(activeEntity?.entity)
           break
-        case 'project':
+        case Variants.PROJECT:
         default:
           addProjectTransformation(activeEntity?.entity)
           break

--- a/config-ui/src/data/Variants.js
+++ b/config-ui/src/data/Variants.js
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+const Variants = {
+  PROJECT: 'project',
+  BOARD: 'board',
+  JOB: 'job'
+}
+
+export { Variants }

--- a/config-ui/src/models/GithubProject.js
+++ b/config-ui/src/models/GithubProject.js
@@ -29,6 +29,7 @@
  * @property {string?} repo
  * @property {boolean?} useApi
  * @property {project|board?} variant
+ * @property {string?} providerId
  */
 class GitHubProject {
   constructor(data = {}) {
@@ -47,6 +48,7 @@ class GitHubProject {
 
     this.useApi = data?.useApi || false
     this.variant = data?.variant || 'project'
+    this.providerId = 'github'
   }
 
   get(property) {

--- a/config-ui/src/models/GitlabProject.js
+++ b/config-ui/src/models/GitlabProject.js
@@ -48,6 +48,7 @@
  * @property {boolean?} archived
  * @property {boolean?} useApi
  * @property {project|board?} variant
+ * @property {string?} providerId
  */
 class GitlabProject {
   constructor(data = {}) {
@@ -86,6 +87,7 @@ class GitlabProject {
 
     this.useApi = data?.useApi || false
     this.variant = data?.variant || 'project'
+    this.providerId = 'gitlab'
   }
 
   get(property) {

--- a/config-ui/src/models/JenkinsJob.js
+++ b/config-ui/src/models/JenkinsJob.js
@@ -26,6 +26,7 @@
  * @property {string|number?} title
  * @property {boolean?} useApi
  * @property {project|board|job?} variant
+ * @property {string?} providerId
  */
 class JenkinsJob {
   constructor(data = {}) {
@@ -37,6 +38,7 @@ class JenkinsJob {
 
     this.useApi = data?.useApi || true
     this.variant = data?.variant || 'job'
+    this.providerId = 'jenkins'
   }
 
   get(property) {

--- a/config-ui/src/models/JiraBoard.js
+++ b/config-ui/src/models/JiraBoard.js
@@ -30,6 +30,7 @@
  * @property {object?} location
  * @property {boolean?} useApi
  * @property {project|board?} variant
+ * @property {string?} providerId
  */
 class JiraBoard {
   constructor(data = {}) {
@@ -56,6 +57,7 @@ class JiraBoard {
 
     this.useApi = data?.useApi || true
     this.variant = data?.variant || 'board'
+    this.providerId = 'jira'
   }
 
   get(property) {


### PR DESCRIPTION
### Config-UI / Data Models / `Entity` Models

- [x] Add `providerId` prop to `GitHubProject`, `GitlabProject`, `JiraBoard` and `JenkinsJob`
- [x] Create `Variants` Global Data Constant (`@data/Variants.js`)

### Does this close any open issues?
Closes #3411

