### PR TITLE
fix: gitee create conn with empty env

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,12 +19,13 @@ package config
 
 import (
 	"fmt"
-	"github.com/apache/incubator-devlake/errors"
-	goerror "github.com/cockroachdb/errors"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/apache/incubator-devlake/errors"
+	goerror "github.com/cockroachdb/errors"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
@@ -69,9 +70,6 @@ func setDefaultValue(v *viper.Viper) {
 	v.SetDefault("PORT", ":8080")
 	v.SetDefault("PLUGIN_DIR", "bin/plugins")
 	v.SetDefault("TEMPORAL_TASK_QUEUE", "DEVLAKE_TASK_QUEUE")
-	v.SetDefault("GITLAB_ENDPOINT", "https://gitlab.com/api/v4/")
-	v.SetDefault("GITHUB_ENDPOINT", "https://api.github.com/")
-	v.SetDefault("GITEE_ENDPOINT", "https://gitee.com/api/v5/")
 }
 
 // replaceNewEnvItemInOldContent replace old config to new config in env file content

--- a/plugins/gitee/models/migrationscripts/20220714_add_init_tables.go
+++ b/plugins/gitee/models/migrationscripts/20220714_add_init_tables.go
@@ -92,10 +92,15 @@ func (*addInitTables) Up(baseRes core.BasicRes) errors.Error {
 	conn.Name = "init gitee connection"
 	conn.ID = 1
 	conn.Endpoint = baseRes.GetConfig("GITEE_ENDPOINT")
+	if encKey == "" || conn.Endpoint == "" {
+		return nil
+	}
+
 	conn.Token, err = core.Encrypt(encKey, baseRes.GetConfig("GITEE_AUTH"))
 	if err != nil {
 		return err
 	}
+
 	conn.Proxy = baseRes.GetConfig("GITEE_PROXY")
 
 	var err1 error


### PR DESCRIPTION
# Summary
if env not set endpoint or enckey
gitee will not create conn any more.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Does this close any open issues?
Closes #3549 

### Screenshots
![image](https://user-images.githubusercontent.com/2921251/197917889-3cab321f-2e95-487e-90dc-803cbaf294ec.png)


### Other Information
Any other information that is important to this PR.
