### PR TITLE
fix cherry-pick #3497. ConvertJobsMeta is only defined in main(0.15).

### DIFF
--- a/plugins/github_graphql/plugin_main.go
+++ b/plugins/github_graphql/plugin_main.go
@@ -72,7 +72,8 @@ func (plugin GithubGraphql) SubTaskMetas() []core.SubTaskMeta {
 
 		tasks.CollectAccountMeta,
 
-		githubTasks.ConvertJobsMeta,
+		githubTasks.ConvertPipelinesMeta,
+		githubTasks.ConvertTasksMeta,
 		githubTasks.EnrichPullRequestIssuesMeta,
 		githubTasks.ConvertRepoMeta,
 		githubTasks.ConvertIssuesMeta,


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

fix cherry-pick #3497. `ConvertJobsMeta` is only defined in main(0.15). 