### PR TITLE
Issues/3521 some graphql bug fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/libgit2/git2go/v33 v33.0.6
 	github.com/magiconair/properties v1.8.5
 	github.com/manifoldco/promptui v0.9.0
-	github.com/merico-dev/graphql v0.0.0-20220804061427-a2245fa66df2
+	github.com/merico-dev/graphql v0.0.0-20221027131946-77460a1fd4cd
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/panjf2000/ants/v2 v2.4.6
 	github.com/robfig/cron/v3 v3.0.0

--- a/go.sum
+++ b/go.sum
@@ -529,6 +529,8 @@ github.com/mediocregopher/radix/v3 v3.3.0/go.mod h1:EmfVyvspXz1uZEyPBMyGK+kjWiKQ
 github.com/mediocregopher/radix/v3 v3.4.2/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i4n7wVopoX3x7Bv8=
 github.com/merico-dev/graphql v0.0.0-20220804061427-a2245fa66df2 h1:sOXuZIg3OwBnvJFfIuO8wegiLpeDCOSVvk2dsbjurd8=
 github.com/merico-dev/graphql v0.0.0-20220804061427-a2245fa66df2/go.mod h1:dcDqG8HXVtfEhTCipFMa0Q+RTKTtDKIO2vJt+JVzHEQ=
+github.com/merico-dev/graphql v0.0.0-20221027131946-77460a1fd4cd h1:hGQXd4a72JSFIZE+ZVkH5ivE925PGogjob6stgc2too=
+github.com/merico-dev/graphql v0.0.0-20221027131946-77460a1fd4cd/go.mod h1:dcDqG8HXVtfEhTCipFMa0Q+RTKTtDKIO2vJt+JVzHEQ=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=

--- a/plugins/github/tasks/account_convertor.go
+++ b/plugins/github/tasks/account_convertor.go
@@ -52,7 +52,19 @@ func ConvertAccounts(taskCtx core.SubTaskContext) errors.Error {
 	db := taskCtx.GetDal()
 	data := taskCtx.GetData().(*GithubTaskData)
 
-	cursor, err := db.Cursor(dal.From(&githubModels.GithubAccount{}), dal.Where("connection_id = ?", data.Options.ConnectionId))
+	cursor, err := db.Cursor(
+		dal.Select("_tool_github_accounts.*"),
+		dal.From(&githubModels.GithubAccount{}),
+		dal.Where(
+			"repo_github_id = ? and _tool_github_accounts.connection_id=?",
+			data.Repo.GithubId,
+			data.Options.ConnectionId,
+		),
+		dal.Join(`left join _tool_github_repo_accounts gra on (
+			_tool_github_accounts.connection_id = gra.connection_id
+			AND _tool_github_accounts.id = gra.account_id
+		)`),
+	)
 	if err != nil {
 		return err
 	}

--- a/plugins/github_graphql/plugin_main.go
+++ b/plugins/github_graphql/plugin_main.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/plugins/core"
 	"github.com/apache/incubator-devlake/plugins/github/models"
@@ -162,6 +163,16 @@ func (plugin GithubGraphql) RootPkgPath() string {
 }
 
 func (plugin GithubGraphql) ApiResources() map[string]map[string]core.ApiResourceHandler {
+	return nil
+}
+
+func (plugin GithubGraphql) Close(taskCtx core.TaskContext) errors.Error {
+	data, ok := taskCtx.GetData().(*githubTasks.GithubTaskData)
+	if !ok {
+		return errors.Default.New(fmt.Sprintf("GetData failed when try to close %+v", taskCtx))
+	}
+	data.ApiClient.Release()
+	data.GraphqlClient.Release()
 	return nil
 }
 

--- a/plugins/github_graphql/tasks/account_collector.go
+++ b/plugins/github_graphql/tasks/account_collector.go
@@ -96,10 +96,9 @@ func CollectAccount(taskCtx core.SubTaskContext) errors.Error {
 			},
 			Table: RAW_ACCOUNTS_TABLE,
 		},
-		IgnoreQueryErr: true,
-		Input:          iterator,
-		InputStep:      100,
-		GraphqlClient:  data.GraphqlClient,
+		Input:         iterator,
+		InputStep:     100,
+		GraphqlClient: data.GraphqlClient,
 		BuildQuery: func(reqData *helper.GraphqlRequestData) (interface{}, map[string]interface{}, error) {
 			accounts := reqData.Input.([]interface{})
 			query := &GraphqlQueryAccountWrapper{}
@@ -115,7 +114,11 @@ func CollectAccount(taskCtx core.SubTaskContext) errors.Error {
 			}
 			return query, variables, nil
 		},
