### PR TITLE
refactor(deployment): support external mysql option for helm chart

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -35,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      matrix:
+        database_type: ["mysql-builtin", "mysql-external"]
     steps:
       - name: Creating kind cluster
         uses: container-tools/kind-action@v1
@@ -62,6 +64,21 @@ jobs:
       #     docker push kind-registry:5000/deploy-test-ui:latest
 
       - name: Helm install devlake
+        if: matrix.database_type == 'mysql-external'
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm install mysql bitnami/mysql --set auth.rootPassword=admin --set auth.database=lake --set auth.username=merico --set auth.password=merico
+          # external mysql at service: mysql
+          helm install --wait --timeout 300s deploy-test deployment/helm \
+            --set service.uiPort=30000 \
+            --set mysql.useExternal=true \
+            --set mysql.externalServer=mysql \
+            --set option.localtime=""
+          kubectl get pods -o wide
+          kubectl get services -o wide
+
+      - name: Helm install devlake
+        if: matrix.database_type == 'mysql-builtin'
         run: |
           export NODE_IP=$(kubectl get nodes --namespace default -o jsonpath="{.items[0].status.addresses[0].address}")
           echo Node IP: ${NODE_IP}

--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -77,7 +77,7 @@ Some useful parameters for the chart, you could also check them in values.yaml
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | replicaCount  | Replica Count for devlake, currently not used  | 1  |
-| mysql.useExternal  | If use external mysql server, currently not used  |  false  |
+| mysql.useExternal  | If use external mysql server, set true |  false  |
 | mysql.externalServer  | External mysql server address  | 127.0.0.1  |
 | mysql.externalPort  | External mysql server port  | 3306  |
 | mysql.username  | username for mysql | merico  |

--- a/deployment/helm/templates/_helpers.tpl
+++ b/deployment/helm/templates/_helpers.tpl
@@ -95,3 +95,26 @@ The ui endpoint
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+The mysql server
+*/}}
+{{- define "mysql.server" -}}
+{{- if .Values.mysql.useExternal }}
+{{- .Values.mysql.externalServer }}
+{{- else }}
+{{- print (include "devlake.fullname" . ) "-mysql" }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+The mysql port
+*/}}
+{{- define "mysql.port" -}}
+{{- if .Values.mysql.useExternal }}
+{{- .Values.mysql.externalPort }}
+{{- else }}
+{{- 3306 }}
+{{- end }}
+{{- end }}

--- a/deployment/helm/templates/deployments.yaml
+++ b/deployment/helm/templates/deployments.yaml
@@ -42,7 +42,7 @@ spec:
             - 'sh'
             - '-c'
             - |
-              until nc -z -w 2 {{ include "devlake.fullname" . }}-mysql 3306 ; do
+              until nc -z -w 2 {{ include "mysql.server" . }} {{ include "mysql.port" . }} ; do
                 echo wait for mysql ready ...
                 sleep 2
               done
@@ -72,7 +72,7 @@ spec:
             - name: GF_SERVER_ROOT_URL
               value: "%(protocol)s://%(domain)s:%(http_port)s/grafana/"
             - name: MYSQL_URL
-              value: {{ include "devlake.fullname" . }}-mysql:3306
+              value: {{ include "mysql.server" . }}:{{ include "mysql.port" . }}
       volumes:
         {{- if ne .Values.option.localtime "" }}
         - name: {{ include "devlake.fullname" . }}-grafana-localtime

--- a/deployment/helm/templates/services.yaml
+++ b/deployment/helm/templates/services.yaml
@@ -16,6 +16,7 @@
 #
 # mysql services
 ---
+{{- if not .Values.mysql.useExternal }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -31,6 +32,7 @@ spec:
       name: mysql
       port: 3306
       targetPort: 3306
+{{- end }}
 
 # grafana services
 ---

--- a/deployment/helm/templates/statefulsets.yaml
+++ b/deployment/helm/templates/statefulsets.yaml
@@ -16,6 +16,7 @@
 #
 ---
 # mysql statefulset
+{{- if not .Values.mysql.useExternal }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -103,7 +104,7 @@ spec:
         resources:
           requests:
             storage: "{{ .Values.mysql.storage.size }}"
-
+{{- end }}
 
 ---
 # devlake
@@ -133,7 +134,7 @@ spec:
             - 'sh'
             - '-c'
             - |
-              until nc -z -w 2 {{ include "devlake.fullname" . }}-mysql 3306 ; do
+              until nc -z -w 2 {{ include "mysql.server" . }} {{ include "mysql.port" . }} ; do
                 echo wait for mysql ready ..
                 sleep 2
               done
@@ -157,7 +158,7 @@ spec:
           env:
             - name: DB_URL
               # yamllint disable-line rule:line-length
-              value: mysql://{{ .Values.mysql.username }}:{{ .Values.mysql.password }}@{{ include "devlake.fullname" . }}-mysql:3306/{{ .Values.mysql.database }}?charset=utf8mb4&parseTime=True
+              value: mysql://{{ .Values.mysql.username }}:{{ .Values.mysql.password }}@{{ include "mysql.server" . }}:{{ include "mysql.port" . }}/{{ .Values.mysql.database }}?charset=utf8mb4&parseTime=True
             - name: ENV_PATH
               value: /app/config/.env
           volumeMounts:

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -21,7 +21,6 @@ replicaCount: 1
 mysql:
   # if use external mysql server, please set true
   #   by default using false, chart will create a single mysql instance
-  # TODO(matrixji): add support external mysql server
   useExternal: false
 
   # the external mysql server address


### PR DESCRIPTION
# Summary
Support external MySQL option for helm chart deployment.

When deploying with MySQL, now operator could using MySQL.useExternal=true to enable the external MySQL server, this is helpful if the operator has a dedicated MySQL server, under this option, there will be no MySQL instance created in devlake's helm release.

### Does this close any open issues?
N/A, Implement some previous TODO.

### Screenshots
```
root@nuc:~/working/incubator-devlake/deployment/helm# kubectl get pod
NAME                                 READY   STATUS    RESTARTS   AGE
mysql-0                              1/1     Running   0          12h
x-devlake-grafana-6c975c8cf9-7l6v6   1/1     Running   0          44m
x-devlake-lake-0                     1/1     Running   0          44m
x-devlake-ui-6c69947fc8-6nrw8        1/1     Running   0          44m
root@nuc:~/working/incubator-devlake/deployment/helm# helm list
NAME 	NAMESPACE	REVISION	UPDATED                                	STATUS  	CHART        	APP VERSION
mysql	default  	1       	2022-10-21 21:20:35.133728667 +0800 CST	deployed	mysql-9.4.1  	8.0.31
x    	default  	1       	2022-10-22 09:15:55.749730773 +0800 CST	deployed	devlake-0.1.0	0.11.0
root@nuc:~/working/incubator-devlake/deployment/helm#
```

### Other Information
N/A
