### PR TITLE
feat: defining PluginBlueprintV200 to support project

### DIFF
--- a/models/domainlayer/code/repo.go
+++ b/models/domainlayer/code/repo.go
@@ -21,7 +21,10 @@ import (
 	"time"
 
 	"github.com/apache/incubator-devlake/models/domainlayer"
+	"github.com/apache/incubator-devlake/plugins/core"
 )
+
+var _ core.Scope = (*Repo)(nil)
 
 type Repo struct {
 	domainlayer.DomainEntity
@@ -48,4 +51,12 @@ type RepoLanguage struct {
 
 func (RepoLanguage) TableName() string {
 	return "repo_languages"
+}
+
+func (r *Repo) ScopeId() string {
+	return r.Id
+}
+
+func (r *Repo) ScopeName() string {
+	return r.Name
 }

--- a/models/domainlayer/ticket/board.go
+++ b/models/domainlayer/ticket/board.go
@@ -18,11 +18,15 @@ limitations under the License.
 package ticket
 
 import (
-	"github.com/apache/incubator-devlake/models/common"
 	"time"
+
+	"github.com/apache/incubator-devlake/models/common"
+	"github.com/apache/incubator-devlake/plugins/core"
 
 	"github.com/apache/incubator-devlake/models/domainlayer"
 )
+
+var _ core.Scope = (*Board)(nil)
 
 type Board struct {
 	domainlayer.DomainEntity
@@ -35,6 +39,14 @@ type Board struct {
 
 func (Board) TableName() string {
 	return "boards"
+}
+
+func (r *Board) ScopeId() string {
+	return r.Id
+}
+
+func (r *Board) ScopeName() string {
+	return r.Name
 }
 
 type BoardSprint struct {

--- a/plugins/core/plugin_blueprint.go
+++ b/plugins/core/plugin_blueprint.go
@@ -61,7 +61,45 @@ type BlueprintScopeV100 struct {
 	Transformation json.RawMessage `json:"transformation"`
 }
 
-/* PluginBlueprintV200 for project support */
+/*
+PluginBlueprintV200 for project support
+
+
+step 1: blueprint.settings like
+	{
+		"version": "2.0.0",
+		"scopes": [
+			{
+				"plugin": "github",
+				"scopes": [
+					{ "id": null, "name": "apache/incubator-devlake" }
+				]
+			}
+		]
+	}
+
+step 2: call plugin PluginBlueprintV200.MakePipelinePlan with
+	[
+		{ "id": "1", "name": "apache/incubator-devlake" }
+	]
+	plugin would return PipelinePlan like the following json, and config-ui should use scopeName for displaying
+	[
+		[
+			{ "plugin": "github", "options": { "scopeId": "1", "scopeName": "apache/incubator-devlake" } }
+		]
+	]
+	and []Scope for project_mapping:
+	[
+		&Repo{ "id": "github:GithubRepo:1:1", "name": "apache/incubator-devlake" },
+		&Board{ "id": "github:GithubRepo:1:1", "name": "apache/incubator-devlake" }
+	]
+
+step 3: framework should maintain the project_mapping table based on the []Scope array
+	[
+		{ "projectName": "xxx", "table": "repos", "rowId": "github:GithubRepo:1:1" },
+		{ "projectName": "xxx", "table": "boards", "rowId": "github:GithubRepo:1:1" },
+	]
+*/
 
 // Scope represents the top level entity for a data source, i.e. github repo, gitlab project, jira board.
 // They turn into repo, board in Domain Layer.
@@ -83,6 +121,9 @@ type PluginBlueprintV200 interface {
 // BlueprintScopeV200 contains the Plugin name and related ScopeIds, connectionId and transformationRuleId should be
 // deduced by the ScopeId
 type BlueprintScopeV200 struct {
-	Plugin   string `json:"plugin" validate:"required"`
-	ScopeIds []string
+	Plugin string `json:"plugin" validate:"required"`
+	Scopes []struct {
+		Id   string
+		Name string
+	}
 }


### PR DESCRIPTION
# Summary

**Epic**: https://github.com/apache/incubator-devlake/issues/3468
**Section**: Implementation No. 3 - Blueprint Plan Generation Version v2.0.0
**Content**:
1. Defining `Scope` interface with methods `ScopeId()/ScopeName()/TableName()`, and update `repos` `boards` `cicd_scopes`(not yet exists, skipped) to implement the interface.
2. `PluginBlueprintV200` takes only `ScopeIds`(`connectionId`/`transformationRuleId` can be inferred) as input, and returns `PipelinePlan` and `[]Scope` to indicate the scopes belonging to the project.

### Does this close any open issues?
Part of #3468 

