### PR TITLE
fix(deployment): Using latest image in helm chart

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -67,6 +67,7 @@ jobs:
           echo Node IP: ${NODE_IP}
           helm install --wait --timeout 300s deploy-test deployment/helm \
             --set service.uiPort=30000 \
+            --set mysql.image.tag=8-debian \
             --set option.localtime=""
           kubectl get pods -o wide
           kubectl get services -o wide

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -49,10 +49,11 @@ mysql:
     size: 5Gi
 
   # image for mysql
+  # mysql:8 for latest version with mysql-8, which avaliable for amd64/arm64v8 arch.
   image:
     repository: mysql
-    tag: 8.0.26
-    pullPolicy: IfNotPresent
+    tag: 8
+    pullPolicy: Always
   
   # resources config for mysql if have
   resources: {}
@@ -71,7 +72,7 @@ grafana:
   # image for grafana
   image:
     repository: apache/devlake-dashboard
-    tag: v0.12.0-rc2
+    tag: latest
     pullPolicy: Always
   
   resources: {}
@@ -86,7 +87,7 @@ grafana:
 lake:
   image:
     repository: apache/devlake
-    tag: v0.12.0-rc2
+    tag: latest
     pullPolicy: Always
   # storage for config
   storage:
@@ -107,7 +108,7 @@ lake:
 ui:
   image:
     repository: apache/devlake-config-ui
-    tag: v0.12.0-rc2
+    tag: latest
     pullPolicy: Always
 
   resources: {}


### PR DESCRIPTION
# Summary

Using the latest image for helm deployment on the main branch.

Fix: #3479, maybe lit bit the same as ongoing #3480

### Does this close any open issues?
Closes #3479

### Screenshots
N/A

### Other Information
Currently, Mysql-8 uses oracle based image, it seems not to work well with the KinD pipeline, so keep Debian-based MySQL image in the CI pipeline.

