### PR TITLE
fix(zentao): use zentaoExecution as boardIdGen

### DIFF
--- a/plugins/zentao/e2e/snapshot_tables/board_issues_task.csv
+++ b/plugins/zentao/e2e/snapshot_tables/board_issues_task.csv
@@ -1,4 +1,4 @@
 board_id,issue_id
-zentao:ZentaoProduct:1:3,zentao:ZentaoTask:1:1
-zentao:ZentaoProduct:1:3,zentao:ZentaoTask:1:2
-zentao:ZentaoProduct:1:3,zentao:ZentaoTask:1:3
+zentao:ZentaoExecution:1:3,zentao:ZentaoTask:1:1
+zentao:ZentaoExecution:1:3,zentao:ZentaoTask:1:2
+zentao:ZentaoExecution:1:3,zentao:ZentaoTask:1:3

--- a/plugins/zentao/tasks/task_convertor.go
+++ b/plugins/zentao/tasks/task_convertor.go
@@ -44,7 +44,7 @@ func ConvertTask(taskCtx core.SubTaskContext) errors.Error {
 	data := taskCtx.GetData().(*ZentaoTaskData)
 	db := taskCtx.GetDal()
 	storyIdGen := didgen.NewDomainIdGenerator(&models.ZentaoStory{})
-	boardIdGen := didgen.NewDomainIdGenerator(&models.ZentaoProduct{})
+	boardIdGen := didgen.NewDomainIdGenerator(&models.ZentaoExecution{})
 	taskIdGen := didgen.NewDomainIdGenerator(&models.ZentaoTask{})
 	cursor, err := db.Cursor(
 		dal.From(&models.ZentaoTask{}),


### PR DESCRIPTION
### Summary
Use models.ZentaoExecution as boardIdGen in taskConvertor

### Does this close any open issues?
Closes xx

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
