### PR TITLE
fix: jira subtask collectAccounts ended unexpectedly

### DIFF
--- a/plugins/jira/tasks/issue_extractor.go
+++ b/plugins/jira/tasks/issue_extractor.go
@@ -19,10 +19,11 @@ package tasks
 
 import (
 	"encoding/json"
-	"github.com/apache/incubator-devlake/errors"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/apache/incubator-devlake/errors"
 
 	"github.com/apache/incubator-devlake/plugins/core/dal"
 
@@ -153,7 +154,9 @@ func extractIssues(data *JiraTaskData, mappings *typeMappings, ignoreBoard bool,
 		results = append(results, changelogItem)
 	}
 	for _, user := range users {
-		results = append(results, user)
+		if user.AccountId != "" {
+			results = append(results, user)
+		}
 	}
 	if !ignoreBoard {
 		results = append(results, &models.JiraBoardIssue{


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [ ] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.



# Summary
when accountId = "" , then 400 error occur. so we need to filter the  accountId = ""

### Does this close any open issues?
Closes #3614 

### Screenshots
![image](https://user-images.githubusercontent.com/101256042/199642664-fa763f98-4fd5-44b9-b5ef-1186803833d4.png)

### Other Information
Any other information that is important to this PR.
