### PR TITLE
fix: checkout if refdiffRules is nil 

### DIFF
--- a/plugins/bitbucket/api/blueprint.go
+++ b/plugins/bitbucket/api/blueprint.go
@@ -78,7 +78,7 @@ func makePipelinePlan(subtaskMetas []core.SubTaskMeta, scope []*core.BlueprintSc
 			}
 		}
 		// refdiff
-		if refdiffRules, ok := transformationRules["refdiff"]; ok {
+		if refdiffRules, ok := transformationRules["refdiff"]; ok && refdiffRules != nil {
 			// add a new task to next stage
 			j := i + 1
 			if j == len(plan) {


### PR DESCRIPTION
# Summary
When we send a post request to http://localhost:4000/api/blueprint, there are some errors.
This is because the refdiffRules of input parameter is nil, and then the program type assertion fails
Adding a `nil check` before type assertion can solves this issue.

### Does this close any open issues?
Closes #3595 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
