### PR TITLE
fix: add optional chain check for null entity name

### DIFF
--- a/config-ui/src/models/GithubProject.js
+++ b/config-ui/src/models/GithubProject.js
@@ -61,7 +61,7 @@ class GitHubProject {
   }
 
   getConfiguredEntityId() {
-    return this.name.toString() || this.id
+    return this.name?.toString() || this.id
   }
 
   getTransformationScopeOptions() {

--- a/config-ui/src/models/JenkinsJob.js
+++ b/config-ui/src/models/JenkinsJob.js
@@ -51,7 +51,7 @@ class JenkinsJob {
   }
 
   getConfiguredEntityId() {
-    return this.name.toString() || this.id
+    return this.name?.toString() || this.id
   }
 
   getTransformationScopeOptions() {


### PR DESCRIPTION
- [x] `Fix` Add Optional chain check (`.?`) for null Entity **Name** event for `GitHubProject` and `JenkinsJob` Data Models (`this.name`)


### Description

This PR applies an optional chaining check to handle `null` or `undefined` entity **names** when keys are generated by **Transformations Manager**, and the base trait function `getConfiguredEntityId()` is accessed by what are expected to be Entity Objects that are instances of `GitHubProject` and `JenkinsJob`. This fix should have been included with PR for Plugin Registry Phase 1, however it was not detected during code review.

### Does this close any open issues?
Closes #3628
