### PR TITLE
fix(framework): add max pageSize

### DIFF
--- a/services/blueprint_helper.go
+++ b/services/blueprint_helper.go
@@ -48,10 +48,9 @@ func GetDbBlueprints(query *BlueprintQuery) ([]*models.DbBlueprint, int64, error
 	if err != nil {
 		return nil, 0, errors.Default.Wrap(err, "error getting DB count of blueprints")
 	}
-	if query.Page > 0 && query.PageSize > 0 {
-		offset := query.PageSize * (query.Page - 1)
-		db = db.Limit(query.PageSize).Offset(offset)
-	}
+
+	db = processDbClausesWithPager(db, query.PageSize, query.Page)
+
 	err = db.Find(&dbBlueprints).Error
 	if err != nil {
 		return nil, 0, errors.Default.Wrap(err, "error finding DB blueprints")

--- a/services/page_helper.go
+++ b/services/page_helper.go
@@ -1,0 +1,35 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import "gorm.io/gorm"
+
+const maxPageSize = 100
+
+func processDbClausesWithPager(tx *gorm.DB, pageSize int, page int) *gorm.DB {
+	if pageSize <= 0 || pageSize > maxPageSize {
+		pageSize = maxPageSize
+	}
+	tx = tx.Limit(pageSize)
+
+	if page > 0 {
+		offset := pageSize * (page - 1)
+		tx = tx.Offset(offset)
+	}
+	return tx
+}

--- a/services/pipeline_helper.go
+++ b/services/pipeline_helper.go
@@ -113,10 +113,9 @@ func GetDbPipelines(query *PipelineQuery) ([]*models.DbPipeline, int64, errors.E
 	if err != nil {
 		return nil, 0, errors.Default.Wrap(err, "error getting DB pipelines count")
 	}
-	if query.Page > 0 && query.PageSize > 0 {
-		offset := query.PageSize * (query.Page - 1)
-		db = db.Limit(query.PageSize).Offset(offset)
-	}
+
+	db = processDbClausesWithPager(db, query.PageSize, query.Page)
+
 	err = db.Find(&dbPipelines).Error
 	if err != nil {
 		return nil, count, errors.Default.Wrap(err, "error finding DB pipelines")

--- a/services/task.go
+++ b/services/task.go
@@ -182,10 +182,9 @@ func GetTasks(query *TaskQuery) ([]models.Task, int64, errors.Error) {
 	if err != nil {
 		return nil, 0, errors.Convert(err)
 	}
-	if query.Page > 0 && query.PageSize > 0 {
-		offset := query.PageSize * (query.Page - 1)
-		db = db.Limit(query.PageSize).Offset(offset)
-	}
+
+	db = processDbClausesWithPager(db, query.PageSize, query.Page)
+
 	tasks := make([]models.Task, 0)
 	err = db.Find(&tasks).Error
 	if err != nil {


### PR DESCRIPTION
# Summary

Added maxPageSize to limit the size of data for the following entities that return to frontend:
blueprint
pipeline
task

We add a new func pagehelper.ProcessDbClausesWithPager to process all pager issues


### Does this close any open issues?
closes #3593 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
