### PR TITLE
fix: skip --select argument if input is empty

### DIFF
--- a/plugins/dbt/tasks/convertor.go
+++ b/plugins/dbt/tasks/convertor.go
@@ -119,7 +119,7 @@ func DbtConverter(taskCtx core.SubTaskContext) errors.Error {
 		dbtExecParams = append(dbtExecParams, "--vars")
 		dbtExecParams = append(dbtExecParams, string(jsonProjectVars))
 	}
-	if models != nil {
+	if len(models) > 0 {
 		dbtExecParams = append(dbtExecParams, "--select")
 		dbtExecParams = append(dbtExecParams, models...)
 	}


### PR DESCRIPTION
# Summary
When convert to `dbt` command line, skip `--select` if,
1. no input in the option (nil)
2. the slice is empty

### Does this close any open issues?
Closes https://github.com/apache/incubator-devlake/issues/3637
