### PR TITLE
feat: modify refs_commits_diffs table name and struct

### DIFF
--- a/helpers/migrationhelper/migrationhelper.go
+++ b/helpers/migrationhelper/migrationhelper.go
@@ -268,9 +268,7 @@ func CopyTableColumn[S any, D any](
 	dstTableName string,
 	transform func(*S) (*D, errors.Error),
 ) (err errors.Error) {
-
 	db := basicRes.GetDal()
-
 	cursor, err := db.Cursor(dal.From(srcTableName))
 	if err != nil {
 		return errors.Default.Wrap(err, fmt.Sprintf("failed to load data from src table [%s]", srcTableName))

--- a/helpers/migrationhelper/migrationhelper.go
+++ b/helpers/migrationhelper/migrationhelper.go
@@ -261,8 +261,8 @@ func TransformTable[S any, D any](
 	return err
 }
 
-// copy data from src table to dst table
-func CopyformTable(
+// Copy data from src table to dst table
+func CopyTableColumn(
 	basicRes core.BasicRes,
 	srcTable core.Tabler,
 	srcColumn []string,

--- a/helpers/migrationhelper/migrationhelper.go
+++ b/helpers/migrationhelper/migrationhelper.go
@@ -261,7 +261,7 @@ func TransformTable[S any, D any](
 	return err
 }
 
-// Copy data from src table to dst table
+// CopyTableColumn can copy data from src table to dst table
 func CopyTableColumn(
 	basicRes core.BasicRes,
 	srcTable core.Tabler,

--- a/models/migrationscripts/20221109_modfiy_commits_diffs.go
+++ b/models/migrationscripts/20221109_modfiy_commits_diffs.go
@@ -44,8 +44,8 @@ func (RefsCommitsDiff20221109) TableName() string {
 // updated format
 
 type CommitsStatus20221109 struct {
-	NewRefCommitSha string `gorm:"primaryKey;type:varchar(40)"`
-	OldRefCommitSha string `gorm:"primaryKey;type:varchar(40)"`
+	NewCommitSha string `gorm:"primaryKey;type:varchar(40)"`
+	OldCommitSha string `gorm:"primaryKey;type:varchar(40)"`
 }
 
 func (CommitsStatus20221109) TableName() string {
@@ -53,17 +53,17 @@ func (CommitsStatus20221109) TableName() string {
 }
 
 type CommitsDiff20221109Before struct {
-	CommitSha       string `gorm:"primaryKey;type:varchar(40)"`
-	NewRefCommitSha string `gorm:"type:varchar(40)"`
-	OldRefCommitSha string `gorm:"type:varchar(40)"`
-	SortingIndex    int
+	CommitSha    string `gorm:"primaryKey;type:varchar(40)"`
+	NewCommitSha string `gorm:"type:varchar(40)"`
+	OldCommitSha string `gorm:"type:varchar(40)"`
+	SortingIndex int
 }
 
 type CommitsDiff20221109After struct {
-	CommitSha       string `gorm:"primaryKey;type:varchar(40)"`
-	NewRefCommitSha string `gorm:"primaryKey;type:varchar(40)"`
-	OldRefCommitSha string `gorm:"primaryKey;type:varchar(40)"`
-	SortingIndex    int
+	CommitSha    string `gorm:"primaryKey;type:varchar(40)"`
+	NewCommitSha string `gorm:"primaryKey;type:varchar(40)"`
+	OldCommitSha string `gorm:"primaryKey;type:varchar(40)"`
+	SortingIndex int
 }
 
 func (script *modifyCommitsDiffs) Up(basicRes core.BasicRes) errors.Error {

--- a/models/migrationscripts/20221109_modfiy_commits_diffs.go
+++ b/models/migrationscripts/20221109_modfiy_commits_diffs.go
@@ -27,22 +27,6 @@ var _ core.MigrationScript = (*modifyCommitsDiffs)(nil)
 
 type modifyCommitsDiffs struct{}
 
-// initial format
-type RefsCommitsDiff20221109 struct {
-	NewRefId        string `gorm:"primaryKey;type:varchar(255)"`
-	OldRefId        string `gorm:"primaryKey;type:varchar(255)"`
-	CommitSha       string `gorm:"primaryKey;type:varchar(40)"`
-	NewRefCommitSha string `gorm:"type:varchar(40)"`
-	OldRefCommitSha string `gorm:"type:varchar(40)"`
-	SortingIndex    int
-}
-
-func (RefsCommitsDiff20221109) TableName() string {
-	return "refs_commits_diffs"
-}
-
-// updated format
-
 type CommitsStatus20221109 struct {
 	NewCommitSha string `gorm:"primaryKey;type:varchar(40)"`
 	OldCommitSha string `gorm:"primaryKey;type:varchar(40)"`

--- a/models/migrationscripts/20221109_modfiy_commits_diffs.go
+++ b/models/migrationscripts/20221109_modfiy_commits_diffs.go
@@ -77,7 +77,7 @@ func (script *modifyCommitsDiffs) Up(basicRes core.BasicRes) errors.Error {
 	dstColumn := []string{"CommitSha", "NewCommitSha", "OldCommitSha", "SortingIndex"}
 
 	// copy data
-	err = migrationhelper.CopyformTable(basicRes, &RefsCommitsDiff20221109{}, srcColumn, &CommitsDiff20221109{}, dstColumn)
+	err = migrationhelper.CopyTableColumn(basicRes, &RefsCommitsDiff20221109{}, srcColumn, &CommitsDiff20221109{}, dstColumn)
 	if err != nil {
 		return err
 	}

--- a/models/migrationscripts/20221109_modfiy_commits_diffs.go
+++ b/models/migrationscripts/20221109_modfiy_commits_diffs.go
@@ -1,0 +1,99 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"github.com/apache/incubator-devlake/errors"
+	"github.com/apache/incubator-devlake/helpers/migrationhelper"
+	"github.com/apache/incubator-devlake/plugins/core"
+)
+
+var _ core.MigrationScript = (*modifyCommitsDiffs)(nil)
+
+type modifyCommitsDiffs struct{}
+
+// initial format
+type RefsCommitsDiff20221109 struct {
+	NewRefId        string `gorm:"primaryKey;type:varchar(255)"`
+	OldRefId        string `gorm:"primaryKey;type:varchar(255)"`
+	CommitSha       string `gorm:"primaryKey;type:varchar(40)"`
+	NewRefCommitSha string `gorm:"type:varchar(40)"`
+	OldRefCommitSha string `gorm:"type:varchar(40)"`
+	SortingIndex    int
+}
+
+func (RefsCommitsDiff20221109) TableName() string {
+	return "refs_commits_diffs"
+}
+
+// updated format
+
+type CommitsStatus20221109 struct {
+	NewRefCommitSha string `gorm:"primaryKey;type:varchar(40)"`
+	OldRefCommitSha string `gorm:"primaryKey;type:varchar(40)"`
+}
+
+func (CommitsStatus20221109) TableName() string {
+	return "commits_diffs_status"
+}
+
+type CommitsDiff20221109Before struct {
+	CommitSha       string `gorm:"primaryKey;type:varchar(40)"`
+	NewRefCommitSha string `gorm:"type:varchar(40)"`
+	OldRefCommitSha string `gorm:"type:varchar(40)"`
+	SortingIndex    int
+}
+
+type CommitsDiff20221109After struct {
+	CommitSha       string `gorm:"primaryKey;type:varchar(40)"`
+	NewRefCommitSha string `gorm:"primaryKey;type:varchar(40)"`
+	OldRefCommitSha string `gorm:"primaryKey;type:varchar(40)"`
+	SortingIndex    int
+}
+
+func (script *modifyCommitsDiffs) Up(basicRes core.BasicRes) errors.Error {
+	db := basicRes.GetDal()
+	// rename table
+	err := db.RenameTable("refs_commits_diffs", "commits_diffs")
+	if err != nil {
+		return err
+	}
+	// copy data
+	err = migrationhelper.TransformTable(
+		basicRes,
+		script,
+		"commits_diffs",
+		func(c *CommitsDiff20221109Before) (*CommitsDiff20221109After, errors.Error) {
+			dst := CommitsDiff20221109After(*c)
+			return &dst, nil
+		},
+	)
+	if err != nil {
+		return err
+	}
+	// add new table: refs_commits_status
+	return db.AutoMigrate(&CommitsStatus20221109{})
+}
+
+func (*modifyCommitsDiffs) Version() uint64 {
+	return 20221109232735
+}
+
+func (*modifyCommitsDiffs) Name() string {
+	return "modify commits diffs"
+}

--- a/models/migrationscripts/20221109_modfiy_commits_diffs.go
+++ b/models/migrationscripts/20221109_modfiy_commits_diffs.go
@@ -73,11 +73,20 @@ func (script *modifyCommitsDiffs) Up(basicRes core.BasicRes) errors.Error {
 		return err
 	}
 
-	srcColumn := []string{"CommitSha", "NewRefCommitSha", "OldRefCommitSha", "SortingIndex"}
-	dstColumn := []string{"CommitSha", "NewCommitSha", "OldCommitSha", "SortingIndex"}
-
 	// copy data
-	err = migrationhelper.CopyTableColumn(basicRes, &RefsCommitsDiff20221109{}, srcColumn, &CommitsDiff20221109{}, dstColumn)
+	err = migrationhelper.CopyTableColumn(
+		basicRes,
+		RefsCommitsDiff20221109{}.TableName(),
+		CommitsDiff20221109{}.TableName(),
+		func(s *RefsCommitsDiff20221109) (*CommitsDiff20221109, errors.Error) {
+			dst := CommitsDiff20221109{}
+			dst.CommitSha = s.CommitSha
+			dst.NewCommitSha = s.NewRefCommitSha
+			dst.OldCommitSha = s.OldRefCommitSha
+
+			return &dst, nil
+		},
+	)
 	if err != nil {
 		return err
 	}

--- a/models/migrationscripts/register.go
+++ b/models/migrationscripts/register.go
@@ -54,5 +54,6 @@ func All() []core.MigrationScript {
 		new(createCollectorState),
 		new(removeCicdPipelineRelation),
 		new(addCicdScope),
+		new(modifyCommitsDiffs),
 	}
 }


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [ ] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.



# Summary
In order to increase the scalability of commits diffs, now the refs_commits_diffs table needs to modify.
1. rename refs_commits_diffs to commits_diffs.
2. upgrade the  commits_diffs struct.
3. add commits_diffs_status table.

### Does this close any open issues?
related to #3685 

### Screenshots
The new tables show:
![image](https://user-images.githubusercontent.com/101256042/200739166-869b6cd7-3779-4565-b9dd-527620748487.png)

copy data result:
pre:
![image](https://user-images.githubusercontent.com/101256042/201055863-f2e5c771-edcd-4a67-b3c7-0fe2e5087925.png)

now:
![image](https://user-images.githubusercontent.com/101256042/201056488-59f2d736-ccef-4921-bd4b-de154d7f3a79.png)




### Other Information
This is just a migration script, the model will be processed in the next pr
