### PR TITLE
feature: skip & rerun failed tasks

### DIFF
--- a/api/blueprints/blueprints.go
+++ b/api/blueprints/blueprints.go
@@ -34,8 +34,8 @@ import (
 // @Accept application/json
 // @Param blueprint body models.Blueprint true "json"
 // @Success 200  {object} models.Blueprint
-// @Failure 400  {string} errcode.Error "Bad Request"
-// @Failure 500  {string} errcode.Error "Internel Error"
+// @Failure 400  {object} shared.ApiBody "Bad Request"
+// @Failure 500  {object} shared.ApiBody "Internal Error"
 // @Router /blueprints [post]
 func Post(c *gin.Context) {
 	blueprint := &models.Blueprint{}
@@ -60,8 +60,8 @@ func Post(c *gin.Context) {
 // @Tags framework/blueprints
 // @Accept application/json
 // @Success 200  {object} gin.H
-// @Failure 400  {string} errcode.Error "Bad Request"
-// @Failure 500  {string} errcode.Error "Internel Error"
+// @Failure 400  {object} shared.ApiBody "Bad Request"
+// @Failure 500  {object} shared.ApiBody "Internal Error"
 // @Router /blueprints [get]
 func Index(c *gin.Context) {
 	var query services.BlueprintQuery
@@ -84,8 +84,8 @@ func Index(c *gin.Context) {
 // @Accept application/json
 // @Param blueprintId path int true "blueprint id"
 // @Success 200  {object} models.Blueprint
-// @Failure 400  {string} errcode.Error "Bad Request"
-// @Failure 500  {string} errcode.Error "Internel Error"
+// @Failure 400  {object} shared.ApiBody "Bad Request"
+// @Failure 500  {object} shared.ApiBody "Internal Error"
 // @Router /blueprints/{blueprintId} [get]
 func Get(c *gin.Context) {
 	blueprintId := c.Param("blueprintId")
@@ -107,8 +107,8 @@ func Get(c *gin.Context) {
 // @Tags framework/blueprints
 // @Param blueprintId path string true "blueprintId"
 // @Success 200
-// @Failure 400  {string} errcode.Error "Bad Request"
-// @Failure 500  {string} errcode.Error "Internel Error"
+// @Failure 400  {object} shared.ApiBody "Bad Request"
+// @Failure 500  {object} shared.ApiBody "Internal Error"
 // @Router /blueprints/{blueprintId} [delete]
 func Delete(c *gin.Context) {
 	pipelineId := c.Param("blueprintId")
@@ -123,39 +123,14 @@ func Delete(c *gin.Context) {
 	}
 }
 
-/*
-func Put(c *gin.Context) {
-	blueprintId := c.Param("blueprintId")
-	id, err := strconv.ParseUint(blueprintId, 10, 64)
-	if err != nil {
-		shared.ApiOutputError(c, err, http.StatusBadRequest)
-		return
-	}
-	editBlueprint := &models.EditBlueprint{}
-	err = c.MustBindWith(editBlueprint, binding.JSON)
-	if err != nil {
-		shared.ApiOutputError(c, err, http.StatusBadRequest)
-		fmt.Println(err)
-		return
-	}
-	editBlueprint.BlueprintId = id
-	blueprint, err := services.ModifyBlueprint(editBlueprint)
-	if err != nil {
-		shared.ApiOutputError(c, err, http.StatusBadRequest)
-		return
-	}
-	shared.ApiOutputSuccess(c, blueprint, http.StatusOK)
-}
-*/
-
 // @Summary patch blueprints
 // @Description patch blueprints
 // @Tags framework/blueprints
 // @Accept application/json
 // @Param blueprintId path string true "blueprintId"
 // @Success 200  {object} models.Blueprint
-// @Failure 400  {string} errcode.Error "Bad Request"
-// @Failure 500  {string} errcode.Error "Internel Error"
+// @Failure 400  {object} shared.ApiBody "Bad Request"
+// @Failure 500  {object} shared.ApiBody "Internal Error"
 // @Router /blueprints/{blueprintId} [Patch]
 func Patch(c *gin.Context) {
 	blueprintId := c.Param("blueprintId")
@@ -184,8 +159,8 @@ func Patch(c *gin.Context) {
 // @Accept application/json
 // @Param blueprintId path string true "blueprintId"
 // @Success 200  {object} models.Pipeline
-// @Failure 400  {string} errcode.Error "Bad Request"
-// @Failure 500  {string} errcode.Error "Internel Error"
+// @Failure 400  {object} shared.ApiBody "Bad Request"
+// @Failure 500  {object} shared.ApiBody "Internal Error"
 // @Router /blueprints/{blueprintId}/trigger [Post]
 func Trigger(c *gin.Context) {
 	blueprintId := c.Param("blueprintId")
@@ -208,8 +183,8 @@ func Trigger(c *gin.Context) {
 // @Accept application/json
 // @Param blueprintId path int true "blueprint id"
 // @Success 200  {object} shared.ResponsePipelines
-// @Failure 400  {string} errcode.Error "Bad Request"
-// @Failure 500  {string} errcode.Error "Internel Error"
+// @Failure 400  {object} shared.ApiBody "Bad Request"
+// @Failure 500  {object} shared.ApiBody "Internal Error"
 // @Router /blueprints/{blueprintId}/pipelines [get]
 func GetBlueprintPipelines(c *gin.Context) {
 	var query services.PipelineQuery

--- a/api/router.go
+++ b/api/router.go
@@ -49,7 +49,8 @@ func RegisterRouter(r *gin.Engine) {
 	r.GET("/blueprints/:blueprintId", blueprints.Get)
 	r.GET("/blueprints/:blueprintId/pipelines", blueprints.GetBlueprintPipelines)
 	r.DELETE("/pipelines/:pipelineId", pipelines.Delete)
-	r.GET("/pipelines/:pipelineId/tasks", task.Index)
+	r.GET("/pipelines/:pipelineId/tasks", task.GetTaskByPipeline)
+	r.POST("/pipelines/:pipelineId/tasks", task.RerunTask)
 
 	r.GET("/pipelines/:pipelineId/logging.tar.gz", pipelines.DownloadLogs)
 

--- a/api/task/task.go
+++ b/api/task/task.go
@@ -23,55 +23,10 @@ import (
 
 	"github.com/apache/incubator-devlake/api/shared"
 	"github.com/apache/incubator-devlake/errors"
+	"github.com/apache/incubator-devlake/models"
 	"github.com/apache/incubator-devlake/services"
 	"github.com/gin-gonic/gin"
 )
-
-/*
-Get list of pipelines
-GET /pipelines/pipeline:id/tasks?status=TASK_RUNNING&pending=1&page=1&=pagesize=10
-{
-	"tasks": [
-		{"id": 1, "plugin": "", ...}
-	],
-	"count": 5
-}
-*/
-// @Summary Get task
-// @Description get task
-// @Description SAMPLE
-// @Description {
-// @Description 	"tasks": [
-// @Description 		{"id": 1, "plugin": "", ...}
-// @Description 	],
-// @Description 	"count": 5
-// @Description }
-// @Tags framework/task
-// @Accept application/json
-// @Param pipelineId path int true "pipelineId"
-// @Success 200  {string} gin.H "{"tasks": tasks, "count": count}"
-// @Failure 400  {string} errcode.Error "Bad Request"
-// @Failure 500  {string} errcode.Error "Internel Error"
-// @Router /pipelines/{pipelineId}/tasks [get]
-func Index(c *gin.Context) {
-	var query services.TaskQuery
-	err := c.ShouldBindQuery(&query)
-	if err != nil {
-		shared.ApiOutputError(c, errors.BadInput.Wrap(err, shared.BadRequestBody))
-		return
-	}
-	err = c.ShouldBindUri(&query)
-	if err != nil {
-		shared.ApiOutputError(c, errors.BadInput.Wrap(err, "bad request URI format"))
-		return
-	}
-	tasks, count, err := services.GetTasks(&query)
-	if err != nil {
-		shared.ApiOutputError(c, errors.Default.Wrap(err, "error getting tasks"))
-		return
-	}
-	shared.ApiOutputSuccess(c, gin.H{"tasks": tasks, "count": count}, http.StatusOK)
-}
 
 func Delete(c *gin.Context) {
 	taskId := c.Param("taskId")
@@ -83,6 +38,120 @@ func Delete(c *gin.Context) {
 	err = services.CancelTask(id)
 	if err != nil {
 		shared.ApiOutputError(c, errors.Default.Wrap(err, "error cancelling task"))
+		return
+	}
+	shared.ApiOutputSuccess(c, nil, http.StatusOK)
+}
+
+type getTaskResponse struct {
+	Tasks []models.Task `json:"tasks"`
+	Count int           `json:"count"`
+}
+
+// GetTaskByPipeline return most recent tasks
+// @Summary Get tasks, only the most recent tasks will be returned
+// @Tags framework/task
+// @Accept application/json
+// @Param pipelineId path int true "pipelineId"
+// @Success 200  {object} getTaskResponse
+// @Failure 400  {object} shared.ApiBody "Bad Request"
+// @Failure 500  {object} shared.ApiBody "Internal Error"
+// @Router /pipelines/{pipelineId}/tasks [get]
+func GetTaskByPipeline(c *gin.Context) {
+	pipelineId, err := strconv.ParseUint(c.Param("pipelineId"), 10, 64)
+	if err != nil {
+		shared.ApiOutputError(c, errors.BadInput.Wrap(err, "invalid pipeline ID format"))
+		return
+	}
+	tasks, err := services.GetTasksWithLastStatus(pipelineId)
+	if err != nil {
+		shared.ApiOutputError(c, errors.Default.Wrap(err, "error getting tasks"))
+		return
+	}
+	shared.ApiOutputSuccess(c, getTaskResponse{Tasks: tasks, Count: len(tasks)}, http.StatusOK)
+}
+
+type rerunRequest struct {
+	TaskId uint64 `json:"taskId"`
+}
+
+// RerunTask rerun the specified the task. If taskId is 0, all failed tasks of this pipeline will rerun
+// @Summary rerun tasks
+// @Tags framework/task
+// @Accept application/json
+// @Param pipelineId path int true "pipelineId"
+// @Param request body rerunRequest false "specify the task to rerun. If it's 0, all failed tasks of this pipeline will rerun"
+// @Success 200  {object} shared.ApiBody
+// @Failure 400  {object} shared.ApiBody "Bad Request"
+// @Failure 500  {object} shared.ApiBody "Internal Error"
+// @Router /pipelines/{pipelineId}/tasks [post]
+func RerunTask(c *gin.Context) {
+	var request rerunRequest
+	err := c.BindJSON(&request)
+	if err != nil {
+		shared.ApiOutputError(c, errors.BadInput.Wrap(err, "invalid task ID format"))
+		return
+	}
+	pipelineId, err := strconv.ParseUint(c.Param("pipelineId"), 10, 64)
+	if err != nil {
+		shared.ApiOutputError(c, errors.BadInput.Wrap(err, "invalid pipeline ID format"))
+		return
+	}
+	pipeline, err := services.GetPipeline(pipelineId)
+	if err != nil {
+		shared.ApiOutputError(c, errors.Default.Wrap(err, "error get pipeline"))
+		return
+	}
+	if pipeline.Status == models.TASK_RUNNING {
+		shared.ApiOutputError(c, errors.BadInput.New("pipeline is running"))
+		return
+	}
+	if pipeline.Status == models.TASK_CREATED || pipeline.Status == models.TASK_RERUN {
+		shared.ApiOutputError(c, errors.BadInput.New("pipeline is waiting to run"))
+		return
+	}
+
+	var failedTasks []models.Task
+	if request.TaskId > 0 {
+		failedTask, err := services.GetTask(request.TaskId)
+		if err != nil || failedTask == nil {
+			shared.ApiOutputError(c, errors.Default.Wrap(err, "error getting failed task"))
+			return
+		}
+		if failedTask.PipelineId != pipelineId {
+			shared.ApiOutputError(c, errors.BadInput.New("the task ID and pipeline ID doesn't match"))
+			return
+		}
+		failedTasks = append(failedTasks, *failedTask)
+	} else {
+		tasks, err := services.GetTasksWithLastStatus(pipelineId)
+		if err != nil {
+			shared.ApiOutputError(c, errors.Default.Wrap(err, "error getting tasks"))
+			return
+		}
+		for _, task := range tasks {
+			if task.Status == models.TASK_FAILED {
+				failedTasks = append(failedTasks, task)
+			}
+		}
+	}
+	if len(failedTasks) == 0 {
+		shared.ApiOutputSuccess(c, nil, http.StatusOK)
+		return
+	}
+	err = services.DeleteCreatedTasks(pipelineId)
+	if err != nil {
+		shared.ApiOutputError(c, errors.Default.Wrap(err, "error delete tasks"))
+		return
+	}
+	_, err = services.SpawnTasks(failedTasks)
+	if err != nil {
+		shared.ApiOutputError(c, errors.Default.Wrap(err, "error create tasks"))
+		return
+	}
+	err = services.UpdateDbPipelineStatus(pipelineId, models.TASK_RERUN)
+	if err != nil {
+		shared.ApiOutputError(c, errors.Default.Wrap(err, "error create tasks"))
 		return
 	}
 	shared.ApiOutputSuccess(c, nil, http.StatusOK)

--- a/models/blueprint.go
+++ b/models/blueprint.go
@@ -39,12 +39,14 @@ type Blueprint struct {
 	//please check this https://crontab.guru/ for detail
 	CronConfig   string          `json:"cronConfig" format:"* * * * *" example:"0 0 * * 1"`
 	IsManual     bool            `json:"isManual"`
+	SkipOnFail   bool            `json:"skipOnFail"`
 	Settings     json.RawMessage `json:"settings" swaggertype:"array,string" example:"please check api: /blueprints/<PLUGIN_NAME>/blueprint-setting"`
 	common.Model `swaggerignore:"true"`
 }
 
 type BlueprintSettings struct {
 	Version     string          `json:"version" validate:"required,semver,oneof=1.0.0"`
+	SkipOnFail  bool            `json:"skipOnFail"`
 	Connections json.RawMessage `json:"connections" validate:"required"`
 	BeforePlan  json.RawMessage `json:"before_plan"`
 	AfterPlan   json.RawMessage `json:"after_plan"`
@@ -69,6 +71,7 @@ type DbBlueprint struct {
 	//please check this https://crontab.guru/ for detail
 	CronConfig   string `json:"cronConfig" format:"* * * * *" example:"0 0 * * 1"`
 	IsManual     bool   `json:"isManual"`
+	SkipOnFail   bool   `json:"skipOnFail"`
 	Settings     string `json:"settings" encrypt:"yes" swaggertype:"array,string" example:"please check api: /blueprints/<PLUGIN_NAME>/blueprint-setting"`
 	common.Model `swaggerignore:"true"`
 }

--- a/models/migrationscripts/20221107_add_skip_on_fail.go
+++ b/models/migrationscripts/20221107_add_skip_on_fail.go
@@ -1,0 +1,60 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"github.com/apache/incubator-devlake/errors"
+	"github.com/apache/incubator-devlake/helpers/migrationhelper"
+	"github.com/apache/incubator-devlake/plugins/core"
+)
+
+var _ core.MigrationScript = (*addSkipOnFail)(nil)
+
+type blueprint20221107 struct {
+	SkipOnFail bool
+}
+
+func (p blueprint20221107) TableName() string {
+	return "_devlake_blueprints"
+}
+
+type task20221107 struct {
+	SkipOnFail bool
+}
+
+func (t task20221107) TableName() string {
+	return "_devlake_tasks"
+}
+
+type addSkipOnFail struct{}
+
+func (*addSkipOnFail) Up(basicRes core.BasicRes) errors.Error {
+	return migrationhelper.AutoMigrateTables(
+		basicRes,
+		&blueprint20221107{},
+		&task20221107{},
+	)
+}
+
+func (*addSkipOnFail) Version() uint64 {
+	return 20221107095744
+}
+
+func (*addSkipOnFail) Name() string {
+	return "add skip_on_fail to _devlake_pipelines and _devlake_tasks"
+}

--- a/models/migrationscripts/register.go
+++ b/models/migrationscripts/register.go
@@ -54,6 +54,7 @@ func All() []core.MigrationScript {
 		new(createCollectorState),
 		new(removeCicdPipelineRelation),
 		new(addCicdScope),
+		new(addSkipOnFail),
 		new(modifyCommitsDiffs),
 	}
 }

--- a/models/task.go
+++ b/models/task.go
@@ -27,6 +27,7 @@ import (
 
 const (
 	TASK_CREATED   = "TASK_CREATED"
+	TASK_RERUN     = "TASK_RERUN"
 	TASK_RUNNING   = "TASK_RUNNING"
 	TASK_COMPLETED = "TASK_COMPLETED"
 	TASK_FAILED    = "TASK_FAILED"
@@ -58,6 +59,7 @@ type Task struct {
 	BeganAt       *time.Time `json:"beganAt"`
 	FinishedAt    *time.Time `json:"finishedAt" gorm:"index"`
 	SpentSeconds  int        `json:"spentSeconds"`
+	SkipOnFail    bool       `json:"-"`
 }
 
 type NewTask struct {

--- a/plugins/core/plugin_blueprint.go
+++ b/plugins/core/plugin_blueprint.go
@@ -25,9 +25,10 @@ import (
 // PipelineTask represents a smallest unit of execution inside a PipelinePlan
 type PipelineTask struct {
 	// Plugin name
-	Plugin   string                 `json:"plugin" binding:"required"`
-	Subtasks []string               `json:"subtasks"`
-	Options  map[string]interface{} `json:"options"`
+	Plugin     string                 `json:"plugin" binding:"required"`
+	SkipOnFail bool                   `json:"skipOnFail"`
+	Subtasks   []string               `json:"subtasks"`
+	Options    map[string]interface{} `json:"options"`
 }
 
 // PipelineStage consist of multiple PipelineTasks, they will be executed in parallel
@@ -51,6 +52,7 @@ type PluginBlueprintV100 interface {
 type BlueprintConnectionV100 struct {
 	Plugin       string                `json:"plugin" validate:"required"`
 	ConnectionId uint64                `json:"connectionId" validate:"required"`
+	SkipOnFail   bool                  `json:"skipOnFail"`
 	Scope        []*BlueprintScopeV100 `json:"scope" validate:"required"`
 }
 

--- a/runner/run_pipeline.go
+++ b/runner/run_pipeline.go
@@ -18,7 +18,6 @@ limitations under the License.
 package runner
 
 import (
-	"sort"
 	"time"
 
 	"github.com/apache/incubator-devlake/errors"
@@ -42,14 +41,6 @@ func RunPipeline(
 	if err != nil {
 		return errors.Convert(err)
 	}
-	sort.Slice(tasks, func(i, j int) bool {
-		if tasks[i].PipelineRow < tasks[j].PipelineRow {
-			return true
-		} else if tasks[i].PipelineRow == tasks[j].PipelineRow {
-			return tasks[i].PipelineCol < tasks[j].PipelineCol
-		}
-		return true
-	})
 	taskIds := make([][]uint64, 0)
 	for _, task := range tasks {
 		for len(taskIds) < task.PipelineRow {

--- a/runner/run_pipeline.go
+++ b/runner/run_pipeline.go
@@ -42,11 +42,25 @@ func RunPipeline(
 	if err != nil {
 		return errors.Convert(err)
 	}
-	taskIds := Get2DTaskIds(tasks)
-	return RunPipelineTasks(log, db, pipelineId, taskIds, runTasks)
+	sort.Slice(tasks, func(i, j int) bool {
+		if tasks[i].PipelineRow < tasks[j].PipelineRow {
+			return true
+		} else if tasks[i].PipelineRow == tasks[j].PipelineRow {
+			return tasks[i].PipelineCol < tasks[j].PipelineCol
+		}
+		return true
+	})
+	taskIds := make([][]uint64, 0)
+	for _, task := range tasks {
+		for len(taskIds) < task.PipelineRow {
+			taskIds = append(taskIds, make([]uint64, 0))
+		}
+		taskIds[task.PipelineRow-1] = append(taskIds[task.PipelineRow-1], task.ID)
+	}
+	return runPipelineTasks(log, db, pipelineId, taskIds, runTasks)
 }
 
-func RunPipelineTasks(
+func runPipelineTasks(
 	log core.Logger,
 	db *gorm.DB,
 	pipelineId uint64,
@@ -90,23 +104,4 @@ func RunPipelineTasks(
 	}
 	log.Info("pipeline finished in %d ms: %v", time.Now().UnixMilli()-dbPipeline.BeganAt.UnixMilli(), err)
 	return errors.Convert(err)
-}
-
-func Get2DTaskIds(tasks []models.Task) [][]uint64 {
-	sort.Slice(tasks, func(i, j int) bool {
-		if tasks[i].PipelineRow < tasks[j].PipelineRow {
-			return true
-		} else if tasks[i].PipelineRow == tasks[j].PipelineRow {
-			return tasks[i].PipelineCol < tasks[j].PipelineCol
-		}
-		return true
-	})
-	taskIds := make([][]uint64, 0)
-	for _, task := range tasks {
-		for len(taskIds) < task.PipelineRow {
-			taskIds = append(taskIds, make([]uint64, 0))
-		}
-		taskIds[task.PipelineRow-1] = append(taskIds[task.PipelineRow-1], task.ID)
-	}
-	return taskIds
 }

--- a/runner/run_task.go
+++ b/runner/run_task.go
@@ -66,7 +66,9 @@ func RunTask(
 			default:
 				e = fmt.Errorf("%v", et)
 			}
-			err = errors.Default.Wrap(e, fmt.Sprintf("run task failed with panic (%s)", utils.GatherCallFrames(0)))
+			if !task.SkipOnFail {
+				err = errors.Default.Wrap(e, fmt.Sprintf("run task failed with panic (%s)", utils.GatherCallFrames(0)))
+			}
 		}
 		finishedAt := time.Now()
 		spentSeconds := finishedAt.Unix() - beganAt.Unix()
@@ -135,6 +137,9 @@ func RunTask(
 		options,
 		progress,
 	)
+	if err != nil && task.SkipOnFail {
+		return nil
+	}
 	return err
 }
 

--- a/services/blueprint_helper.go
+++ b/services/blueprint_helper.go
@@ -90,6 +90,7 @@ func parseBlueprint(DbBlueprint *models.DbBlueprint) *models.Blueprint {
 		Enable:     DbBlueprint.Enable,
 		CronConfig: DbBlueprint.CronConfig,
 		IsManual:   DbBlueprint.IsManual,
+		SkipOnFail: DbBlueprint.SkipOnFail,
 		Settings:   []byte(DbBlueprint.Settings),
 		Model:      DbBlueprint.Model,
 	}
@@ -105,6 +106,7 @@ func parseDbBlueprint(blueprint *models.Blueprint) *models.DbBlueprint {
 		Enable:     blueprint.Enable,
 		CronConfig: blueprint.CronConfig,
 		IsManual:   blueprint.IsManual,
+		SkipOnFail: blueprint.SkipOnFail,
 		Settings:   string(blueprint.Settings),
 		Model:      blueprint.Model,
 	}

--- a/services/blueprint_makeplan_v100.go
+++ b/services/blueprint_makeplan_v100.go
@@ -54,6 +54,7 @@ func GeneratePlanJsonV100(settings *models.BlueprintSettings) (core.PipelinePlan
 		}
 		for _, stage := range plans[i] {
 			for _, task := range stage {
+				task.SkipOnFail = settings.SkipOnFail
 				if task.Plugin == "dora" {
 					hasDoraEnrich = true
 					for k, v := range task.Options {

--- a/services/pipeline_helper.go
+++ b/services/pipeline_helper.go
@@ -196,3 +196,12 @@ func decryptDbPipeline(dbPipeline *models.DbPipeline) (*models.DbPipeline, error
 	dbPipeline.Plan = plan
 	return dbPipeline, nil
 }
+
+// UpdateDbPipelineStatus update the status of pipeline
+func UpdateDbPipelineStatus(pipelineId uint64, status string) errors.Error {
+	err := db.Model(&models.DbPipeline{}).Where("id = ?", pipelineId).Update("status", status).Error
+	if err != nil {
+		return errors.Convert(err)
+	}
+	return nil
+}

--- a/services/pipeline_runner.go
+++ b/services/pipeline_runner.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
+
 	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/logger"
 	"github.com/apache/incubator-devlake/models"
@@ -28,7 +30,6 @@ import (
 	"github.com/apache/incubator-devlake/runner"
 	"github.com/apache/incubator-devlake/worker/app"
 	"go.temporal.io/sdk/client"
-	"time"
 )
 
 type pipelineRunner struct {
@@ -43,7 +44,7 @@ func (p *pipelineRunner) runPipelineStandalone() errors.Error {
 		db,
 		p.pipeline.ID,
 		func(taskIds []uint64) errors.Error {
-			return runTasksStandalone(p.logger, taskIds)
+			return RunTasksStandalone(p.logger, taskIds)
 		},
 	)
 }
@@ -79,7 +80,8 @@ func (p *pipelineRunner) runPipelineViaTemporal() errors.Error {
 	return errors.Convert(err)
 }
 
-func getPipelineLogger(pipeline *models.Pipeline) core.Logger {
+// GetPipelineLogger returns logger for the pipeline
+func GetPipelineLogger(pipeline *models.Pipeline) core.Logger {
 	pipelineLogger := globalPipelineLog.Nested(
 		fmt.Sprintf("pipeline #%d", pipeline.ID),
 	)
@@ -98,13 +100,13 @@ func getPipelineLogger(pipeline *models.Pipeline) core.Logger {
 
 // runPipeline start a pipeline actually
 func runPipeline(pipelineId uint64) errors.Error {
-	pipeline, err := GetPipeline(pipelineId)
+	ppl, err := GetPipeline(pipelineId)
 	if err != nil {
 		return err
 	}
 	pipelineRun := pipelineRunner{
-		logger:   getPipelineLogger(pipeline),
-		pipeline: pipeline,
+		logger:   GetPipelineLogger(ppl),
+		pipeline: ppl,
 	}
 	// run
 	if temporalClient != nil {

--- a/services/task.go
+++ b/services/task.go
@@ -362,7 +362,7 @@ func getTaskIdFromActivityId(activityId string) (uint64, errors.Error) {
 	return errors.Convert01(strconv.ParseUint(submatches[1], 10, 64))
 }
 
-// DeleteCreatedTasks deletes tasks with status `TASK_RERUN`
+// DeleteCreatedTasks deletes tasks with status `TASK_CREATED`
 func DeleteCreatedTasks(pipelineId uint64) errors.Error {
 	err := db.Where("pipeline_id = ? AND status = ?", pipelineId, models.TASK_CREATED).Delete(&models.Task{}).Error
 	if err != nil {

--- a/services/task.go
+++ b/services/task.go
@@ -27,9 +27,9 @@ import (
 	"sync"
 
 	"github.com/apache/incubator-devlake/errors"
-
 	"github.com/apache/incubator-devlake/logger"
 	"github.com/apache/incubator-devlake/models"
+	"github.com/apache/incubator-devlake/models/common"
 	"github.com/apache/incubator-devlake/plugins/core"
 	"github.com/apache/incubator-devlake/runner"
 	"gorm.io/gorm"
@@ -153,6 +153,7 @@ func CreateTask(newTask *models.NewTask) (*models.Task, errors.Error) {
 		PipelineId:  newTask.PipelineId,
 		PipelineRow: newTask.PipelineRow,
 		PipelineCol: newTask.PipelineCol,
+		SkipOnFail:  newTask.SkipOnFail,
 	}
 	err = db.Save(&task).Error
 	if err != nil {
@@ -194,6 +195,60 @@ func GetTasks(query *TaskQuery) ([]models.Task, int64, errors.Error) {
 	return tasks, count, nil
 }
 
+// GetTasksWithLastStatus returns task list of the pipeline, only the most recently tasks would be returned
+func GetTasksWithLastStatus(pipelineId uint64) ([]models.Task, errors.Error) {
+	var tasks []models.Task
+	dbInner := db.Model(&models.Task{}).Order("id DESC").Where("pipeline_id = ?", pipelineId)
+	err := dbInner.Find(&tasks).Error
+	if err != nil {
+		return nil, errors.Convert(err)
+	}
+	taskIds := make(map[int64]struct{})
+	var result []models.Task
+	var maxRow, maxCol int
+	for _, task := range tasks {
+		if task.PipelineRow > maxRow {
+			maxRow = task.PipelineRow
+		}
+		if task.PipelineCol > maxCol {
+			maxCol = task.PipelineCol
+		}
+	}
+	for _, task := range tasks {
+		index := int64(task.PipelineRow)*int64(maxCol) + int64(task.PipelineCol)
+		if _, ok := taskIds[index]; !ok {
+			taskIds[index] = struct{}{}
+			result = append(result, task)
+		}
+	}
+	runningTasks.FillProgressDetailToTasks(result)
+	return result, nil
+}
+
+// SpawnTasks create new tasks from the failed ones
+func SpawnTasks(input []models.Task) ([]models.Task, errors.Error) {
+	var result []models.Task
+	for _, task := range input {
+		task.Model = common.Model{}
+		task.Status = models.TASK_CREATED
+		task.Message = ""
+		task.Progress = 0
+		task.ProgressDetail = nil
+		task.FailedSubTask = ""
+		task.BeganAt = nil
+		task.FinishedAt = nil
+		task.SpentSeconds = 0
+		task.SkipOnFail = true
+		result = append(result, task)
+	}
+	err := db.Save(&result).Error
+	if err != nil {
+		taskLog.Error(err, "save task failed")
+		return nil, errors.Internal.Wrap(err, "save task failed")
+	}
+	return result, nil
+}
+
 // GetTask FIXME ...
 func GetTask(taskId uint64) (*models.Task, errors.Error) {
 	task := &models.Task{}
@@ -217,19 +272,22 @@ func CancelTask(taskId uint64) errors.Error {
 	return nil
 }
 
-func runTasksStandalone(parentLogger core.Logger, taskIds []uint64) errors.Error {
+// RunTasksStandalone run tasks in parallel
+func RunTasksStandalone(parentLogger core.Logger, taskIds []uint64) errors.Error {
+	if len(taskIds) == 0 {
+		return nil
+	}
 	results := make(chan error)
 	for _, taskId := range taskIds {
-		taskId := taskId
-		go func() {
-			taskLog.Info("run task #%d in background ", taskId)
+		go func(id uint64) {
+			taskLog.Info("run task #%d in background ", id)
 			var err errors.Error
-			taskErr := runTaskStandalone(parentLogger, taskId)
+			taskErr := runTaskStandalone(parentLogger, id)
 			if taskErr != nil {
-				err = errors.Default.Wrap(taskErr, fmt.Sprintf("Error running task %d.", taskId))
+				err = errors.Default.Wrap(taskErr, fmt.Sprintf("Error running task %d.", id))
 			}
 			results <- err
-		}()
+		}(taskId)
 	}
 	errs := make([]error, 0)
 	var err error
@@ -302,4 +360,13 @@ func getTaskIdFromActivityId(activityId string) (uint64, errors.Error) {
 		return 0, errors.Default.New("activityId does not match")
 	}
 	return errors.Convert01(strconv.ParseUint(submatches[1], 10, 64))
+}
+
+// DeleteCreatedTasks deletes tasks with status `TASK_RERUN`
+func DeleteCreatedTasks(pipelineId uint64) errors.Error {
+	err := db.Where("pipeline_id = ? AND status = ?", pipelineId, models.TASK_CREATED).Delete(&models.Task{}).Error
+	if err != nil {
+		return errors.Convert(err)
+	}
+	return nil
 }


### PR DESCRIPTION
# Summary
Give users the option to skip/rerun failed tasks, and rerun them in the future.
To skip failed tasks, set the `onFailSkip=true` on creating the blueprint.
![image](https://user-images.githubusercontent.com/8455907/200216489-45b34c41-99f9-47e0-9f24-bf3172c2bd7b.png)
To rerun failed tasks, post `taskId` to the API `/pipelines/{pipelineId}/tasks`, if `taskId = 0` all failed tasks will rerun
![image](https://user-images.githubusercontent.com/8455907/200220146-651af7e7-aa63-41a2-b515-6e86297759cd.png)
To get tasks, `GET /pipelines/{pipelineId}/tasks`, only the most recent tasks will be returned

## The process flow for rerun:
**We introduced a new pipeline status `TASK_RERUN` which indicates the pipeline is going to rerun**
### The HTTP handler part
1. find the pipeline by ID, and return an error if the status is among `TASK_CREATED`, `TASK_RUNNING`, and `TASK_RERUN`
2. find the tasks that need to be rerun
3. delete all tasks with the status `TASK_CREATED`
4. generate new tasks from the tasks that need to be rerun, and set their status as `TASK_CREATED`
5. set the pipeline status as `TASK_RERUN`

### The pipeline scheduler part

1. scan the table `_devlake_pipelines`, and find the first pipeline with status `TASK_CREATED` or `TASK_RERUN`
2. set the status of the pipeline to `TASK_RUNNING`
3. run the pipeline in another goroutine


### Does this close any open issues?
Closes #2499 

