### PR TITLE
refactor(ci): add yaml lint for helm chart

### DIFF
--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -14,18 +14,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ include "devlake.fullname" . }}-config
-data:
-  MYSQL_USER: "{{ .Values.mysql.username }}"
-  MYSQL_PASSWORD: "{{ .Values.mysql.password }}"
-  MYSQL_DATABASE: "{{ .Values.mysql.database }}"
-  MYSQL_ROOT_PASSWORD: "{{ .Values.mysql.rootPassword }}"
-  LOGGING_DIR: "{{ .Values.lake.loggingDir }}"
-{{- if .Values.ui.basicAuth.enabled }}
-  ADMIN_USER: "{{ .Values.ui.basicAuth.user }}"
-  ADMIN_PASS: "{{ .Values.ui.basicAuth.password }}"
-{{- end }}
+
+name: yaml-lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  yamlint-helm:
+    name: lint for helm chart
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: install latest helm
+        run: curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+      - name: helm template for chart
+        run: helm template test deployment/helm > helm-deployment.yaml
+      - name: yamllint
+        uses: karancode/yamllint-github-action@master
+        with:
+          yamllint_file_or_dir: helm-deployment.yaml
+          yamllint_strict: false
+          yamllint_comment: true
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/deployment/helm/templates/deployments.yaml
+++ b/deployment/helm/templates/deployments.yaml
@@ -42,9 +42,11 @@ spec:
             - 'sh'
             - '-c'
             - |
-              until nc -z -w 2 {{ include "devlake.fullname" . }}-mysql 3306 && echo mysql is ready ; do
+              until nc -z -w 2 {{ include "devlake.fullname" . }}-mysql 3306 ; do
+                echo wait for mysql ready ...
                 sleep 2
               done
+              echo mysql is ready
       containers:
         - name: grafana
           image: "{{ .Values.grafana.image.repository }}:{{ .Values.grafana.image.tag }}"
@@ -113,10 +115,6 @@ spec:
               value: {{ include "devlake.fullname" . }}-lake.{{ .Release.Namespace }}.svc.cluster.local:8080
             - name: GRAFANA_ENDPOINT
               value: {{ include "devlake.fullname" . }}-grafana.{{ .Release.Namespace }}.svc.cluster.local:3000
-            # - name: ADMIN_USER
-            #   value: "admin"
-            # - name: ADMIN_PASS
-            #   value: "admin"
           volumeMounts:
             {{- if ne .Values.option.localtime "" }}
             - name: {{ include "devlake.fullname" . }}-ui-localtime

--- a/deployment/helm/templates/services.yaml
+++ b/deployment/helm/templates/services.yaml
@@ -54,8 +54,6 @@ spec:
       nodePort: {{ .Values.service.grafanaPort }}
       {{- end }}
 
-
-
 # devlake services
 ---
 apiVersion: v1

--- a/deployment/helm/templates/statefulsets.yaml
+++ b/deployment/helm/templates/statefulsets.yaml
@@ -96,7 +96,7 @@ spec:
     - metadata:
         name: {{ include "devlake.fullname" . }}-mysql-data
       spec:
-        accessModes: [ "ReadWriteOnce" ]
+        accessModes: ["ReadWriteOnce"]
         {{- with .Values.mysql.storage.class }}
         storageClassName: "{{ . }}"
         {{- end }}
@@ -133,9 +133,11 @@ spec:
             - 'sh'
             - '-c'
             - |
-              until nc -z -w 2 {{ include "devlake.fullname" . }}-mysql 3306 && echo mysql is ready ; do
+              until nc -z -w 2 {{ include "devlake.fullname" . }}-mysql 3306 ; do
+                echo wait for mysql ready ..
                 sleep 2
               done
+              echo mysql is ready
       containers:
         - name: lake
           image: "{{ .Values.lake.image.repository }}:{{ .Values.lake.image.tag }}"
@@ -154,6 +156,7 @@ spec:
                 name: {{ include "devlake.fullname" . }}-config
           env:
             - name: DB_URL
+              # yamllint disable-line rule:line-length
               value: mysql://{{ .Values.mysql.username }}:{{ .Values.mysql.password }}@{{ include "devlake.fullname" . }}-mysql:3306/{{ .Values.mysql.database }}?charset=utf8mb4&parseTime=True
             - name: ENV_PATH
               value: /app/config/.env
@@ -176,7 +179,7 @@ spec:
     - metadata:
         name: {{ include "devlake.fullname" . }}-lake-config
       spec:
-        accessModes: [ "ReadWriteOnce" ]
+        accessModes: ["ReadWriteOnce"]
         {{- with .Values.lake.storage.class }}
         storageClassName: "{{ . }}"
         {{- end }}


### PR DESCRIPTION
# Summary
Add yaml lint for helm chart

Initial add yamllint for helm chart, this is could help to avoid some low-level mistakes, such as typo, incorrect indent. May add more yaml to lint, such k8s yaml, docker-compose's yaml, etc.

Related Issue: #3388

### Does this close any open issues?
Partially fix #3388

### Screenshots
If have any lint issue on YAML from the helm chart, it will be blocked at Pipeline, and Got the below comments on PR:

![image](https://user-images.githubusercontent.com/183388/196638137-4ad32fc0-5b86-4352-a9b0-9b59e842b295.png)


### Other Information
N/A
