### PR TITLE
fix: test connection response with 500

### DIFF
--- a/plugins/bitbucket/api/connection.go
+++ b/plugins/bitbucket/api/connection.go
@@ -63,12 +63,6 @@ func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, erro
 		return nil, err
 	}
 
-	resBody := &models.ApiUserResponse{}
-	err = helper.UnmarshalResponse(res, resBody)
-	if err != nil {
-		return nil, err
-	}
-
 	if res.StatusCode != http.StatusOK {
 		return nil, errors.HttpStatus(res.StatusCode).New("unexpected status code when testing connection")
 	}

--- a/plugins/bitbucket/models/connection.go
+++ b/plugins/bitbucket/models/connection.go
@@ -50,14 +50,6 @@ type TransformationRules struct {
 	IssueTypeRequirement string `mapstructure:"issueTypeRequirement" json:"issueTypeRequirement"`
 }
 
-type ApiUserResponse struct {
-	Username      string `json:"username"`
-	DisplayName   string `json:"display_name"`
-	AccountId     int    `json:"account_id"`
-	Uuid          string `json:"uuid"`
-	AccountStatus string `json:"account_status"`
-}
-
 type BitbucketConnection struct {
 	helper.RestConnection `mapstructure:",squash"`
 	helper.BasicAuth      `mapstructure:",squash"`


### PR DESCRIPTION
# Summary
fix #3517 [Bug][bitbucket] The endpoint /plugins/bitbucket/test responses with status code 500

### Does this close any open issues?
Closes #3517 

### Screenshots
![image](https://user-images.githubusercontent.com/8455907/197102370-3a1ade2b-3e50-495b-8f5a-9a70d8aa108e.png)


### Other Information
Any other information that is important to this PR.
