### PR TITLE
fix(framework): remove cicdPipelineRelationship

### DIFF
--- a/models/domainlayer/devops/cicd_pipeline.go
+++ b/models/domainlayer/devops/cicd_pipeline.go
@@ -20,8 +20,6 @@ package devops
 import (
 	"time"
 
-	"github.com/apache/incubator-devlake/models/common"
-
 	"github.com/apache/incubator-devlake/models/domainlayer"
 )
 
@@ -39,16 +37,6 @@ type CICDPipeline struct {
 
 func (CICDPipeline) TableName() string {
 	return "cicd_pipelines"
-}
-
-type CICDPipelineRelationship struct {
-	ParentPipelineId string `gorm:"primaryKey;type:varchar(255)"`
-	ChildPipelineId  string `gorm:"primaryKey;type:varchar(255)"`
-	common.NoPKModel
-}
-
-func (CICDPipelineRelationship) TableName() string {
-	return "cicd_pipeline_relationships"
 }
 
 const (

--- a/models/migrationscripts/20221107_remove_cicd_pipeline_relation.go
+++ b/models/migrationscripts/20221107_remove_cicd_pipeline_relation.go
@@ -1,0 +1,43 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"github.com/apache/incubator-devlake/errors"
+	"github.com/apache/incubator-devlake/plugins/core"
+)
+
+type removeCicdPipelineRelation struct{}
+
+type CICDPipelineRelationship20221107 struct{}
+
+func (CICDPipelineRelationship20221107) TableName() string {
+	return "cicd_pipeline_relationships"
+}
+
+func (*removeCicdPipelineRelation) Up(basicRes core.BasicRes) errors.Error {
+	return basicRes.GetDal().DropTables(CICDPipelineRelationship20221107{})
+}
+
+func (*removeCicdPipelineRelation) Version() uint64 {
+	return 20221107000001
+}
+
+func (*removeCicdPipelineRelation) Name() string {
+	return "Remove cicd_pipeline_relation"
+}

--- a/models/migrationscripts/register.go
+++ b/models/migrationscripts/register.go
@@ -52,5 +52,6 @@ func All() []core.MigrationScript {
 		new(changeLeadTimeMinutesToInt64),
 		new(addRepoSnapshot),
 		new(createCollectorState),
+		new(removeCicdPipelineRelation),
 	}
 }

--- a/plugins/jenkins/e2e/builds_test.go
+++ b/plugins/jenkins/e2e/builds_test.go
@@ -80,7 +80,6 @@ func TestJenkinsBuildsDataFlow(t *testing.T) {
 	dataflowTester.FlushTabler(&devops.CICDTask{})
 	dataflowTester.FlushTabler(&devops.CICDPipeline{})
 	dataflowTester.FlushTabler(&devops.CiCDPipelineCommit{})
-	dataflowTester.FlushTabler(&devops.CICDPipelineRelationship{})
 	dataflowTester.Subtask(tasks.EnrichApiBuildWithStagesMeta, taskData)
 	dataflowTester.Subtask(tasks.ConvertBuildsToCICDMeta, taskData)
 	dataflowTester.Subtask(tasks.ConvertBuildReposMeta, taskData)
@@ -113,15 +112,6 @@ func TestJenkinsBuildsDataFlow(t *testing.T) {
 			"environment",
 			"created_date",
 			"finished_date",
-		),
-	)
-
-	dataflowTester.VerifyTable(
-		devops.CICDPipelineRelationship{},
-		"./snapshot_tables/cicd_pipeline_relationships.csv",
-		e2ehelper.ColumnWithRawData(
-			"parent_pipeline_id",
-			"child_pipeline_id",
 		),
 	)
 

--- a/plugins/jenkins/e2e/snapshot_tables/cicd_pipeline_relationships.csv
+++ b/plugins/jenkins/e2e/snapshot_tables/cicd_pipeline_relationships.csv
@@ -1,1 +1,0 @@
-parent_pipeline_id,child_pipeline_id

--- a/plugins/jenkins/tasks/build_cicd_convertor.go
+++ b/plugins/jenkins/tasks/build_cicd_convertor.go
@@ -108,16 +108,6 @@ func ConvertBuildsToCICD(taskCtx core.SubTaskContext) (err errors.Error) {
 				DurationSec:  uint64(durationSec),
 				CreatedDate:  jenkinsBuild.StartTime,
 			}
-
-			if jenkinsBuild.TriggeredBy != "" {
-				domainPipelineRelation := &devops.CICDPipelineRelationship{
-					ParentPipelineId: buildIdGen.Generate(jenkinsBuild.ConnectionId,
-						jenkinsBuild.TriggeredBy),
-					ChildPipelineId: buildIdGen.Generate(jenkinsBuild.ConnectionId,
-						jenkinsBuild.FullDisplayName),
-				}
-				results = append(results, domainPipelineRelation)
-			}
 			jenkinsPipeline.RawDataOrigin = jenkinsBuild.RawDataOrigin
 			results = append(results, jenkinsPipeline)
 


### PR DESCRIPTION
# Summary

I created cicd_pipeline_relationships by mistaken, so this pr is to do the following:
1. remove model: CICDPipelineRelationship
2. create migrationscript to delete table.cicd_pipeline_relationships which created in models/migrationscripts/20220905_modfiy_cicd_pipeline.go
3. delete the code which insert data to table.cicd_pipeline_relationships

### Does this close any open issues?
Closes #3682

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
