### PR TITLE
feat: add "enable graphql" in config-ui

### DIFF
--- a/config-ui/src/components/blueprints/ConnectionDialog.jsx
+++ b/config-ui/src/components/blueprints/ConnectionDialog.jsx
@@ -53,6 +53,7 @@ const ConnectionDialog = (props) => {
     endpointUrl,
     proxy,
     rateLimitPerHour = 0,
+    enableGraphql = true,
     token,
     initialTokenStore = {},
     username,
@@ -77,6 +78,7 @@ const ConnectionDialog = (props) => {
     onEndpointChange = () => {},
     onProxyChange = () => {},
     onRateLimitChange = () => {},
+    onEnableGraphqlChange = () => {},
     onTokenChange = () => {},
     onUsernameChange = () => {},
     onPasswordChange = () => {},
@@ -250,6 +252,7 @@ const ConnectionDialog = (props) => {
                     endpointUrl={endpointUrl}
                     proxy={proxy}
                     rateLimitPerHour={rateLimitPerHour}
+                    enableGraphql={enableGraphql}
                     token={token}
                     initialTokenStore={initialTokenStore}
                     username={username}
@@ -262,6 +265,7 @@ const ConnectionDialog = (props) => {
                     onEndpointChange={onEndpointChange}
                     onProxyChange={onProxyChange}
                     onRateLimitChange={onRateLimitChange}
+                    onEnableGraphqlChange={onEnableGraphqlChange}
                     onTokenChange={onTokenChange}
                     onUsernameChange={onUsernameChange}
                     onPasswordChange={onPasswordChange}

--- a/config-ui/src/components/pipelines/StageTaskName.jsx
+++ b/config-ui/src/components/pipelines/StageTaskName.jsx
@@ -65,7 +65,7 @@ const StageTaskName = (props) => {
           {ProviderLabels[task?.plugin?.toUpperCase()] ||
             task?.plugin?.toUpperCase()}{' '}
           {(task.plugin === Providers.GITHUB ||
-            task.plugin === 'github_graphql') && (
+            task.plugin === Providers.GITHUB_GRAPHQL) && (
             <>
               @{task.options.owner}/{task.options.repo}
             </>

--- a/config-ui/src/components/pipelines/StageTaskName.jsx
+++ b/config-ui/src/components/pipelines/StageTaskName.jsx
@@ -61,14 +61,16 @@ const StageTaskName = (props) => {
           ref={popoverTriggerRef}
           style={{ display: 'block', margin: '5px 0 5px 0' }}
         >
-          <strong>Task ID {task.id}</strong>{' '}
-          {ProviderLabels[task?.plugin?.toUpperCase()]}{' '}
-          {task.plugin === Providers.GITHUB &&
-            task.plugin !== Providers.JENKINS && (
-              <>
-                @{task.options.owner}/{task.options.repo}
-              </>
-            )}
+          <strong>Task#{task.id}</strong>{' '}
+          {ProviderLabels[task?.plugin?.toUpperCase()] ||
+            task?.plugin?.toUpperCase()}{' '}
+          {(task.plugin === Providers.GITHUB ||
+            task.plugin === 'github_graphql') && (
+            <>
+              @{task.options.owner}/{task.options.repo}
+            </>
+          )}
+          {task.plugin === Providers.JENKINS && <>@{task.options.jobName}</>}
           {task.plugin === Providers.JIRA && (
             <>Board ID {task.options.boardId}</>
           )}

--- a/config-ui/src/hooks/useConnectionManager.jsx
+++ b/config-ui/src/hooks/useConnectionManager.jsx
@@ -54,6 +54,7 @@ function useConnectionManager(
   const [initialTokenStore, setInitialTokenStore] = useState(defaultTokenStore)
   const [username, setUsername] = useState()
   const [password, setPassword] = useState()
+  const [enableGraphql, setEnableGraphql] = useState(true)
 
   const [isSaving, setIsSaving] = useState(false)
   const [isFetching, setIsFetching] = useState(false)
@@ -102,9 +103,19 @@ function useConnectionManager(
       password,
       token,
       proxy,
-      rateLimitPerHour
+      rateLimitPerHour,
+      enableGraphql
     }),
-    [name, endpointUrl, username, password, token, proxy, rateLimitPerHour]
+    [
+      name,
+      endpointUrl,
+      username,
+      password,
+      token,
+      proxy,
+      rateLimitPerHour,
+      enableGraphql
+    ]
   )
 
   const testConnection = useCallback(
@@ -539,6 +550,7 @@ function useConnectionManager(
       setName(activeConnection?.name)
       setEndpointUrl(activeConnection?.endpoint)
       setRateLimitPerHour(activeConnection?.rateLimitPerHour)
+      setEnableGraphql(activeConnection?.enableGraphql)
       setProxy(activeConnection?.proxy)
       setUsername(activeConnection?.username)
       setPassword(activeConnection?.password)
@@ -656,6 +668,7 @@ function useConnectionManager(
     endpointUrl,
     proxy,
     rateLimitPerHour,
+    enableGraphql,
     username,
     password,
     token,
@@ -667,6 +680,7 @@ function useConnectionManager(
     setEndpointUrl,
     setProxy,
     setRateLimitPerHour,
+    setEnableGraphql,
     setToken,
     setInitialTokenStore,
     setUsername,

--- a/config-ui/src/hooks/useIntegrations.jsx
+++ b/config-ui/src/hooks/useIntegrations.jsx
@@ -23,6 +23,7 @@ import Plugin from '@/models/Plugin'
 // "integration" Plugins a.k.a "Providers"
 import JiraPlugin from '@/registry/plugins/jira.json'
 import GitHubPlugin from '@/registry/plugins/github.json'
+import GitHubGraphqlPlugin from '@/registry/plugins/github_graphql.json'
 import GitLabPlugin from '@/registry/plugins/gitlab.json'
 import JenkinsPlugin from '@/registry/plugins/jenkins.json'
 import TapdPlugin from '@/registry/plugins/tapd.json'
@@ -46,6 +47,7 @@ function useIntegrations(
   pluginRegistry = [
     JiraPlugin,
     GitHubPlugin,
+    GitHubGraphqlPlugin,
     GitLabPlugin,
     JenkinsPlugin,
     TapdPlugin,

--- a/config-ui/src/models/Connection.js
+++ b/config-ui/src/models/Connection.js
@@ -55,6 +55,7 @@ class Connection {
     this.username = data?.username || ''
     this.password = data?.password || ''
     this.rateLimitPerHour = data?.rateLimitPerHour || 0
+    this.enableGraphql = data?.enableGraphql || false
     this.createdAt = data?.createdAt || null
     this.updatedAt = data?.updatedAt || null
 

--- a/config-ui/src/pages/configure/connections/AddConnection.jsx
+++ b/config-ui/src/pages/configure/connections/AddConnection.jsx
@@ -75,6 +75,7 @@ export default function AddConnection() {
     endpointUrl,
     proxy,
     rateLimitPerHour,
+    enableGraphql,
     token,
     initialTokenStore,
     username,
@@ -83,6 +84,7 @@ export default function AddConnection() {
     setEndpointUrl,
     setProxy,
     setRateLimitPerHour,
+    setEnableGraphql,
     setUsername,
     setPassword,
     setToken,
@@ -208,6 +210,7 @@ export default function AddConnection() {
                   endpointUrl={endpointUrl}
                   proxy={proxy}
                   rateLimitPerHour={rateLimitPerHour}
+                  enableGraphql={enableGraphql}
                   token={token}
                   initialTokenStore={initialTokenStore}
                   username={username}
@@ -220,6 +223,7 @@ export default function AddConnection() {
                   onEndpointChange={setEndpointUrl}
                   onProxyChange={setProxy}
                   onRateLimitChange={setRateLimitPerHour}
+                  onEnableGraphqlChange={setEnableGraphql}
                   onTokenChange={setToken}
                   onUsernameChange={setUsername}
                   onPasswordChange={setPassword}

--- a/config-ui/src/pages/configure/connections/ConfigureConnection.jsx
+++ b/config-ui/src/pages/configure/connections/ConfigureConnection.jsx
@@ -69,6 +69,7 @@ export default function ConfigureConnection() {
     endpointUrl,
     proxy,
     rateLimitPerHour = 0,
+    enableGraphql,
     username,
     password,
     token,
@@ -84,6 +85,7 @@ export default function ConfigureConnection() {
     setEndpointUrl,
     setProxy,
     setRateLimitPerHour,
+    setEnableGraphql,
     setUsername,
     setPassword,
     setToken,
@@ -326,6 +328,7 @@ export default function ConfigureConnection() {
                           endpointUrl={endpointUrl}
                           proxy={proxy}
                           rateLimitPerHour={rateLimitPerHour}
+                          enableGraphql={enableGraphql}
                           token={token}
                           initialTokenStore={initialTokenStore}
                           username={username}
@@ -338,6 +341,7 @@ export default function ConfigureConnection() {
                           onEndpointChange={setEndpointUrl}
                           onProxyChange={setProxy}
                           onRateLimitChange={setRateLimitPerHour}
+                          onEnableGraphqlChange={setEnableGraphql}
                           onTokenChange={setToken}
                           onUsernameChange={setUsername}
                           onPasswordChange={setPassword}

--- a/config-ui/src/pages/configure/connections/ConnectionForm.jsx
+++ b/config-ui/src/pages/configure/connections/ConnectionForm.jsx
@@ -84,6 +84,7 @@ export default function ConnectionForm(props) {
     password,
     proxy = '',
     rateLimitPerHour = 0,
+    enableGraphql = true,
     isSaving,
     isTesting,
     showError,
@@ -101,6 +102,7 @@ export default function ConnectionForm(props) {
     onPasswordChange = () => {},
     onProxyChange = () => {},
     onRateLimitChange = () => {},
+    onEnableGraphqlChange = () => {},
     onValidate = () => {},
     authType = 'token',
     sourceLimits = {},
@@ -807,108 +809,152 @@ export default function ConnectionForm(props) {
           Providers.BITBUCKET,
           Providers.GITEE
         ].includes(activeProvider?.id) && (
-          <>
-            <div className='formContainer'>
-              <FormGroup
+          <div className='formContainer'>
+            <FormGroup
+              disabled={isTesting || isSaving || isLocked}
+              inline={true}
+              labelFor='connection-proxy'
+              className={formGroupClassName}
+              contentClassName='formGroupContent'
+            >
+              <Label>{labels ? labels.proxy : <>Proxy&nbsp;URL</>}</Label>
+              <InputGroup
+                id='connection-proxy'
+                inputRef={connectionProxyRef}
+                tabIndex={3}
+                placeholder={
+                  placeholders.proxy
+                    ? placeholders.proxy
+                    : 'http://proxy.localhost:8080'
+                }
+                defaultValue={proxy}
+                onChange={(e) => onProxyChange(e.target.value)}
                 disabled={isTesting || isSaving || isLocked}
-                inline={true}
-                labelFor='connection-proxy'
-                className={formGroupClassName}
-                contentClassName='formGroupContent'
+                className={`input input-proxy ${
+                  fieldHasError('Proxy') ? 'invalid-field' : ''
+                }`}
+                rightElement={
+                  <InputValidationError error={getFieldError('Proxy')} />
+                }
+              />
+            </FormGroup>
+          </div>
+        )}
+        {[Providers.GITHUB].includes(activeProvider?.id) && (
+          <div className='formContainer'>
+            <FormGroup
+              disabled={isTesting || isSaving || isLocked}
+              inline={true}
+              labelFor='connection-ratelimit'
+              className={formGroupClassName}
+              contentClassName='formGroupContent'
+            >
+              <Label>
+                {labels?.enableGraphql || <>Use Graphql APIs</>}
+                {tooltips?.enableGraphql ? (
+                  <Tooltip
+                    className='connection-tooltip'
+                    intent={Intent.PRIMARY}
+                    content={tooltips?.enableGraphql}
+                  >
+                    <TooltipIcon />
+                  </Tooltip>
+                ) : null}
+              </Label>
+              <div
+                className='ratelimit-options'
+                style={{ display: 'flex', float: 'left' }}
               >
-                <Label>{labels ? labels.proxy : <>Proxy&nbsp;URL</>}</Label>
-                <InputGroup
-                  id='connection-proxy'
-                  inputRef={connectionProxyRef}
-                  tabIndex={3}
-                  placeholder={
-                    placeholders.proxy
-                      ? placeholders.proxy
-                      : 'http://proxy.localhost:8080'
-                  }
-                  defaultValue={proxy}
-                  onChange={(e) => onProxyChange(e.target.value)}
-                  disabled={isTesting || isSaving || isLocked}
-                  className={`input input-proxy ${
-                    fieldHasError('Proxy') ? 'invalid-field' : ''
-                  }`}
-                  rightElement={
-                    <InputValidationError error={getFieldError('Proxy')} />
-                  }
+                <Switch
+                  checked={enableGraphql}
+                  label={enableGraphql ? 'Enabled' : 'Disabled'}
+                  onChange={() => onEnableGraphqlChange(!enableGraphql)}
+                  style={{ marginBottom: '0' }}
                 />
-              </FormGroup>
-            </div>
-            <div className='formContainer'>
-              <FormGroup
-                disabled={isTesting || isSaving || isLocked}
-                inline={true}
-                labelFor='connection-ratelimit'
-                className={formGroupClassName}
-                contentClassName='formGroupContent'
+              </div>
+            </FormGroup>
+          </div>
+        )}
+        {[
+          Providers.GITHUB,
+          Providers.GITLAB,
+          Providers.JIRA,
+          Providers.JENKINS,
+          Providers.TAPD,
+          Providers.AZURE,
+          Providers.BITBUCKET,
+          Providers.GITEE
+        ].includes(activeProvider?.id) && (
+          <div className='formContainer'>
+            <FormGroup
+              disabled={isTesting || isSaving || isLocked}
+              inline={true}
+              labelFor='connection-ratelimit'
+              className={formGroupClassName}
+              contentClassName='formGroupContent'
+            >
+              <Label>
+                {labels ? labels.rateLimitPerHour : <>Rate&nbsp;Limit</>}
+                {tooltips?.rateLimitPerHour ? (
+                  <Tooltip
+                    className='connection-tooltip'
+                    intent={Intent.PRIMARY}
+                    content={tooltips?.rateLimitPerHour}
+                  >
+                    <TooltipIcon />
+                  </Tooltip>
+                ) : null}
+              </Label>
+              <div
+                className='ratelimit-options'
+                style={{ display: 'flex', float: 'left' }}
               >
-                <Label>
-                  {labels ? labels.rateLimitPerHour : <>Rate&nbsp;Limit</>}
-                  {tooltips?.rateLimitPerHour ? (
-                    <Tooltip
-                      className='connection-tooltip'
-                      intent={Intent.PRIMARY}
-                      content={tooltips?.rateLimitPerHour}
-                    >
-                      <TooltipIcon />
-                    </Tooltip>
-                  ) : null}
-                </Label>
-                <div
-                  className='ratelimit-options'
-                  style={{ display: 'flex', float: 'left' }}
-                >
-                  {enableRateLimit && (
-                    <div style={{ marginRight: '10px' }}>
-                      <NumericInput
-                        id='connection-ratelimit'
-                        ref={connectionRateLimitRef}
-                        disabled={isTesting || isSaving || isLocked}
-                        min={0}
-                        max={1000000000}
-                        clampValueOnBlur={true}
-                        className={`input input-ratelimit ${
-                          fieldHasError('RateLimit') ? 'invalid-field' : ''
-                        }`}
-                        fill={false}
-                        placeholder={
-                          placeholders.rateLimitPerHour
-                            ? placeholders.rateLimitPerHour
-                            : '1000'
-                        }
-                        allowNumericCharactersOnly={true}
-                        onValueChange={(rateLimitPerHour) => {
-                          onRateLimitChange(rateLimitPerHour)
-                        }}
-                        value={rateLimitPerHour}
-                        rightElement={
-                          <InputValidationError
-                            error={getFieldError('RateLimit')}
-                          />
-                        }
-                      />
-                    </div>
-                  )}
-                  <Switch
-                    checked={enableRateLimit}
-                    label={
-                      enableRateLimit ? (
-                        <>Enabled &mdash; {rateLimitPerHour} Requests/hr</>
-                      ) : (
-                        'Disabled'
-                      )
-                    }
-                    onChange={() => setEnableRateLimit(!enableRateLimit)}
-                    style={{ marginBottom: '0' }}
-                  />
-                </div>
-              </FormGroup>
-            </div>
-          </>
+                {enableRateLimit && (
+                  <div style={{ marginRight: '10px' }}>
+                    <NumericInput
+                      id='connection-ratelimit'
+                      ref={connectionRateLimitRef}
+                      disabled={isTesting || isSaving || isLocked}
+                      min={0}
+                      max={1000000000}
+                      clampValueOnBlur={true}
+                      className={`input input-ratelimit ${
+                        fieldHasError('RateLimit') ? 'invalid-field' : ''
+                      }`}
+                      fill={false}
+                      placeholder={
+                        placeholders.rateLimitPerHour
+                          ? placeholders.rateLimitPerHour
+                          : '1000'
+                      }
+                      allowNumericCharactersOnly={true}
+                      onValueChange={(rateLimitPerHour) => {
+                        onRateLimitChange(rateLimitPerHour)
+                      }}
+                      value={rateLimitPerHour}
+                      rightElement={
+                        <InputValidationError
+                          error={getFieldError('RateLimit')}
+                        />
+                      }
+                    />
+                  </div>
+                )}
+                <Switch
+                  checked={enableRateLimit}
+                  label={
+                    enableRateLimit ? (
+                      <>Enabled &mdash; {rateLimitPerHour} Requests/hr</>
+                    ) : (
+                      'Disabled'
+                    )
+                  }
+                  onChange={() => setEnableRateLimit(!enableRateLimit)}
+                  style={{ marginBottom: '0' }}
+                />
+              </div>
+            </FormGroup>
+          </div>
         )}
         {enableActions && (
           <div

--- a/config-ui/src/registry/plugins/github.json
+++ b/config-ui/src/registry/plugins/github.json
@@ -34,7 +34,8 @@
     },
     "tooltips": {
       "token": "Due to Github's rate limit, input more tokens, \ncomma separated, to accelerate data collection.",
-      "rateLimitPerHour": "Rate Limit requests per hour,\nEnter a numeric value > 0 to enable."
+      "rateLimitPerHour": "Rate Limit requests per hour,\nEnter a numeric value > 0 to enable.",
+      "enableGraphql": "GraphQL APIs are 10+ times faster than REST APIs, but it may not be supported in GitHub on-premise versions.  "
     }
  },
  "availableDataDomains": ["CODE", "TICKET", "CODEREVIEW", "CROSS", "CICD"],

--- a/config-ui/src/registry/plugins/github_graphql.json
+++ b/config-ui/src/registry/plugins/github_graphql.json
@@ -1,0 +1,12 @@
+{
+  "id": "github_graphql",
+  "name": "GitHubGraphql",
+  "type": "pipeline",
+  "enabled": true,
+  "multiConnection": true,
+  "connectionLimit": 0,
+  "isBeta": false,
+  "isProvider": true,
+  "icon": "src/images/integrations/github.svg",
+  "private": false
+}

--- a/plugins/github/api/blueprint.go
+++ b/plugins/github/api/blueprint.go
@@ -137,7 +137,7 @@ func makePipelinePlan(subtaskMetas []core.SubTaskMeta, scope []*core.BlueprintSc
 					Options:  options,
 				})
 			} else {
-				return nil, errors.Default.New("plugin github_graphql does not support SubTaskMetas")
+				return nil, errors.BadInput.New("plugin github_graphql does not support SubTaskMetas")
 			}
 		} else {
 			subtasks, err := helper.MakePipelinePlanSubtasks(subtaskMetas, scopeElem.Entities)

--- a/plugins/github/models/connection.go
+++ b/plugins/github/models/connection.go
@@ -30,6 +30,7 @@ type TestConnectionRequest struct {
 type GithubConnection struct {
 	helper.RestConnection `mapstructure:",squash"`
 	helper.AccessToken    `mapstructure:",squash"`
+	EnableGraphql         bool `mapstructure:"enableGraphql" json:"enableGraphql"`
 }
 
 type TransformationRules struct {

--- a/plugins/github/models/migrationscripts/20221114_add_enable_graphql_for_connection.go
+++ b/plugins/github/models/migrationscripts/20221114_add_enable_graphql_for_connection.go
@@ -1,0 +1,60 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"github.com/apache/incubator-devlake/errors"
+	"github.com/apache/incubator-devlake/plugins/core"
+	"github.com/apache/incubator-devlake/plugins/core/dal"
+)
+
+type GithubConnection20221111 struct {
+	EnableGraphql bool
+}
+
+func (GithubConnection20221111) TableName() string {
+	return "_tool_github_connections"
+}
+
+type addEnableGraphqlForConnection struct{}
+
+func (*addEnableGraphqlForConnection) Up(res core.BasicRes) errors.Error {
+	db := res.GetDal()
+	err := db.AutoMigrate(&GithubConnection20221111{})
+	if err != nil {
+		return err
+	}
+	err = db.UpdateColumn(
+		&GithubConnection20221111{},
+		`enable_graphql`,
+		dal.DalClause{Expr: `(endpoint = 'https://api.github.com/')`},
+		dal.Where(`true`),
+	)
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+func (*addEnableGraphqlForConnection) Version() uint64 {
+	return 20221111000008
+}
+
+func (*addEnableGraphqlForConnection) Name() string {
+	return "UpdateSchemas for addEnableGraphqlForConnection"
+}

--- a/plugins/github/models/migrationscripts/register.go
+++ b/plugins/github/models/migrationscripts/register.go
@@ -30,5 +30,6 @@ func All() []core.MigrationScript {
 		new(addGithubPipelineTable),
 		new(deleteGithubPipelineTable),
 		new(addHeadRepoIdFieldInGithubPr),
+		new(addEnableGraphqlForConnection),
 	}
 }

--- a/plugins/github_graphql/tasks/account_collector.go
+++ b/plugins/github_graphql/tasks/account_collector.go
@@ -61,6 +61,7 @@ var CollectAccountMeta = core.SubTaskMeta{
 	EntryPoint:       CollectAccount,
 	EnabledByDefault: true,
 	Description:      "Collect Account data from GithubGraphql api",
+	DomainTypes:      []string{core.DOMAIN_TYPE_CROSS},
 }
 
 type SimpleAccount struct {

--- a/plugins/github_graphql/tasks/check_run_collector.go
+++ b/plugins/github_graphql/tasks/check_run_collector.go
@@ -89,6 +89,7 @@ var CollectCheckRunMeta = core.SubTaskMeta{
 	EntryPoint:       CollectCheckRun,
 	EnabledByDefault: true,
 	Description:      "Collect CheckRun data from GithubGraphql api",
+	DomainTypes:      []string{core.DOMAIN_TYPE_CICD},
 }
 
 var _ core.SubTaskEntryPoint = CollectAccount

--- a/plugins/github_graphql/tasks/issue_collector.go
+++ b/plugins/github_graphql/tasks/issue_collector.go
@@ -77,6 +77,7 @@ var CollectIssueMeta = core.SubTaskMeta{
 	EntryPoint:       CollectIssue,
 	EnabledByDefault: true,
 	Description:      "Collect Issue data from GithubGraphql api",
+	DomainTypes:      []string{core.DOMAIN_TYPE_TICKET},
 }
 
 var _ core.SubTaskEntryPoint = CollectIssue

--- a/plugins/github_graphql/tasks/pr_collector.go
+++ b/plugins/github_graphql/tasks/pr_collector.go
@@ -118,6 +118,7 @@ var CollectPrMeta = core.SubTaskMeta{
 	EntryPoint:       CollectPr,
 	EnabledByDefault: true,
 	Description:      "Collect Pr data from GithubGraphql api",
+	DomainTypes:      []string{core.DOMAIN_TYPE_CODE_REVIEW},
 }
 
 var _ core.SubTaskEntryPoint = CollectPr

--- a/plugins/github_graphql/tasks/repo_collector.go
+++ b/plugins/github_graphql/tasks/repo_collector.go
@@ -60,6 +60,7 @@ var CollectRepoMeta = core.SubTaskMeta{
 	EntryPoint:       CollectRepo,
 	EnabledByDefault: true,
 	Description:      "Collect Repo data from GithubGraphql api",
+	DomainTypes:      []string{core.DOMAIN_TYPE_CODE},
 }
 
 func CollectRepo(taskCtx core.SubTaskContext) errors.Error {


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->
1. add enableGraphql in config-ui
2. display repo name for github graphql
3. add domain_entity for github graphql

I add a column for github connection `enable_graphql`. `Github.makePipelinePlan` will return github_graphql or github by enable_graphql.

### Does this close any open issues?
Closes #3528
Related #3529

### Screenshots

![image](https://user-images.githubusercontent.com/3294100/201596776-5b34e73a-cea7-45d8-8112-4c83149e09ea.png)
![image](https://user-images.githubusercontent.com/3294100/201596877-ade85ca4-e388-42cc-a8c6-84c1cbb13566.png)
