### PR TITLE
fix: support github repository with dot(.) char

### DIFF
--- a/config-ui/src/hooks/useBlueprintValidation.jsx
+++ b/config-ui/src/hooks/useBlueprintValidation.jsx
@@ -90,7 +90,7 @@ function useBlueprintValidation({
   }, [])
 
   const validateRepositoryName = useCallback((projects = []) => {
-    const repoRegExp = /([a-z0-9_-]){2,}\/([a-z0-9_-]){2,}$/gi
+    const repoRegExp = /([a-z0-9_-]){2,}\/([.a-z0-9_-]){2,}$/gi
     return projects.every((p) => p.value.match(repoRegExp))
   }, [])
 


### PR DESCRIPTION
# Summary
fix pattern which matches repository name for the support repository name contains a dot

### Does this close any open issues?
Closes #3620 

### Screenshots
after patched:
![image](https://user-images.githubusercontent.com/183388/200452926-930974db-3b5b-4cbc-9026-16431dfb9486.png)

### Other Information
N/A