-		ResponseParser: func(iQuery interface{}, variables map[string]interface{}) ([]interface{}, error) {
+		ResponseParserWithDataErrors: func(iQuery interface{}, variables map[string]interface{}, dataErrors []graphql.DataError) ([]interface{}, error) {
+			for _, dataError := range dataErrors {
+				// log and ignore
+				taskCtx.GetLogger().Warn(dataError, `query user get error but ignore`)
+			}
 			query := iQuery.(*GraphqlQueryAccountWrapper)
 			accounts := query.Users
 

--- a/plugins/github_graphql/tasks/issue_collector.go
+++ b/plugins/github_graphql/tasks/issue_collector.go
@@ -25,6 +25,7 @@ import (
 	githubTasks "github.com/apache/incubator-devlake/plugins/github/tasks"
 	"github.com/apache/incubator-devlake/plugins/helper"
 	"github.com/merico-dev/graphql"
+	"strings"
 	"time"
 )
 
@@ -170,7 +171,7 @@ func convertGithubIssue(issue GraphqlQueryIssue, connectionId uint64, repository
 		Number:          issue.Number,
 		State:           issue.State,
 		Title:           issue.Title,
-		Body:            issue.Body,
+		Body:            strings.ReplaceAll(issue.Body, "\x00", `<0x00>`),
 		Url:             issue.Url,
 		ClosedAt:        issue.ClosedAt,
 		GithubCreatedAt: issue.CreatedAt,

--- a/plugins/helper/graphql_collector.go
+++ b/plugins/helper/graphql_collector.go
@@ -177,11 +177,12 @@ func (collector *GraphqlCollector) Execute() errors.Error {
 		err = errors.Default.Combine(collector.workerErrors)
 		logger.Error(err, "ended Graphql collector execution with error")
 		logger.Error(collector.workerErrors[0], "the first error of them")
+		return err
 	} else {
 		logger.Info("ended api collection without error")
 	}
-	err = divider.Close()
 
+	err = divider.Close()
 	return err
 }
 

--- a/scripts/compile-plugins.sh
+++ b/scripts/compile-plugins.sh
@@ -21,18 +21,21 @@
 #
 # compile specific plugin and fire up api server:
 #   PLUGIN=<PLUGIN_NAME> make dev
+#   PLUGIN=<PLUGIN_NAME> PLUGIN2=<PLUGIN_NAME2> make dev
 #
 # compile all plugins and fire up api server in DEBUG MODE with `delve`:
 #   make debug
 #
 # compile specific plugin and fire up api server in DEBUG MODE with `delve`:
 #   PLUGIN=<PLUGIN_NAME> make dev
+#   PLUGIN=<PLUGIN_NAME> PLUGIN2=<PLUGIN_NAME> make dev
 
 set -e
 
 echo "Usage: "
 echo "  build all plugins:              $0 [golang build flags...]"
 echo "  build and keep one plugin only: PLUGIN=jira $0 [golang build flags...]"
+echo "  build and keep two plugin only: PLUGIN=jira PLUGIN2=github $0 [golang build flags...]"
 
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 PLUGIN_SRC_DIR=$SCRIPT_DIR/../plugins
@@ -42,6 +45,10 @@ if [ -z "$PLUGIN" ]; then
     PLUGINS=$(find $PLUGIN_SRC_DIR/* -maxdepth 0 -type d -not -name core -not -name helper -not -empty)
 else
     PLUGINS=$PLUGIN_SRC_DIR/$PLUGIN
+fi
+
+if [ $PLUGIN ] && [ $PLUGIN2 ]; then
+    PLUGINS="$PLUGINS $PLUGIN_SRC_DIR/$PLUGIN2"
 fi
 
 rm -rf $PLUGIN_OUTPUT_DIR/*


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Commit1: more readable error message should be displayed in all HTTP APIs
Related #3467 Related #3521
`panic` crushed lake so it is no error message. Replace it with `checkError` method


### Commit2: The rate limit logic does not end after collecting is finished
Closes #3474
add `release` method to close the routine.


### Commit3: update too much user when request GitHub
Closes #3533
Use `_tool_github_repo_accounts` to filter the accounts that need to be updated


### Commit4: support 2 plugin in `make dev`
github_graphql can only run with github


### Commit5: invalid byte sequence for encoding "UTF8": 0x00 (SQLSTATE 22021) type/bug
Related #3564
Now it is not a final solution. Just replace the char '\0' with the string `<0x00>`


### Commit6: Graphql query need the retry logic
Closes #3521
Add retry logic for all types of errors when querying.


### Commit7: GitHub Graphql will skip requesting all 100 users when one of them does not exist
Closes #3491
Deal data errors (which returned from response body) in github graphql users collector. Now ignore `not exist` error and save others.


### Commit8: the users on the top of each page are droped.
Closes #3602
`HasNext` will move the db cursor to next in golang... In the past, the first row will be skip. So fix it.





 