### PR TITLE
fix(config-ui): the judgment condition is wrong to let the data scope is not displayed

### DIFF
--- a/config-ui/src/models/DataScopeConnection.js
+++ b/config-ui/src/models/DataScopeConnection.js
@@ -67,7 +67,7 @@ class DataScopeConnection {
   }
 
   hasScopeEntities() {
-    return this.scopeEntities > 0
+    return this.scopeEntities.length > 0
   }
 
   get(property) {


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

The judgment condition is wrong to let the data scope is not displayed.

### Does this close any open issues?
Closes #3696

### Screenshots

Before:
![screenshot-20221108-140342](https://user-images.githubusercontent.com/37237996/200492615-b905bec0-ae1b-4fa1-a5e5-00afdc480a08.png)

Fixed:
![WX20221108-143927@2x](https://user-images.githubusercontent.com/37237996/200492743-7bf490bb-9e69-4674-b651-216b055fbaac.png)

### Other Information
Nothing.
