### PR TITLE
fix(framework): simplify the migration scripts

### DIFF
--- a/models/migrationscripts/20220904_encrypt_pipeline.go
+++ b/models/migrationscripts/20220904_encrypt_pipeline.go
@@ -19,95 +19,71 @@ package migrationscripts
 
 import (
 	"context"
+	"github.com/apache/incubator-devlake/models/migrationscripts/archived"
+
 	"github.com/apache/incubator-devlake/config"
 	"github.com/apache/incubator-devlake/plugins/core"
-	"time"
 
 	"github.com/apache/incubator-devlake/errors"
-	"github.com/apache/incubator-devlake/models/common"
-	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
 
-type Pipeline0904TempBefore struct {
-	NewPlan string
-}
-
-func (Pipeline0904TempBefore) TableName() string {
-	return "_devlake_pipelines"
-}
-
-type Pipeline0904Temp struct {
-	common.Model
-	Name          string     `json:"name" gorm:"index"`
-	BlueprintId   uint64     `json:"blueprintId"`
-	NewPlan       string     `json:"plan" encrypt:"yes"`
-	TotalTasks    int        `json:"totalTasks"`
-	FinishedTasks int        `json:"finishedTasks"`
-	BeganAt       *time.Time `json:"beganAt"`
-	FinishedAt    *time.Time `json:"finishedAt" gorm:"index"`
-	Status        string     `json:"status"`
-	Message       string     `json:"message"`
-	SpentSeconds  int        `json:"spentSeconds"`
-	Stage         int        `json:"stage"`
-	Plan          datatypes.JSON
-}
-
-func (Pipeline0904Temp) TableName() string {
-	return "_devlake_pipelines"
-}
-
-type Pipeline0904TempAfter struct {
-	NewPlan string
+type PipelineEncryption0904 struct {
+	archived.Model
 	Plan    string
+	RawPlan string
 }
 
-func (Pipeline0904TempAfter) TableName() string {
+func (PipelineEncryption0904) TableName() string {
 	return "_devlake_pipelines"
 }
 
 type encryptPipeline struct{}
 
 func (*encryptPipeline) Up(ctx context.Context, db *gorm.DB) errors.Error {
-	err := db.AutoMigrate(&Pipeline0904TempBefore{})
+	c := config.GetConfig()
+	encKey := c.GetString(core.EncodeKeyEnvStr)
+	if encKey == "" {
+		return errors.BadInput.New("invalid encKey")
+	}
+
+	pipeline := &PipelineEncryption0904{}
+	err := db.Migrator().RenameColumn(pipeline, "plan", "raw_plan")
 	if err != nil {
 		return errors.Convert(err)
 	}
-	var result *gorm.DB
-	var pipelineList []Pipeline0904Temp
-	result = db.Find(&pipelineList)
-
-	if result.Error != nil {
-		return errors.Convert(result.Error)
+	err = db.AutoMigrate(pipeline)
+	if err != nil {
+		return errors.Convert(err)
 	}
 
-	// Encrypt all pipelines.plan&settings which had been stored before v0.14
-	for _, v := range pipelineList {
-		c := config.GetConfig()
-		encKey := c.GetString(core.EncodeKeyEnvStr)
-		if encKey == "" {
-			return errors.BadInput.New("invalid encKey")
-		}
-		v.NewPlan, err = core.Encrypt(encKey, string(v.Plan))
+	// Encrypt all pipelines.plan which had been stored before v0.14
+	cursor, err := db.Model(pipeline).Rows()
+	if err != nil {
+		return errors.Convert(err)
+	}
+	defer cursor.Close()
+
+	for cursor.Next() {
+		err = db.ScanRows(cursor, pipeline)
 		if err != nil {
 			return errors.Convert(err)
 		}
-
-		err = errors.Convert(db.Save(&v).Error)
+		pipeline.Plan, err = core.Encrypt(encKey, pipeline.RawPlan)
+		if err != nil {
+			return errors.Convert(err)
+		}
+		err = errors.Convert(db.Save(pipeline).Error)
 		if err != nil {
 			return errors.Convert(err)
 		}
 	}
 
-	err = db.Migrator().DropColumn(&Pipeline0904Temp{}, "plan")
+	err = db.Migrator().DropColumn(pipeline, "raw_plan")
 	if err != nil {
 		return errors.Convert(err)
 	}
-	err = db.Migrator().RenameColumn(&Pipeline0904TempAfter{}, "new_plan", "plan")
-	if err != nil {
-		return errors.Convert(err)
-	}
-	_ = db.Find(&pipelineList)
+	_ = db.First(pipeline)
 	return nil
 }
 


### PR DESCRIPTION
# Summary

In pr: https://github.com/apache/incubator-devlake/pull/3712, we fixed bugs, but because it's an urgent fix, the way we fixed the bug is quite complicated(another reason is less familiar with PostgreSQL). 
In this pr, we found a new way to simplify the migration script that changed in pr #3712 , and tested through the following steps:
1. deploy devlake  v0.12 by docker-compose
2. created several blueprints and pipelines
3. shutdown v0.12 devlake
4. deploy new code 
5. check blueprints and pipelines through config-ui

### Does this close any open issues?
Relates to https://github.com/apache/incubator-devlake/issues/3537

### Screenshots
![image](https://user-images.githubusercontent.com/39366025/201520969-7e3025c7-b28e-40d8-82d8-3b31662a573c.png)

### Other Information
Any other information that is important to this PR.
