### PR TITLE
fix(framework): modify table name for migrationscript

### DIFF
--- a/models/migrationscripts/20220913_fix_commitfile_id_toolong.go
+++ b/models/migrationscripts/20220913_fix_commitfile_id_toolong.go
@@ -77,7 +77,7 @@ func (script *fixCommitFileIdTooLong) Up(basicRes core.BasicRes) errors.Error {
 	return migrationhelper.TransformTable(
 		basicRes,
 		script,
-		"commit_files",
+		"commit_file_components",
 		func(s *commitFileComponent20220913) (*commitFileComponent20220913, errors.Error) {
 			// copy data
 			dst := commitFileComponent20220913(*s)


### PR DESCRIPTION
# Summary

According to #3718 , we only made a small change:
`commit_files` to `commit_file_components`

### Does this close any open issues?
Closes #3718 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
