### PR TITLE
fix: pass the value of projectPath to dbt project-dir argument

### DIFF
--- a/plugins/dbt/tasks/convertor.go
+++ b/plugins/dbt/tasks/convertor.go
@@ -110,7 +110,7 @@ func DbtConverter(taskCtx core.SubTaskContext) errors.Error {
 			return err
 		}
 	}
-	dbtExecParams := []string{"dbt", "run", "--profiles-dir", projectPath}
+	dbtExecParams := []string{"dbt", "run", "--project-dir", projectPath}
 	if projectVars != nil {
 		jsonProjectVars, err := json.Marshal(projectVars)
 		if err != nil {


### PR DESCRIPTION
# Summary
pass the value of `projectPath` from dbt plugin to the argument `--project-dir` of the command `dbt run` instead of `--profiles-dir`

### Does this close any open issues?
Closes https://github.com/apache/incubator-devlake/issues/3574
