### PR TITLE
feat: add bitbucket issueStatusOther for bitbucket transformationrules

### DIFF
--- a/models/domainlayer/ticket/issue.go
+++ b/models/domainlayer/ticket/issue.go
@@ -65,4 +65,5 @@ const (
 	TODO        = "TODO"
 	DONE        = "DONE"
 	IN_PROGRESS = "IN_PROGRESS"
+	OTHER       = "OTHER"
 )

--- a/plugins/bitbucket/models/connection.go
+++ b/plugins/bitbucket/models/connection.go
@@ -42,6 +42,7 @@ type TransformationRules struct {
 	IssueStatusTODO       []string `mapstructure:"issueStatusTodo" json:"issueStatusTodo"`
 	IssueStatusINPROGRESS []string `mapstructure:"issueStatusInProgress" json:"issueStatusInProgress"`
 	IssueStatusDONE       []string `mapstructure:"issueStatusDone" json:"issueStatusDone"`
+	IssueStatusOTHER      []string `mapstructure:"issueStatusOther" json:"issueStatusOther"`
 }
 
 type BitbucketConnection struct {

--- a/plugins/bitbucket/tasks/issue_extractor.go
+++ b/plugins/bitbucket/tasks/issue_extractor.go
@@ -188,5 +188,8 @@ func newIssueStatusMap(config models.TransformationRules) (map[string]string, er
 	for _, state := range config.IssueStatusDONE {
 		issueStatusMap[state] = ticket.DONE
 	}
+	for _, state := range config.IssueStatusOTHER {
+		issueStatusMap[state] = ticket.OTHER
+	}
 	return issueStatusMap, nil
 }


### PR DESCRIPTION
# Summary
BitBucket does not have priority, component because the BitBucket issue has priority, component as semantically explicit attributes that do not need to be extracted from the issue labels like GitHub does.

BitBucket does not have a type configuration because
a. BitBucket issue also has a type field, so there is no need to extract it from labels like GitHub does.
b. BitBucket types are only "enhancement", "proposal", "task", "bug", and cannot be customized by users. So by default we transform "enhancement", "proposal" and "task" to REQUIREMENT and "bug" to BUG to save users' time.

BitBucket does not have severity because BitBucket does not have related fields, so let's put it aside for a while and do it later.

BitBucket has "status mapping" because unlike GitHub issues which only have 2 statuses "open" and "closed", BitBucket has a lot more. We can't transform them to the 3 standard issue statuses "TODO", "IN_PROGRESS" and "DONE" on behalf of users. Thus, we add the "status mapping" configuration to let users decide.

now add bitbucket a new Status mapping `issueStatusOther` in order to let users define some status they do not want to define.

### Does this close any open issues?
Closes #3368 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
