### PR TITLE
Don't check network connection when service is behind a proxy

### DIFF
--- a/plugins/helper/api_client.go
+++ b/plugins/helper/api_client.go
@@ -84,10 +84,13 @@ func NewApiClient(
 	if err != nil {
 		return nil, errors.Default.New("Failed to resolve Port")
 	}
-	err = utils.CheckNetwork(parsedUrl.Hostname(), port, 10*time.Second)
-	if err != nil {
-		return nil, errors.Default.Wrap(err, "Failed to connect")
-	}
+
+    if proxy != "" {
+        err = utils.CheckNetwork(parsedUrl.Hostname(), port, 10*time.Second)
+        if err != nil {
+            return nil, errors.Default.Wrap(err, "Failed to connect")
+        }
+    }
 	apiClient := &ApiClient{}
 	apiClient.Setup(
 		endpoint,

--- a/plugins/helper/api_client.go
+++ b/plugins/helper/api_client.go
@@ -85,7 +85,7 @@ func NewApiClient(
 		return nil, errors.Default.New("Failed to resolve Port")
 	}
 
-    if proxy != "" {
+    if proxy == "" {
         err = utils.CheckNetwork(parsedUrl.Hostname(), port, 10*time.Second)
         if err != nil {
             return nil, errors.Default.Wrap(err, "Failed to connect")
@@ -110,6 +110,16 @@ func NewApiClient(
 	}
 
 	if proxy != "" {
+        var pu, err := url.Parse(proxy)
+        if err != nil {
+            return nil, errors.BadInput.Wrap(err, fmt.Sprintf("Invalid Proxy URL: %s", proxy))
+        }
+
+        err = utils.CheckNetwork(pu.Hostname(), port, 10*time.Second)
+        if err != nil {
+            return nil, errors.Default.Wrap(err, "Failed to connect to proxy")
+        }
+
 		err = apiClient.SetProxy(proxy)
 		if err != nil {
 			return nil, errors.Convert(err)


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [ ] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
Currently the NewApiClient function errors if the service is behind a proxy since it cannot establish a direct connection.
Instead skip the network test when a proxy is configured.

