### PR TITLE
Issues/3234 add parallelLabels for blueprint/pipeline

### DIFF
--- a/api/blueprints/blueprints.go
+++ b/api/blueprints/blueprints.go
@@ -67,7 +67,7 @@ func Post(c *gin.Context) {
 // @Param is_manual query bool false "is_manual"
 // @Param page query int false "page"
 // @Param page_size query int false "page_size"
-// @Param parallel_label query string false "parallel_label"
+// @Param label query string false "label"
 // @Success 200  {object} PaginatedBlueprint
 // @Failure 400  {object} shared.ApiBody "Bad Request"
 // @Failure 500  {object} shared.ApiBody "Internal Error"

--- a/api/blueprints/blueprints.go
+++ b/api/blueprints/blueprints.go
@@ -29,8 +29,8 @@ import (
 )
 
 type PaginatedBlueprint struct {
-	Blueprints []*models.Blueprint
-	Count      int64
+	Blueprints []*models.Blueprint `json:"blueprints"`
+	Count      int64               `json:"count"`
 }
 
 // @Summary post blueprints
@@ -63,7 +63,11 @@ func Post(c *gin.Context) {
 // @Summary get blueprints
 // @Description get blueprints
 // @Tags framework/blueprints
-// @Accept application/json
+// @Param enable query bool false "enable"
+// @Param is_manual query bool false "is_manual"
+// @Param page query int false "page"
+// @Param page_size query int false "page_size"
+// @Param parallel_label query string false "parallel_label"
 // @Success 200  {object} PaginatedBlueprint
 // @Failure 400  {object} shared.ApiBody "Bad Request"
 // @Failure 500  {object} shared.ApiBody "Internal Error"

--- a/api/pipelines/pipelines.go
+++ b/api/pipelines/pipelines.go
@@ -81,14 +81,14 @@ GET /pipelines?status=TASK_RUNNING&pending=1&page=1&pagesize=10
 */
 
 // @Summary Get list of pipelines
-// @Description GET /pipelines?status=TASK_RUNNING&pending=1&parallel_label=search_text&page=1&pagesize=10
+// @Description GET /pipelines?status=TASK_RUNNING&pending=1&label=search_text&page=1&pagesize=10
 // @Tags framework/pipelines
 // @Param status query string false "status"
 // @Param pending query int false "pending"
 // @Param page query int false "page"
 // @Param pagesize query int false "pagesize"
 // @Param blueprint_id query int false "blueprint_id"
-// @Param parallel_label query string false "parallel_label"
+// @Param label query string false "label"
 // @Success 200  {object} shared.ResponsePipelines
 // @Failure 400  {string} errcode.Error "Bad Request"
 // @Failure 500  {string} errcode.Error "Internel Error"

--- a/api/pipelines/pipelines.go
+++ b/api/pipelines/pipelines.go
@@ -83,10 +83,12 @@ GET /pipelines?status=TASK_RUNNING&pending=1&page=1&pagesize=10
 // @Summary Get list of pipelines
 // @Description GET /pipelines?status=TASK_RUNNING&pending=1&page=1&pagesize=10
 // @Tags framework/pipelines
-// @Param status query string true "query"
-// @Param pending query int true "query"
-// @Param page query int true "query"
-// @Param pagesize query int true "query"
+// @Param status query string false "status"
+// @Param pending query int false "pending"
+// @Param page query int false "page"
+// @Param pagesize query int false "pagesize"
+// @Param blueprint_id query int false "blueprint_id"
+// @Param parallel_label query string false "parallel_label"
 // @Success 200  {object} shared.ResponsePipelines
 // @Failure 400  {string} errcode.Error "Bad Request"
 // @Failure 500  {string} errcode.Error "Internel Error"

--- a/api/pipelines/pipelines.go
+++ b/api/pipelines/pipelines.go
@@ -81,7 +81,7 @@ GET /pipelines?status=TASK_RUNNING&pending=1&page=1&pagesize=10
 */
 
 // @Summary Get list of pipelines
-// @Description GET /pipelines?status=TASK_RUNNING&pending=1&page=1&pagesize=10
+// @Description GET /pipelines?status=TASK_RUNNING&pending=1&parallel_label=search_text&page=1&pagesize=10
 // @Tags framework/pipelines
 // @Param status query string false "status"
 // @Param pending query int false "pending"

--- a/config-ui/src/hooks/usePipelineManager.jsx
+++ b/config-ui/src/hooks/usePipelineManager.jsx
@@ -57,21 +57,19 @@ function usePipelineManager(
   const [logfile, setLogfile] = useState('logging.tar.gz')
 
   const runPipeline = useCallback(
-    (runSettings = null) => {
-      console.log('>> RUNNING PIPELINE....')
+    (blueprintId) => {
+      console.log('>> RUNNING PIPELINE....', blueprintId)
       try {
         setIsRunning(true)
         setErrors([])
         ToastNotification.clear()
-        console.log('>> DISPATCHING PIPELINE REQUEST', runSettings || settings)
         const run = async () => {
           // @todo: remove "ID" fallback key when no longer needed
           const p = await request.post(
-            `${DEVLAKE_ENDPOINT}/pipelines`,
-            runSettings || settings
+            `${DEVLAKE_ENDPOINT}/blueprints/${blueprintId}/trigger`
           )
           const t = await request.get(
-            `${DEVLAKE_ENDPOINT}/pipelines/${p.data?.ID || p.data?.id}/tasks`
+            `${DEVLAKE_ENDPOINT}/pipelines/${p.data?.id}/tasks`
           )
           console.log('>> RAW PIPELINE DATA FROM API...', p.data)
           setPipelineRun({

--- a/config-ui/src/pages/blueprints/blueprint-detail.jsx
+++ b/config-ui/src/pages/blueprints/blueprint-detail.jsx
@@ -140,7 +140,7 @@ const BlueprintDetail = (props) => {
 
   const runBlueprint = useCallback(() => {
     if (activeBlueprint !== null) {
-      runPipeline()
+      runPipeline(activeBlueprint.id)
     }
   }, [activeBlueprint, runPipeline])
 

--- a/config-ui/src/pages/blueprints/create-blueprint.jsx
+++ b/config-ui/src/pages/blueprints/create-blueprint.jsx
@@ -815,7 +815,7 @@ const CreateBlueprint = (props) => {
         blueprintId: saveBlueprintComplete?.id,
         plan: saveBlueprintComplete?.plan
       }
-      runPipeline(newPipelineConfiguration)
+      runPipeline(saveBlueprintComplete?.id)
       setRunNow(false)
       history.push(`/blueprints/detail/${saveBlueprintComplete?.id}`)
     } else if (newBlueprintId) {

--- a/models/blueprint.go
+++ b/models/blueprint.go
@@ -19,10 +19,9 @@ package models
 
 import (
 	"encoding/json"
-
-	"github.com/apache/incubator-devlake/errors"
 	"time"
 
+	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/models/common"
 	"github.com/apache/incubator-devlake/plugins/core"
 )

--- a/models/blueprint.go
+++ b/models/blueprint.go
@@ -78,6 +78,8 @@ type DbBlueprint struct {
 	SkipOnFail   bool   `json:"skipOnFail"`
 	Settings     string `json:"settings" encrypt:"yes" swaggertype:"array,string" example:"please check api: /blueprints/<PLUGIN_NAME>/blueprint-setting"`
 	common.Model `swaggerignore:"true"`
+
+	Labels []DbBlueprintLabel `json:"-" gorm:"-"`
 }
 
 func (DbBlueprint) TableName() string {
@@ -88,7 +90,7 @@ type DbBlueprintLabel struct {
 	CreatedAt   time.Time `json:"createdAt"`
 	UpdatedAt   time.Time `json:"updatedAt"`
 	BlueprintId uint64    `json:"blueprint_id" gorm:"primaryKey"`
-	Name        string    `json:"name" gorm:"primaryKey"`
+	Name        string    `json:"name" gorm:"primaryKey;index"`
 }
 
 func (DbBlueprintLabel) TableName() string {

--- a/models/blueprint.go
+++ b/models/blueprint.go
@@ -39,12 +39,12 @@ type Blueprint struct {
 	Plan        json.RawMessage `json:"plan"`
 	Enable      bool            `json:"enable"`
 	//please check this https://crontab.guru/ for detail
-	CronConfig     string          `json:"cronConfig" format:"* * * * *" example:"0 0 * * 1"`
-	IsManual       bool            `json:"isManual"`
-	SkipOnFail     bool            `json:"skipOnFail"`
-	ParallelLabels []string        `json:"parallelLabels"`
-	Settings       json.RawMessage `json:"settings" swaggertype:"array,string" example:"please check api: /blueprints/<PLUGIN_NAME>/blueprint-setting"`
-	common.Model   `swaggerignore:"true"`
+	CronConfig   string          `json:"cronConfig" format:"* * * * *" example:"0 0 * * 1"`
+	IsManual     bool            `json:"isManual"`
+	SkipOnFail   bool            `json:"skipOnFail"`
+	Labels       []string        `json:"labels"`
+	Settings     json.RawMessage `json:"settings" swaggertype:"array,string" example:"please check api: /blueprints/<PLUGIN_NAME>/blueprint-setting"`
+	common.Model `swaggerignore:"true"`
 }
 
 type BlueprintSettings struct {
@@ -84,13 +84,13 @@ func (DbBlueprint) TableName() string {
 	return "_devlake_blueprints"
 }
 
-type DbBlueprintParallelLabel struct {
+type DbBlueprintLabel struct {
 	CreatedAt   time.Time `json:"createdAt"`
 	UpdatedAt   time.Time `json:"updatedAt"`
 	BlueprintId uint64    `json:"blueprint_id" gorm:"primaryKey"`
 	Name        string    `json:"name" gorm:"primaryKey"`
 }
 
-func (DbBlueprintParallelLabel) TableName() string {
-	return "_devlake_blueprint_parallel_labels"
+func (DbBlueprintLabel) TableName() string {
+	return "_devlake_blueprint_labels"
 }

--- a/models/blueprint.go
+++ b/models/blueprint.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 
 	"github.com/apache/incubator-devlake/errors"
+	"time"
 
 	"github.com/apache/incubator-devlake/models/common"
 	"github.com/apache/incubator-devlake/plugins/core"
@@ -39,11 +40,12 @@ type Blueprint struct {
 	Plan        json.RawMessage `json:"plan"`
 	Enable      bool            `json:"enable"`
 	//please check this https://crontab.guru/ for detail
-	CronConfig   string          `json:"cronConfig" format:"* * * * *" example:"0 0 * * 1"`
-	IsManual     bool            `json:"isManual"`
-	SkipOnFail   bool            `json:"skipOnFail"`
-	Settings     json.RawMessage `json:"settings" swaggertype:"array,string" example:"please check api: /blueprints/<PLUGIN_NAME>/blueprint-setting"`
-	common.Model `swaggerignore:"true"`
+	CronConfig     string          `json:"cronConfig" format:"* * * * *" example:"0 0 * * 1"`
+	IsManual       bool            `json:"isManual"`
+	SkipOnFail     bool            `json:"skipOnFail"`
+	ParallelLabels []string        `json:"parallelLabels"`
+	Settings       json.RawMessage `json:"settings" swaggertype:"array,string" example:"please check api: /blueprints/<PLUGIN_NAME>/blueprint-setting"`
+	common.Model   `swaggerignore:"true"`
 }
 
 type BlueprintSettings struct {
@@ -81,4 +83,15 @@ type DbBlueprint struct {
 
 func (DbBlueprint) TableName() string {
 	return "_devlake_blueprints"
+}
+
+type DbBlueprintParallelLabel struct {
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+	BlueprintId uint64    `json:"blueprint_id" gorm:"primaryKey"`
+	Name        string    `json:"name" gorm:"primaryKey"`
+}
+
+func (DbBlueprintParallelLabel) TableName() string {
+	return "_devlake_blueprint_parallel_labels"
 }

--- a/models/migrationscripts/20221115_add_labels.go
+++ b/models/migrationscripts/20221115_add_labels.go
@@ -19,6 +19,7 @@ package migrationscripts
 
 import (
 	"github.com/apache/incubator-devlake/errors"
+	"github.com/apache/incubator-devlake/helpers/migrationhelper"
 	"github.com/apache/incubator-devlake/plugins/core"
 	"time"
 )
@@ -27,7 +28,7 @@ type DbPipelineLabel20221115 struct {
 	CreatedAt  time.Time `json:"createdAt"`
 	UpdatedAt  time.Time `json:"updatedAt"`
 	PipelineId uint64    `json:"pipeline_id" gorm:"primaryKey"`
-	Name       string    `json:"name" gorm:"primaryKey"`
+	Name       string    `json:"name" gorm:"primaryKey;index"`
 }
 
 func (DbPipelineLabel20221115) TableName() string {
@@ -38,7 +39,7 @@ type DbBlueprintLabel20221115 struct {
 	CreatedAt   time.Time `json:"createdAt"`
 	UpdatedAt   time.Time `json:"updatedAt"`
 	BlueprintId uint64    `json:"blueprint_id" gorm:"primaryKey"`
-	Name        string    `json:"name" gorm:"primaryKey"`
+	Name        string    `json:"name" gorm:"primaryKey;index"`
 }
 
 func (DbBlueprintLabel20221115) TableName() string {
@@ -48,16 +49,7 @@ func (DbBlueprintLabel20221115) TableName() string {
 type addLabels struct{}
 
 func (*addLabels) Up(res core.BasicRes) errors.Error {
-	db := res.GetDal()
-	err := db.AutoMigrate(&DbPipelineLabel20221115{})
-	if err != nil {
-		return err
-	}
-	err = db.AutoMigrate(&DbBlueprintLabel20221115{})
-	if err != nil {
-		return err
-	}
-	return nil
+	return migrationhelper.AutoMigrateTables(res, &DbPipelineLabel20221115{}, &DbBlueprintLabel20221115{})
 }
 
 func (*addLabels) Version() uint64 {
@@ -65,5 +57,5 @@ func (*addLabels) Version() uint64 {
 }
 
 func (*addLabels) Name() string {
-	return "add parallel labels' schema for blueprint and pipeline"
+	return "add labels' schema for blueprint and pipeline"
 }

--- a/models/migrationscripts/20221115_add_parallel_labels.go
+++ b/models/migrationscripts/20221115_add_parallel_labels.go
@@ -1,0 +1,69 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"github.com/apache/incubator-devlake/errors"
+	"github.com/apache/incubator-devlake/plugins/core"
+	"time"
+)
+
+type DbPipelineParallelLabel20221115 struct {
+	CreatedAt  time.Time `json:"createdAt"`
+	UpdatedAt  time.Time `json:"updatedAt"`
+	PipelineId uint64    `json:"pipeline_id" gorm:"primaryKey"`
+	Name       string    `json:"name" gorm:"primaryKey"`
+}
+
+func (DbPipelineParallelLabel20221115) TableName() string {
+	return "_devlake_pipeline_parallel_labels"
+}
+
+type DbBlueprintParallelLabel20221115 struct {
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+	BlueprintId uint64    `json:"blueprint_id" gorm:"primaryKey"`
+	Name        string    `json:"name" gorm:"primaryKey"`
+}
+
+func (DbBlueprintParallelLabel20221115) TableName() string {
+	return "_devlake_blueprint_parallel_labels"
+}
+
+type addParallelLabels struct{}
+
+func (*addParallelLabels) Up(res core.BasicRes) errors.Error {
+	db := res.GetDal()
+	err := db.AutoMigrate(&DbPipelineParallelLabel20221115{})
+	if err != nil {
+		return err
+	}
+	err = db.AutoMigrate(&DbBlueprintParallelLabel20221115{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (*addParallelLabels) Version() uint64 {
+	return 20221115000034
+}
+
+func (*addParallelLabels) Name() string {
+	return "UpdateSchemas for addParallelLabels"
+}

--- a/models/migrationscripts/20221115_add_parallel_labels.go
+++ b/models/migrationscripts/20221115_add_parallel_labels.go
@@ -23,47 +23,47 @@ import (
 	"time"
 )
 
-type DbPipelineParallelLabel20221115 struct {
+type DbPipelineLabel20221115 struct {
 	CreatedAt  time.Time `json:"createdAt"`
 	UpdatedAt  time.Time `json:"updatedAt"`
 	PipelineId uint64    `json:"pipeline_id" gorm:"primaryKey"`
 	Name       string    `json:"name" gorm:"primaryKey"`
 }
 
-func (DbPipelineParallelLabel20221115) TableName() string {
-	return "_devlake_pipeline_parallel_labels"
+func (DbPipelineLabel20221115) TableName() string {
+	return "_devlake_pipeline_labels"
 }
 
-type DbBlueprintParallelLabel20221115 struct {
+type DbBlueprintLabel20221115 struct {
 	CreatedAt   time.Time `json:"createdAt"`
 	UpdatedAt   time.Time `json:"updatedAt"`
 	BlueprintId uint64    `json:"blueprint_id" gorm:"primaryKey"`
 	Name        string    `json:"name" gorm:"primaryKey"`
 }
 
-func (DbBlueprintParallelLabel20221115) TableName() string {
-	return "_devlake_blueprint_parallel_labels"
+func (DbBlueprintLabel20221115) TableName() string {
+	return "_devlake_blueprint_labels"
 }
 
-type addParallelLabels struct{}
+type addLabels struct{}
 
-func (*addParallelLabels) Up(res core.BasicRes) errors.Error {
+func (*addLabels) Up(res core.BasicRes) errors.Error {
 	db := res.GetDal()
-	err := db.AutoMigrate(&DbPipelineParallelLabel20221115{})
+	err := db.AutoMigrate(&DbPipelineLabel20221115{})
 	if err != nil {
 		return err
 	}
-	err = db.AutoMigrate(&DbBlueprintParallelLabel20221115{})
+	err = db.AutoMigrate(&DbBlueprintLabel20221115{})
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (*addParallelLabels) Version() uint64 {
+func (*addLabels) Version() uint64 {
 	return 20221115000034
 }
 
-func (*addParallelLabels) Name() string {
-	return "UpdateSchemas for addParallelLabels"
+func (*addLabels) Name() string {
+	return "add parallel labels' schema for blueprint and pipeline"
 }

--- a/models/migrationscripts/register.go
+++ b/models/migrationscripts/register.go
@@ -60,5 +60,6 @@ func All() []core.MigrationScript {
 		new(addProjectTables),
 		new(addProjectToBluePrint),
 		new(addProjectIssueMetric),
+		new(addParallelLabels),
 	}
 }

--- a/models/migrationscripts/register.go
+++ b/models/migrationscripts/register.go
@@ -60,6 +60,6 @@ func All() []core.MigrationScript {
 		new(addProjectTables),
 		new(addProjectToBluePrint),
 		new(addProjectIssueMetric),
-		new(addParallelLabels),
+		new(addLabels),
 	}
 }

--- a/models/pipeline.go
+++ b/models/pipeline.go
@@ -64,6 +64,8 @@ type DbPipeline struct {
 	Message       string     `json:"message"`
 	SpentSeconds  int        `json:"spentSeconds"`
 	Stage         int        `json:"stage"`
+
+	Labels []DbPipelineLabel `json:"-" gorm:"-"`
 }
 
 func (DbPipeline) TableName() string {
@@ -74,7 +76,7 @@ type DbPipelineLabel struct {
 	CreatedAt  time.Time `json:"createdAt"`
 	UpdatedAt  time.Time `json:"updatedAt"`
 	PipelineId uint64    `json:"pipeline_id" gorm:"primaryKey"`
-	Name       string    `json:"name" gorm:"primaryKey"`
+	Name       string    `json:"name" gorm:"primaryKey;index"`
 }
 
 func (DbPipelineLabel) TableName() string {

--- a/models/pipeline.go
+++ b/models/pipeline.go
@@ -28,27 +28,27 @@ import (
 
 type Pipeline struct {
 	common.Model
-	Name           string         `json:"name" gorm:"index"`
-	BlueprintId    uint64         `json:"blueprintId"`
-	Plan           datatypes.JSON `json:"plan"`
-	TotalTasks     int            `json:"totalTasks"`
-	FinishedTasks  int            `json:"finishedTasks"`
-	BeganAt        *time.Time     `json:"beganAt"`
-	FinishedAt     *time.Time     `json:"finishedAt" gorm:"index"`
-	Status         string         `json:"status"`
-	Message        string         `json:"message"`
-	SpentSeconds   int            `json:"spentSeconds"`
-	Stage          int            `json:"stage"`
-	ParallelLabels []string       `json:"parallelLabels"`
+	Name          string         `json:"name" gorm:"index"`
+	BlueprintId   uint64         `json:"blueprintId"`
+	Plan          datatypes.JSON `json:"plan"`
+	TotalTasks    int            `json:"totalTasks"`
+	FinishedTasks int            `json:"finishedTasks"`
+	BeganAt       *time.Time     `json:"beganAt"`
+	FinishedAt    *time.Time     `json:"finishedAt" gorm:"index"`
+	Status        string         `json:"status"`
+	Message       string         `json:"message"`
+	SpentSeconds  int            `json:"spentSeconds"`
+	Stage         int            `json:"stage"`
+	Labels        []string       `json:"labels"`
 }
 
 // We use a 2D array because the request body must be an array of a set of tasks
 // to be executed concurrently, while each set is to be executed sequentially.
 type NewPipeline struct {
-	Name           string            `json:"name"`
-	Plan           core.PipelinePlan `json:"plan" swaggertype:"array,string" example:"please check api /pipelines/<PLUGIN_NAME>/pipeline-plan"`
-	ParallelLabels []string          `json:"parallelLabels"`
-	BlueprintId    uint64
+	Name        string            `json:"name"`
+	Plan        core.PipelinePlan `json:"plan" swaggertype:"array,string" example:"please check api /pipelines/<PLUGIN_NAME>/pipeline-plan"`
+	Labels      []string          `json:"labels"`
+	BlueprintId uint64
 }
 
 type DbPipeline struct {
@@ -70,13 +70,13 @@ func (DbPipeline) TableName() string {
 	return "_devlake_pipelines"
 }
 
-type DbPipelineParallelLabel struct {
+type DbPipelineLabel struct {
 	CreatedAt  time.Time `json:"createdAt"`
 	UpdatedAt  time.Time `json:"updatedAt"`
 	PipelineId uint64    `json:"pipeline_id" gorm:"primaryKey"`
 	Name       string    `json:"name" gorm:"primaryKey"`
 }
 
-func (DbPipelineParallelLabel) TableName() string {
-	return "_devlake_pipeline_parallel_labels"
+func (DbPipelineLabel) TableName() string {
+	return "_devlake_pipeline_labels"
 }

--- a/models/pipeline.go
+++ b/models/pipeline.go
@@ -28,25 +28,27 @@ import (
 
 type Pipeline struct {
 	common.Model
-	Name          string         `json:"name" gorm:"index"`
-	BlueprintId   uint64         `json:"blueprintId"`
-	Plan          datatypes.JSON `json:"plan"`
-	TotalTasks    int            `json:"totalTasks"`
-	FinishedTasks int            `json:"finishedTasks"`
-	BeganAt       *time.Time     `json:"beganAt"`
-	FinishedAt    *time.Time     `json:"finishedAt" gorm:"index"`
-	Status        string         `json:"status"`
-	Message       string         `json:"message"`
-	SpentSeconds  int            `json:"spentSeconds"`
-	Stage         int            `json:"stage"`
+	Name           string         `json:"name" gorm:"index"`
+	BlueprintId    uint64         `json:"blueprintId"`
+	Plan           datatypes.JSON `json:"plan"`
+	TotalTasks     int            `json:"totalTasks"`
+	FinishedTasks  int            `json:"finishedTasks"`
+	BeganAt        *time.Time     `json:"beganAt"`
+	FinishedAt     *time.Time     `json:"finishedAt" gorm:"index"`
+	Status         string         `json:"status"`
+	Message        string         `json:"message"`
+	SpentSeconds   int            `json:"spentSeconds"`
+	Stage          int            `json:"stage"`
+	ParallelLabels []string       `json:"parallelLabels"`
 }
 
 // We use a 2D array because the request body must be an array of a set of tasks
 // to be executed concurrently, while each set is to be executed sequentially.
 type NewPipeline struct {
-	Name        string            `json:"name"`
-	Plan        core.PipelinePlan `json:"plan" swaggertype:"array,string" example:"please check api /pipelines/<PLUGIN_NAME>/pipeline-plan"`
-	BlueprintId uint64
+	Name           string            `json:"name"`
+	Plan           core.PipelinePlan `json:"plan" swaggertype:"array,string" example:"please check api /pipelines/<PLUGIN_NAME>/pipeline-plan"`
+	ParallelLabels []string          `json:"parallelLabels"`
+	BlueprintId    uint64
 }
 
 type DbPipeline struct {
@@ -66,4 +68,15 @@ type DbPipeline struct {
 
 func (DbPipeline) TableName() string {
 	return "_devlake_pipelines"
+}
+
+type DbPipelineParallelLabel struct {
+	CreatedAt  time.Time `json:"createdAt"`
+	UpdatedAt  time.Time `json:"updatedAt"`
+	PipelineId uint64    `json:"pipeline_id" gorm:"primaryKey"`
+	Name       string    `json:"name" gorm:"primaryKey"`
+}
+
+func (DbPipelineParallelLabel) TableName() string {
+	return "_devlake_pipeline_parallel_labels"
 }

--- a/plugins/helper/api_async_client.go
+++ b/plugins/helper/api_async_client.go
@@ -111,7 +111,6 @@ func CreateAsyncApiClient(
 		numOfWorkers,
 		requests,
 		duration,
-		retry,
 		logger,
 	)
 	if err != nil {

--- a/plugins/helper/worker_scheduler.go
+++ b/plugins/helper/worker_scheduler.go
@@ -48,7 +48,6 @@ func NewWorkerScheduler(
 	workerNum int,
 	maxWork int,
 	maxWorkDuration time.Duration,
-	maxRetry int,
 	logger core.Logger,
 ) (*WorkerScheduler, errors.Error) {
 	if maxWork <= 0 {

--- a/plugins/helper/worker_scheduler_test.go
+++ b/plugins/helper/worker_scheduler_test.go
@@ -31,7 +31,7 @@ func TestWorkerSchedulerQpsControl(t *testing.T) {
 	// assuming we want 2 requests per second
 	testChannel := make(chan int, 100)
 	ctx, cancel := context.WithCancel(context.Background())
-	s, _ := NewWorkerScheduler(ctx, 5, 2, 1*time.Second, 0, unithelper.DummyLogger())
+	s, _ := NewWorkerScheduler(ctx, 5, 2, 1*time.Second, unithelper.DummyLogger())
 	defer s.Release()
 	for i := 1; i <= 5; i++ {
 		t := i

--- a/services/blueprint.go
+++ b/services/blueprint.go
@@ -54,12 +54,12 @@ func CreateBlueprint(blueprint *models.Blueprint) errors.Error {
 	if err != nil {
 		return err
 	}
-	dbBlueprint, dbBlueprintLabels := parseDbBlueprint(blueprint)
+	dbBlueprint := parseDbBlueprint(blueprint)
 	dbBlueprint, err = encryptDbBlueprint(dbBlueprint)
 	if err != nil {
 		return err
 	}
-	err = SaveDbBlueprint(dbBlueprint, dbBlueprintLabels)
+	err = SaveDbBlueprint(dbBlueprint)
 	if err != nil {
 		return err
 	}
@@ -73,7 +73,7 @@ func CreateBlueprint(blueprint *models.Blueprint) errors.Error {
 
 // GetBlueprints returns a paginated list of Blueprints based on `query`
 func GetBlueprints(query *BlueprintQuery) ([]*models.Blueprint, int64, errors.Error) {
-	dbBlueprints, dbLabelsMap, count, err := GetDbBlueprints(query)
+	dbBlueprints, count, err := GetDbBlueprints(query)
 	if err != nil {
 		return nil, 0, errors.Convert(err)
 	}
@@ -83,7 +83,7 @@ func GetBlueprints(query *BlueprintQuery) ([]*models.Blueprint, int64, errors.Er
 		if err != nil {
 			return nil, 0, err
 		}
-		blueprint := parseBlueprint(dbBlueprint, dbLabelsMap[dbBlueprint.ID])
+		blueprint := parseBlueprint(dbBlueprint)
 		blueprints = append(blueprints, blueprint)
 	}
 	return blueprints, count, nil
@@ -91,7 +91,7 @@ func GetBlueprints(query *BlueprintQuery) ([]*models.Blueprint, int64, errors.Er
 
 // GetBlueprint returns the detail of a given Blueprint ID
 func GetBlueprint(blueprintId uint64) (*models.Blueprint, errors.Error) {
-	dbBlueprint, dbLabels, err := GetDbBlueprint(blueprintId)
+	dbBlueprint, err := GetDbBlueprint(blueprintId)
 	if err != nil {
 		if goerror.Is(err, gorm.ErrRecordNotFound) {
 			return nil, errors.NotFound.New("blueprint not found")
@@ -102,7 +102,7 @@ func GetBlueprint(blueprintId uint64) (*models.Blueprint, errors.Error) {
 	if err != nil {
 		return nil, err
 	}
-	blueprint := parseBlueprint(dbBlueprint, dbLabels)
+	blueprint := parseBlueprint(dbBlueprint)
 	return blueprint, nil
 }
 
@@ -180,12 +180,12 @@ func PatchBlueprint(id uint64, body map[string]interface{}) (*models.Blueprint, 
 	}
 
 	// save
-	dbBlueprint, dbBlueprintLabels := parseDbBlueprint(blueprint)
+	dbBlueprint := parseDbBlueprint(blueprint)
 	dbBlueprint, err = encryptDbBlueprint(dbBlueprint)
 	if err != nil {
 		return nil, err
 	}
-	err = SaveDbBlueprint(dbBlueprint, dbBlueprintLabels)
+	err = SaveDbBlueprint(dbBlueprint)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +216,7 @@ func DeleteBlueprint(id uint64) errors.Error {
 func ReloadBlueprints(c *cron.Cron) errors.Error {
 	enable := true
 	isManual := false
-	dbBlueprints, dbLabelsMap, _, err := GetDbBlueprints(&BlueprintQuery{Enable: &enable, IsManual: &isManual})
+	dbBlueprints, _, err := GetDbBlueprints(&BlueprintQuery{Enable: &enable, IsManual: &isManual})
 	if err != nil {
 		return err
 	}
@@ -229,7 +229,7 @@ func ReloadBlueprints(c *cron.Cron) errors.Error {
 		if err != nil {
 			return err
 		}
-		blueprint := parseBlueprint(dbBlueprint, dbLabelsMap[dbBlueprint.ID])
+		blueprint := parseBlueprint(dbBlueprint)
 		plan, err := blueprint.UnmarshalPlan()
 		if err != nil {
 			blueprintLog.Error(err, failToCreateCronJob)

--- a/services/blueprint.go
+++ b/services/blueprint.go
@@ -34,12 +34,13 @@ import (
 	"gorm.io/gorm"
 )
 
-// BlueprintQuery FIXME ...
+// BlueprintQuery is a query for GetBlueprints
 type BlueprintQuery struct {
-	Enable   *bool `form:"enable,omitempty"`
-	IsManual *bool `form:"is_manual"`
-	Page     int   `form:"page"`
-	PageSize int   `form:"pageSize"`
+	Enable        *bool  `form:"enable,omitempty"`
+	IsManual      *bool  `form:"is_manual"`
+	Page          int    `form:"page"`
+	PageSize      int    `form:"pageSize"`
+	ParallelLabel string `form:"parallel_label"`
 }
 
 var (

--- a/services/blueprint.go
+++ b/services/blueprint.go
@@ -351,7 +351,6 @@ func TriggerBlueprint(id uint64) (*models.Pipeline, errors.Error) {
 		return nil, err
 	}
 
-	fmt.Println(blueprint.ParallelLabels)
 	pipeline, err := createPipelineByBlueprint(blueprint, blueprint.Name, plan)
 	// done
 	return pipeline, err

--- a/services/blueprint_helper.go
+++ b/services/blueprint_helper.go
@@ -27,29 +27,29 @@ import (
 )
 
 // SaveDbBlueprint accepts a Blueprint instance and upsert it to database
-func SaveDbBlueprint(dbBlueprint *models.DbBlueprint, parallelLabelModels []models.DbBlueprintParallelLabel) errors.Error {
+func SaveDbBlueprint(dbBlueprint *models.DbBlueprint, labelModels []models.DbBlueprintLabel) errors.Error {
 	err := db.Save(&dbBlueprint).Error
 	if err != nil {
 		return errors.Default.Wrap(err, "error creating DB blueprint")
 	}
-	err = db.Delete(&models.DbBlueprintParallelLabel{}, `blueprint_id = ?`, dbBlueprint.ID).Error
+	err = db.Delete(&models.DbBlueprintLabel{}, `blueprint_id = ?`, dbBlueprint.ID).Error
 	if err != nil {
-		return errors.Default.Wrap(err, "error delete DB blueprint's old parallelLabelModels")
+		return errors.Default.Wrap(err, "error delete DB blueprint's old labelModels")
 	}
-	if len(parallelLabelModels) > 0 {
-		for _, parallelLabelModel := range parallelLabelModels {
-			parallelLabelModel.BlueprintId = dbBlueprint.ID
+	if len(labelModels) > 0 {
+		for _, labelModel := range labelModels {
+			labelModel.BlueprintId = dbBlueprint.ID
 		}
-		err = db.Create(&parallelLabelModels).Error
+		err = db.Create(&labelModels).Error
 		if err != nil {
-			return errors.Default.Wrap(err, "error creating DB blueprint's parallelLabelModels")
+			return errors.Default.Wrap(err, "error creating DB blueprint's labelModels")
 		}
 	}
 	return nil
 }
 
 // GetDbBlueprints returns a paginated list of Blueprints based on `query`
-func GetDbBlueprints(query *BlueprintQuery) ([]*models.DbBlueprint, map[uint64][]models.DbBlueprintParallelLabel, int64, errors.Error) {
+func GetDbBlueprints(query *BlueprintQuery) ([]*models.DbBlueprint, map[uint64][]models.DbBlueprintLabel, int64, errors.Error) {
 	dbBlueprints := make([]*models.DbBlueprint, 0)
 	dbQuery := db.Model(dbBlueprints).Order("id DESC")
 	if query.Enable != nil {
@@ -58,11 +58,11 @@ func GetDbBlueprints(query *BlueprintQuery) ([]*models.DbBlueprint, map[uint64][
 	if query.IsManual != nil {
 		dbQuery = dbQuery.Where("is_manual = ?", *query.IsManual)
 	}
-	if query.ParallelLabel != "" {
+	if query.Label != "" {
 		dbQuery = dbQuery.
-			Joins(`left join _devlake_blueprint_parallel_labels ON
-                  _devlake_blueprint_parallel_labels.blueprint_id = _devlake_blueprints.id`).
-			Where(`_devlake_blueprint_parallel_labels.name = ?`, query.ParallelLabel)
+			Joins(`left join _devlake_blueprint_labels ON
+                  _devlake_blueprint_labels.blueprint_id = _devlake_blueprints.id`).
+			Where(`_devlake_blueprint_labels.name = ?`, query.Label)
 	}
 
 	var count int64
@@ -82,18 +82,18 @@ func GetDbBlueprints(query *BlueprintQuery) ([]*models.DbBlueprint, map[uint64][
 	for _, dbBlueprint := range dbBlueprints {
 		blueprintIds = append(blueprintIds, dbBlueprint.ID)
 	}
-	dbParallelLabels := []models.DbBlueprintParallelLabel{}
-	dbParallelLabelsMap := map[uint64][]models.DbBlueprintParallelLabel{}
-	db.Where(`blueprint_id in ?`, blueprintIds).Find(&dbParallelLabels)
-	for _, dbParallelLabel := range dbParallelLabels {
-		dbParallelLabelsMap[dbParallelLabel.BlueprintId] = append(dbParallelLabelsMap[dbParallelLabel.BlueprintId], dbParallelLabel)
+	dbLabels := []models.DbBlueprintLabel{}
+	dbLabelsMap := map[uint64][]models.DbBlueprintLabel{}
+	db.Where(`blueprint_id in ?`, blueprintIds).Find(&dbLabels)
+	for _, dbLabel := range dbLabels {
+		dbLabelsMap[dbLabel.BlueprintId] = append(dbLabelsMap[dbLabel.BlueprintId], dbLabel)
 	}
 
-	return dbBlueprints, dbParallelLabelsMap, count, nil
+	return dbBlueprints, dbLabelsMap, count, nil
 }
 
 // GetDbBlueprint returns the detail of a given Blueprint ID
-func GetDbBlueprint(dbBlueprintId uint64) (*models.DbBlueprint, []models.DbBlueprintParallelLabel, errors.Error) {
+func GetDbBlueprint(dbBlueprintId uint64) (*models.DbBlueprint, []models.DbBlueprintLabel, errors.Error) {
 	dbBlueprint := &models.DbBlueprint{}
 	err := db.First(dbBlueprint, dbBlueprintId).Error
 	if err != nil {
@@ -102,12 +102,12 @@ func GetDbBlueprint(dbBlueprintId uint64) (*models.DbBlueprint, []models.DbBluep
 		}
 		return nil, nil, errors.Default.Wrap(err, "error getting blueprint from DB")
 	}
-	dbParallelLabels := []models.DbBlueprintParallelLabel{}
-	err = db.Find(&dbParallelLabels, "blueprint_id = ?", dbBlueprint.ID).Error
+	dbLabels := []models.DbBlueprintLabel{}
+	err = db.Find(&dbLabels, "blueprint_id = ?", dbBlueprint.ID).Error
 	if err != nil {
 		return nil, nil, errors.Internal.Wrap(err, "error getting the blueprint from database")
 	}
-	return dbBlueprint, dbParallelLabels, nil
+	return dbBlueprint, dbLabels, nil
 }
 
 // DeleteDbBlueprint deletes blueprint by id
@@ -120,28 +120,28 @@ func DeleteDbBlueprint(id uint64) errors.Error {
 }
 
 // parseBlueprint
-func parseBlueprint(DbBlueprint *models.DbBlueprint, parallelLabelModels []models.DbBlueprintParallelLabel) *models.Blueprint {
-	parallelLabelList := []string{}
-	for _, labelModel := range parallelLabelModels {
-		parallelLabelList = append(parallelLabelList, labelModel.Name)
+func parseBlueprint(DbBlueprint *models.DbBlueprint, labelModels []models.DbBlueprintLabel) *models.Blueprint {
+	labelList := []string{}
+	for _, labelModel := range labelModels {
+		labelList = append(labelList, labelModel.Name)
 	}
 	blueprint := models.Blueprint{
-		Name:           DbBlueprint.Name,
-		Mode:           DbBlueprint.Mode,
-		Plan:           []byte(DbBlueprint.Plan),
-		Enable:         DbBlueprint.Enable,
-		CronConfig:     DbBlueprint.CronConfig,
-		IsManual:       DbBlueprint.IsManual,
-		SkipOnFail:     DbBlueprint.SkipOnFail,
-		Settings:       []byte(DbBlueprint.Settings),
-		Model:          DbBlueprint.Model,
-		ParallelLabels: parallelLabelList,
+		Name:       DbBlueprint.Name,
+		Mode:       DbBlueprint.Mode,
+		Plan:       []byte(DbBlueprint.Plan),
+		Enable:     DbBlueprint.Enable,
+		CronConfig: DbBlueprint.CronConfig,
+		IsManual:   DbBlueprint.IsManual,
+		SkipOnFail: DbBlueprint.SkipOnFail,
+		Settings:   []byte(DbBlueprint.Settings),
+		Model:      DbBlueprint.Model,
+		Labels:     labelList,
 	}
 	return &blueprint
 }
 
 // parseDbBlueprint
-func parseDbBlueprint(blueprint *models.Blueprint) (*models.DbBlueprint, []models.DbBlueprintParallelLabel) {
+func parseDbBlueprint(blueprint *models.Blueprint) (*models.DbBlueprint, []models.DbBlueprintLabel) {
 	dbBlueprint := models.DbBlueprint{
 		Name:       blueprint.Name,
 		Mode:       blueprint.Mode,
@@ -153,15 +153,15 @@ func parseDbBlueprint(blueprint *models.Blueprint) (*models.DbBlueprint, []model
 		Settings:   string(blueprint.Settings),
 		Model:      blueprint.Model,
 	}
-	parallelLabels := []models.DbBlueprintParallelLabel{}
-	for _, label := range blueprint.ParallelLabels {
-		parallelLabels = append(parallelLabels, models.DbBlueprintParallelLabel{
+	labels := []models.DbBlueprintLabel{}
+	for _, label := range blueprint.Labels {
+		labels = append(labels, models.DbBlueprintLabel{
 			// NOTICE: BlueprintId may be nil
 			BlueprintId: blueprint.ID,
 			Name:        label,
 		})
 	}
-	return &dbBlueprint, parallelLabels
+	return &dbBlueprint, labels
 }
 
 // encryptDbBlueprint

--- a/services/blueprint_helper.go
+++ b/services/blueprint_helper.go
@@ -55,6 +55,15 @@ func GetDbBlueprints(query *BlueprintQuery) ([]*models.DbBlueprint, map[uint64][
 	if query.Enable != nil {
 		dbQuery = dbQuery.Where("enable = ?", *query.Enable)
 	}
+	if query.IsManual != nil {
+		dbQuery = dbQuery.Where("is_manual = ?", *query.IsManual)
+	}
+	if query.ParallelLabel != "" {
+		dbQuery = dbQuery.
+			Joins(`left join _devlake_blueprint_parallel_labels ON
+                  _devlake_blueprint_parallel_labels.blueprint_id = _devlake_blueprints.id`).
+			Where(`_devlake_blueprint_parallel_labels.name = ?`, query.ParallelLabel)
+	}
 
 	var count int64
 	err := dbQuery.Count(&count).Error
@@ -96,7 +105,7 @@ func GetDbBlueprint(dbBlueprintId uint64) (*models.DbBlueprint, []models.DbBluep
 	dbParallelLabels := []models.DbBlueprintParallelLabel{}
 	err = db.Find(&dbParallelLabels, "blueprint_id = ?", dbBlueprint.ID).Error
 	if err != nil {
-		return nil, nil, errors.Internal.Wrap(err, "error getting the pipeline from database")
+		return nil, nil, errors.Internal.Wrap(err, "error getting the blueprint from database")
 	}
 	return dbBlueprint, dbParallelLabels, nil
 }

--- a/services/blueprint_helper.go
+++ b/services/blueprint_helper.go
@@ -147,7 +147,9 @@ func parseDbBlueprint(blueprint *models.Blueprint) (*models.DbBlueprint, []model
 	parallelLabels := []models.DbBlueprintParallelLabel{}
 	for _, label := range blueprint.ParallelLabels {
 		parallelLabels = append(parallelLabels, models.DbBlueprintParallelLabel{
-			Name: label,
+			// NOTICE: BlueprintId may be nil
+			BlueprintId: blueprint.ID,
+			Name:        label,
 		})
 	}
 	return &dbBlueprint, parallelLabels

--- a/services/blueprint_helper.go
+++ b/services/blueprint_helper.go
@@ -65,8 +65,7 @@ func GetDbBlueprints(query *BlueprintQuery) ([]*models.DbBlueprint, int64, error
 	}
 	if query.Label != "" {
 		dbQuery = dbQuery.
-			Joins(`left join _devlake_blueprint_labels ON
-                  _devlake_blueprint_labels.blueprint_id = _devlake_blueprints.id`).
+			Joins(`left join _devlake_blueprint_labels ON _devlake_blueprint_labels.blueprint_id = _devlake_blueprints.id`).
 			Where(`_devlake_blueprint_labels.name = ?`, query.Label)
 	}
 

--- a/services/pipeline.go
+++ b/services/pipeline.go
@@ -202,18 +202,16 @@ func RunPipelineInQueue(pipelineMaxParallel int64) {
 			pipelineParallelLabels = append(pipelineParallelLabels, dbParallelLabel.Name)
 		}
 		runningParallelLabels = append(runningParallelLabels, pipelineParallelLabels...)
-		globalPipelineLog.Info("now running runningParallelLabels is, %s", runningParallelLabels)
+		globalPipelineLog.Info("now running runningParallelLabels is %s", runningParallelLabels)
 
 		go func(pipelineId uint64, parallelLabels []string) {
 			defer sema.Release(1)
 			defer func() {
 				runningParallelLabels = utils.SliceRemove(runningParallelLabels, parallelLabels...)
-				globalPipelineLog.Info("finish pipeline, %d", pipelineId)
-				globalPipelineLog.Info("now finish runningParallelLabels is, %s", runningParallelLabels)
+				globalPipelineLog.Info("finish pipeline #%d, now runningParallelLabels is %s", pipelineId, runningParallelLabels)
 			}()
 			globalPipelineLog.Info("run pipeline, %d", pipelineId)
-			//err = runPipeline(pipelineId)
-			time.Sleep(time.Second * 10)
+			err = runPipeline(pipelineId)
 			if err != nil {
 				globalPipelineLog.Error(err, "failed to run pipeline %d", pipelineId)
 			}

--- a/services/pipeline.go
+++ b/services/pipeline.go
@@ -40,13 +40,14 @@ var notificationService *NotificationService
 var temporalClient client.Client
 var globalPipelineLog = logger.Global.Nested("pipeline service")
 
-// PipelineQuery FIXME ...
+// PipelineQuery is a query for GetPipelines
 type PipelineQuery struct {
-	Status      string `form:"status"`
-	Pending     int    `form:"pending"`
-	Page        int    `form:"page"`
-	PageSize    int    `form:"pageSize"`
-	BlueprintId uint64 `uri:"blueprintId" form:"blueprint_id"`
+	Status        string `form:"status"`
+	Pending       int    `form:"pending"`
+	Page          int    `form:"page"`
+	PageSize      int    `form:"pageSize"`
+	BlueprintId   uint64 `uri:"blueprintId" form:"blueprint_id"`
+	ParallelLabel string `form:"parallel_label"`
 }
 
 func pipelineServiceInit() {
@@ -108,7 +109,7 @@ func CreatePipeline(newPipeline *models.NewPipeline) (*models.Pipeline, errors.E
 
 // GetPipelines by query
 func GetPipelines(query *PipelineQuery) ([]*models.Pipeline, int64, errors.Error) {
-	dbPipelines, i, err := GetDbPipelines(query)
+	dbPipelines, dbParallelLabelsMap, i, err := GetDbPipelines(query)
 	if err != nil {
 		return nil, 0, errors.Convert(err)
 	}
@@ -118,8 +119,7 @@ func GetPipelines(query *PipelineQuery) ([]*models.Pipeline, int64, errors.Error
 		if err != nil {
 			return nil, 0, err
 		}
-		// TODO query parallelLabelModels
-		pipeline := parsePipeline(dbPipeline, nil)
+		pipeline := parsePipeline(dbPipeline, dbParallelLabelsMap[dbPipeline.ID])
 		pipelines = append(pipelines, pipeline)
 	}
 

--- a/services/pipeline.go
+++ b/services/pipeline.go
@@ -174,9 +174,9 @@ func RunPipelineInQueue(pipelineMaxParallel int64) {
 			// prepare query to find an appropriate pipeline to execute
 			db.Where("status IN ?", []string{models.TASK_CREATED, models.TASK_RERUN}).
 				Joins(`left join _devlake_pipeline_labels ON
-                  _devlake_pipeline_labels.pipeline_id = _devlake_pipelines.id AND
-                  _devlake_pipeline_labels.name LIKE 'parallel/%' AND
-                  _devlake_pipeline_labels.name in ?`, runningParallelLabels).
+						_devlake_pipeline_labels.pipeline_id = _devlake_pipelines.id AND
+						_devlake_pipeline_labels.name LIKE 'parallel/%' AND
+						_devlake_pipeline_labels.name in ?`, runningParallelLabels).
 				Group(`id`).
 				Having(`count(_devlake_pipeline_labels.name)=0`).
 				Select("id").

--- a/services/pipeline.go
+++ b/services/pipeline.go
@@ -174,7 +174,7 @@ func RunPipelineInQueue(pipelineMaxParallel int64) {
 			db.Where("status IN ?", []string{models.TASK_CREATED, models.TASK_RERUN}).
 				Joins(`left join _devlake_pipeline_labels ON
                   _devlake_pipeline_labels.pipeline_id = _devlake_pipelines.id AND
-                  _devlake_pipeline_labels.name = 'parallel/%' AND
+                  _devlake_pipeline_labels.name LIKE 'parallel/%' AND
                   _devlake_pipeline_labels.name in ?`, runningParallelLabels).
 				Group(`id`).
 				Having(`count(_devlake_pipeline_labels.name)=0`).
@@ -205,7 +205,6 @@ func RunPipelineInQueue(pipelineMaxParallel int64) {
 			}
 		}
 		runningParallelLabels = append(runningParallelLabels, pipelineParallelLabels...)
-		globalPipelineLog.Info("now running runningParallelLabels is %s", runningParallelLabels)
 
 		go func(pipelineId uint64, parallelLabels []string) {
 			defer sema.Release(1)
@@ -213,7 +212,7 @@ func RunPipelineInQueue(pipelineMaxParallel int64) {
 				runningParallelLabels = utils.SliceRemove(runningParallelLabels, parallelLabels...)
 				globalPipelineLog.Info("finish pipeline #%d, now runningParallelLabels is %s", pipelineId, runningParallelLabels)
 			}()
-			globalPipelineLog.Info("run pipeline, %d", pipelineId)
+			globalPipelineLog.Info("run pipeline, %d, now running runningParallelLabels are %s", pipelineId, runningParallelLabels)
 			err = runPipeline(pipelineId)
 			if err != nil {
 				globalPipelineLog.Error(err, "failed to run pipeline %d", pipelineId)

--- a/services/pipeline_helper.go
+++ b/services/pipeline_helper.go
@@ -200,6 +200,7 @@ func parsePipeline(dbPipeline *models.DbPipeline, parallelLabelModels []models.D
 }
 
 // parseDbPipeline converts Pipeline to DbPipeline
+// nolint:unused
 func parseDbPipeline(pipeline *models.Pipeline) (*models.DbPipeline, []models.DbPipelineParallelLabel) {
 	dbPipeline := models.DbPipeline{
 		Model:         pipeline.Model,

--- a/services/pipeline_helper.go
+++ b/services/pipeline_helper.go
@@ -126,8 +126,7 @@ func GetDbPipelines(query *PipelineQuery) ([]*models.DbPipeline, int64, errors.E
 	}
 	if query.Label != "" {
 		dbQuery = dbQuery.
-			Joins(`left join _devlake_pipeline_labels ON
-                  _devlake_pipeline_labels.pipeline_id = _devlake_pipelines.id`).
+			Joins(`left join _devlake_pipeline_labels ON _devlake_pipeline_labels.pipeline_id = _devlake_pipelines.id`).
 			Where(`_devlake_pipeline_labels.name = ?`, query.Label)
 	}
 	var count int64

--- a/services/pipeline_runner.go
+++ b/services/pipeline_runner.go
@@ -117,27 +117,28 @@ func runPipeline(pipelineId uint64) errors.Error {
 	if err != nil {
 		err = errors.Default.Wrap(err, fmt.Sprintf("Error running pipeline %d.", pipelineId))
 	}
-	pipeline, e := GetPipeline(pipelineId)
+	dbPipeline, _, e := GetDbPipeline(pipelineId)
 	if e != nil {
 		return errors.Default.Wrap(err, fmt.Sprintf("Unable to get pipeline %d.", pipelineId))
 	}
 	// finished, update database
 	finishedAt := time.Now()
-	pipeline.FinishedAt = &finishedAt
-	pipeline.SpentSeconds = int(finishedAt.Unix() - pipeline.BeganAt.Unix())
+	dbPipeline.FinishedAt = &finishedAt
+	if dbPipeline.BeganAt != nil {
+		dbPipeline.SpentSeconds = int(finishedAt.Unix() - dbPipeline.BeganAt.Unix())
+	}
 	if err != nil {
-		pipeline.Status = models.TASK_FAILED
+		dbPipeline.Status = models.TASK_FAILED
 		if lakeErr := errors.AsLakeErrorType(err); lakeErr != nil {
-			pipeline.Message = lakeErr.Messages().Format()
+			dbPipeline.Message = lakeErr.Messages().Format()
 		} else {
-			pipeline.Message = err.Error()
+			dbPipeline.Message = err.Error()
 		}
 	} else {
-		pipeline.Status = models.TASK_COMPLETED
-		pipeline.Message = ""
+		dbPipeline.Status = models.TASK_COMPLETED
+		dbPipeline.Message = ""
 	}
-	dbPipeline := parseDbPipeline(pipeline)
-	dbe := db.Model(dbPipeline).Select("finished_at", "spent_seconds", "status", "message").Updates(dbPipeline).Error
+	dbe := db.Model(dbPipeline).Updates(dbPipeline).Error
 	if dbe != nil {
 		globalPipelineLog.Error(dbe, "update pipeline state failed")
 		return errors.Convert(dbe)

--- a/services/pipeline_runner.go
+++ b/services/pipeline_runner.go
@@ -117,7 +117,7 @@ func runPipeline(pipelineId uint64) errors.Error {
 	if err != nil {
 		err = errors.Default.Wrap(err, fmt.Sprintf("Error running pipeline %d.", pipelineId))
 	}
-	dbPipeline, _, e := GetDbPipeline(pipelineId)
+	dbPipeline, e := GetDbPipeline(pipelineId)
 	if e != nil {
 		return errors.Default.Wrap(err, fmt.Sprintf("Unable to get pipeline %d.", pipelineId))
 	}

--- a/utils/slice.go
+++ b/utils/slice.go
@@ -1,0 +1,37 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+// SliceRemove remove some items in old slice
+func SliceRemove[T ~int | ~string](source []T, toRemoves ...T) []T {
+	j := 0
+	for _, v := range source {
+		needRemove := false
+		for _, toRemove := range toRemoves {
+			if v == toRemove {
+				needRemove = true
+				break
+			}
+		}
+		if !needRemove {
+			source[j] = v
+			j++
+		}
+	}
+	return source[:j]
+}

--- a/utils/slice_test.go
+++ b/utils/slice_test.go
@@ -1,0 +1,30 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+// TestSliceRemove test the SliceRemove
+func TestSliceRemove(t *testing.T) {
+	assert.Equal(t, []int{3, 4, 5}, SliceRemove([]int{1, 2, 3, 4, 5}, 1, 2))
+	assert.Equal(t, []int{1, 2, 4, 5}, SliceRemove([]int{1, 2, 3, 4, 5}, 3, 3))
+	assert.Equal(t, []string{`1`, `2`, `4`, `5`}, SliceRemove([]string{`1`, `2`, `3`, `4`, `5`}, `3`, `3`))
+}


### PR DESCRIPTION
### Summary
1. add labels for blueprint/pipeline
2. use labels which start with `parallel/*` to control how pipeline run parallel.
3. [config-ui] use api `trigger` to run blueprint
4. delete unused param `retry`
5. fix a bug imported by https://github.com/apache/incubator-devlake/pull/3754: the response body from `/blueprints` changed.

![image](https://user-images.githubusercontent.com/3294100/202756285-495f11a6-b8a2-4806-b39c-a16dd20d8253.png)


Now the pipelines with the same labels which start with `parallel/*` (just need one) can only run one by one.
all labels in the blueprint will pass to the pipeline when triggered.

### Does this close any open issues?
Closes #3234

### Screenshots
![image](https://user-images.githubusercontent.com/3294100/202985321-31483aae-cb16-432c-9e9d-e5d14fa8f795.png)
![image](https://user-images.githubusercontent.com/3294100/202985518-65a3eedb-770f-42a2-9ffb-4a36237ff2bc.png)
![image](https://user-images.githubusercontent.com/3294100/202985718-531824a0-bbac-424d-b18b-0e7c9a8641f6.png)

![image](https://user-images.githubusercontent.com/3294100/202985987-fe26137d-2830-482f-b47e-e8dfec1989fb.png)
parallel_label in `Get /pipelines` must be a complete label name to filter.
![image](https://user-images.githubusercontent.com/3294100/202985919-7bf0ff28-fb8b-4090-ab87-a58d074f1372.png)

