### PR TITLE
fix: delete 0.15 protection in .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -69,8 +69,6 @@ github:
       whatever: Just a placehold to make it in protection
     release-v0.14:
       whatever: Just a placehold to make it in protection
-    release-v0.15:
-      whatever: Just a placehold to make it in protection
   # The triage role allows people to assign, edit, and close issues and pull requests,
   # without giving them write access to the code.
   collaborators:


### PR DESCRIPTION
# Summary

delete 0.15 protection in `.asf.yaml`. It need add back when release-v0.15 is created.