### PR TITLE
refactor: update integration context initial props

### DIFF
--- a/config-ui/src/store/integrations-context.jsx
+++ b/config-ui/src/store/integrations-context.jsx
@@ -19,9 +19,9 @@ import React, { useState } from 'react'
 import useIntegrations from '@/hooks/useIntegrations'
 
 const IntegrationsContext = React.createContext({
-  registry: {},
-  plugins: {},
-  integrations: {},
+  Registry: {},
+  Plugins: {},
+  Integrations: {},
   activeProvider: null,
   Providers: {},
   ProviderIcons: {},
@@ -34,9 +34,9 @@ const IntegrationsContext = React.createContext({
 
 export const IntegrationsContextProvider = (props) => {
   const {
-    registry: Registry,
-    plugins: Plugins,
-    integrations: Integrations,
+    Registry,
+    Plugins,
+    Integrations,
     activeProvider,
     Providers,
     ProviderLabels,

--- a/config-ui/src/store/integrations-context.jsx
+++ b/config-ui/src/store/integrations-context.jsx
@@ -49,9 +49,9 @@ export const IntegrationsContextProvider = (props) => {
   } = useIntegrations()
 
   const contextValue = {
-    Registry,
-    Plugins,
-    Integrations,
+    registry: Registry,
+    plugins: Plugins,
+    integrations: Integrations,
     activeProvider,
     Providers,
     ProviderLabels,

--- a/config-ui/src/store/integrations-context.jsx
+++ b/config-ui/src/store/integrations-context.jsx
@@ -34,9 +34,9 @@ const IntegrationsContext = React.createContext({
 
 export const IntegrationsContextProvider = (props) => {
   const {
-    Registry,
-    Plugins,
-    Integrations,
+    registry,
+    plugins,
+    integrations,
     activeProvider,
     Providers,
     ProviderLabels,
@@ -49,9 +49,9 @@ export const IntegrationsContextProvider = (props) => {
   } = useIntegrations()
 
   const contextValue = {
-    registry: Registry,
-    plugins: Plugins,
-    integrations: Integrations,
+    Registry: registry,
+    Plugins: plugins,
+    Integrations: integrations,
     activeProvider,
     Providers,
     ProviderLabels,


### PR DESCRIPTION
### Config-UI / Integrations Context

- [x] Fix Integrations Context Initial Properties case for `Registry`, `Plugins` and `Integrations` (Shape)

### Does this close any open issues?
Closes #3625