### PR TITLE
fix(ci): fix yaml lint not run

### DIFF
--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -32,11 +32,8 @@ jobs:
       - name: helm template for chart
         run: helm template test deployment/helm > helm-deployment.yaml
       - name: yamllint
-        uses: karancode/yamllint-github-action@master
+        uses: ibiqlik/action-yamllint@v3
         with:
-          yamllint_file_or_dir: helm-deployment.yaml
-          yamllint_strict: false
-          yamllint_comment: true
-        env:
-          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          file_or_dir: helm-deployment.yaml
+          strict: false
 


### PR DESCRIPTION
# Summary
Fix yaml lint not running in CI due to the action's name not matching the required pattern.

### Does this close any open issues?
None

### Screenshots
![image](https://user-images.githubusercontent.com/183388/197331885-2ba012f2-945b-46dd-8716-6f04096d7adc.png)

### Other Information
N/A
