### PR TITLE
feat: github support scope and transformation rule

### DIFF
--- a/plugins/github/api/scope.go
+++ b/plugins/github/api/scope.go
@@ -1,0 +1,164 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/apache/incubator-devlake/errors"
+	"github.com/apache/incubator-devlake/plugins/core"
+	"github.com/apache/incubator-devlake/plugins/core/dal"
+	"github.com/apache/incubator-devlake/plugins/github/models"
+	"github.com/apache/incubator-devlake/plugins/helper"
+	"github.com/mitchellh/mapstructure"
+)
+
+// PutScope create or update github repo
+// @Summary create or update github repo
+// @Description Create or update github repo
+// @Tags plugins/github
+// @Accept application/json
+// @Param connectionId path int false "connection ID"
+// @Param repoId path int false "repo ID"
+// @Param scope body models.GithubRepo true "json"
+// @Success 200  {object} models.GithubRepo
+// @Failure 400  {object} shared.ApiBody "Bad Request"
+// @Failure 500  {object} shared.ApiBody "Internal Error"
+// @Router /plugins/github/connections/{connectionId}/scopes/{repoId} [PUT]
+func PutScope(input *core.ApiResourceInput) (*core.ApiResourceOutput, errors.Error) {
+	connectionId, repoId := extractParam(input.Params)
+	if connectionId*repoId == 0 {
+		return nil, errors.BadInput.New("invalid connectionId or repoId")
+	}
+	var repo models.GithubRepo
+	err := errors.Convert(mapstructure.Decode(input.Body, &repo))
+	if err != nil {
+		return nil, errors.BadInput.Wrap(err, "decoding Github repo error")
+	}
+	err = verifyRepo(&repo)
+	if err != nil {
+		return nil, err
+	}
+	err = basicRes.GetDal().CreateOrUpdate(repo)
+	if err != nil {
+		return nil, errors.Default.Wrap(err, "error on saving GithubRepo")
+	}
+	return &core.ApiResourceOutput{Body: repo, Status: http.StatusOK}, nil
+}
+
+// UpdateScope patch to github repo
+// @Summary patch to github repo
+// @Description patch to github repo
+// @Tags plugins/github
+// @Accept application/json
+// @Param connectionId path int false "connection ID"
+// @Param repoId path int false "repo ID"
+// @Param scope body models.GithubRepo true "json"
+// @Success 200  {object} models.GithubRepo
+// @Failure 400  {object} shared.ApiBody "Bad Request"
+// @Failure 500  {object} shared.ApiBody "Internal Error"
+// @Router /plugins/github/connections/{connectionId}/scopes/{repoId} [PATCH]
+func UpdateScope(input *core.ApiResourceInput) (*core.ApiResourceOutput, errors.Error) {
+	connectionId, repoId := extractParam(input.Params)
+	if connectionId*repoId == 0 {
+		return nil, errors.BadInput.New("invalid connectionId or repoId")
+	}
+	var repo models.GithubRepo
+	err := basicRes.GetDal().First(&repo, dal.Where("connection_id = ? AND github_id = ?", connectionId, repoId))
+	if err != nil {
+		return nil, errors.Default.Wrap(err, "getting GithubRepo error")
+	}
+	err = helper.DecodeMapStruct(input.Body, &repo)
+	if err != nil {
+		return nil, errors.Default.Wrap(err, "patch github repo error")
+	}
+	err = verifyRepo(&repo)
+	if err != nil {
+		return nil, err
+	}
+	err = basicRes.GetDal().Update(repo)
+	if err != nil {
+		return nil, errors.Default.Wrap(err, "error on saving GithubRepo")
+	}
+	return &core.ApiResourceOutput{Body: repo, Status: http.StatusOK}, nil
+}
+
+// GetScopeList get Github repos
+// @Summary get Github repos
+// @Description get Github repos
+// @Tags plugins/github
+// @Param connectionId path int false "connection ID"
+// @Success 200  {object} []models.GithubRepo
+// @Failure 400  {object} shared.ApiBody "Bad Request"
+// @Failure 500  {object} shared.ApiBody "Internal Error"
+// @Router /plugins/github/connections/{connectionId}/scopes/ [GET]
+func GetScopeList(input *core.ApiResourceInput) (*core.ApiResourceOutput, errors.Error) {
+	var repos []models.GithubRepo
+	connectionId, _ := extractParam(input.Params)
+	if connectionId == 0 {
+		return nil, errors.BadInput.New("invalid path params")
+	}
+	err := basicRes.GetDal().All(&repos, dal.Where("connection_id = ?", connectionId))
+	if err != nil {
+		return nil, err
+	}
+	return &core.ApiResourceOutput{Body: repos, Status: http.StatusOK}, nil
+}
+
+// GetScope get one Github repo
+// @Summary get one Github repo
+// @Description get one Github repo
+// @Tags plugins/github
+// @Param connectionId path int false "connection ID"
+// @Param repoId path int false "repo ID"
+// @Success 200  {object} models.GithubRepo
+// @Failure 400  {object} shared.ApiBody "Bad Request"
+// @Failure 500  {object} shared.ApiBody "Internal Error"
+// @Router /plugins/github/connections/{connectionId}/scopes/{repoId} [GET]
+func GetScope(input *core.ApiResourceInput) (*core.ApiResourceOutput, errors.Error) {
+	var repo models.GithubRepo
+	connectionId, repoId := extractParam(input.Params)
+	if connectionId*repoId == 0 {
+		return nil, errors.BadInput.New("invalid path params")
+	}
+	err := basicRes.GetDal().First(&repo, dal.Where("connection_id = ? AND github_id = ?", connectionId, repoId))
+	if err != nil {
+		return nil, err
+	}
+	return &core.ApiResourceOutput{Body: repo, Status: http.StatusOK}, nil
+}
+
+func extractParam(params map[string]string) (uint64, uint64) {
+	connectionId, _ := strconv.ParseUint(params["connectionId"], 10, 64)
+	repoId, _ := strconv.ParseUint(params["repoId"], 10, 64)
+	return connectionId, repoId
+}
+
+func verifyRepo(repo *models.GithubRepo) errors.Error {
+	if repo.ConnectionId == 0 {
+		return errors.BadInput.New("invalid connectionId")
+	}
+	if repo.GithubId == 0 {
+		return errors.BadInput.New("invalid repoId")
+	}
+	if repo.ScopeId != strconv.Itoa(repo.GithubId) {
+		return errors.BadInput.New("the scope_id does not match the github_id")
+	}
+	return nil
+}

--- a/plugins/github/api/transformation_rule.go
+++ b/plugins/github/api/transformation_rule.go
@@ -111,13 +111,16 @@ func GetTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOutpu
 // @Summary return all transformation rules
 // @Description return all transformation rules
 // @Tags plugins/github
+// @Param pageSize query int false "page size, default 50"
+// @Param page query int false "page size, default 1"
 // @Success 200  {object} []models.TransformationRules
 // @Failure 400  {object} shared.ApiBody "Bad Request"
 // @Failure 500  {object} shared.ApiBody "Internal Error"
 // @Router /plugins/github/transformation_rules [GET]
 func GetTransformationRuleList(input *core.ApiResourceInput) (*core.ApiResourceOutput, errors.Error) {
 	var rules []models.TransformationRules
-	err := basicRes.GetDal().All(&rules)
+	limit, offset := getLimitOffset(input.Query)
+	err := basicRes.GetDal().All(&rules, dal.Limit(limit), dal.Offset(offset))
 	if err != nil {
 		return nil, errors.Default.Wrap(err, "error on get TransformationRule list")
 	}

--- a/plugins/github/api/transformation_rule.go
+++ b/plugins/github/api/transformation_rule.go
@@ -1,0 +1,125 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/apache/incubator-devlake/errors"
+	"github.com/apache/incubator-devlake/plugins/core"
+	"github.com/apache/incubator-devlake/plugins/core/dal"
+	"github.com/apache/incubator-devlake/plugins/github/models"
+	"github.com/apache/incubator-devlake/plugins/helper"
+	"github.com/mitchellh/mapstructure"
+)
+
+// CreateTransformationRule create transformation rule for Github
+// @Summary create transformation rule for Github
+// @Description create transformation rule for Github
+// @Tags plugins/github
+// @Accept application/json
+// @Param transformationRule body models.TransformationRules true "transformation rule"
+// @Success 200  {object} models.TransformationRules
+// @Failure 400  {object} shared.ApiBody "Bad Request"
+// @Failure 500  {object} shared.ApiBody "Internal Error"
+// @Router /plugins/github/transformation_rules [POST]
+func CreateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOutput, errors.Error) {
+	var rule models.TransformationRules
+	err := mapstructure.Decode(input.Body, &rule)
+	if err != nil {
+		return nil, errors.Default.Wrap(err, "error in decoding transformation rule")
+	}
+	err = basicRes.GetDal().Create(&rule)
+	if err != nil {
+		return nil, errors.Default.Wrap(err, "error on saving TransformationRule")
+	}
+	return &core.ApiResourceOutput{Body: rule, Status: http.StatusOK}, nil
+}
+
+// UpdateTransformationRule update transformation rule for Github
+// @Summary update transformation rule for Github
+// @Description update transformation rule for Github
+// @Tags plugins/github
+// @Accept application/json
+// @Param id path int true "id"
+// @Param transformationRule body models.TransformationRules true "transformation rule"
+// @Success 200  {object} models.TransformationRules
+// @Failure 400  {object} shared.ApiBody "Bad Request"
+// @Failure 500  {object} shared.ApiBody "Internal Error"
+// @Router /plugins/github/transformation_rules/{id} [PATCH]
+func UpdateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOutput, errors.Error) {
+	transformationRuleId, err := strconv.ParseUint(input.Params["id"], 10, 64)
+	if err != nil {
+		return nil, errors.Default.Wrap(err, "the transformation rule ID should be an integer")
+	}
+	var old models.TransformationRules
+	err = basicRes.GetDal().First(&old, dal.Where("id = ?", transformationRuleId))
+	if err != nil {
+		return nil, errors.Default.Wrap(err, "error on saving TransformationRule")
+	}
+	err = helper.DecodeMapStruct(input.Body, &old)
+	if err != nil {
+		return nil, errors.Default.Wrap(err, "error decoding map into transformationRule")
+	}
+	old.ID = transformationRuleId
+	err = basicRes.GetDal().Update(&old, dal.Where("id = ?", transformationRuleId))
+	if err != nil {
+		return nil, errors.Default.Wrap(err, "error on saving TransformationRule")
+	}
+	return &core.ApiResourceOutput{Body: old, Status: http.StatusOK}, nil
+}
+
+// GetTransformationRule return one transformation rule
+// @Summary return one transformation rule
+// @Description return one transformation rule
+// @Tags plugins/github
+// @Param id path int true "id"
+// @Success 200  {object} models.TransformationRules
+// @Failure 400  {object} shared.ApiBody "Bad Request"
+// @Failure 500  {object} shared.ApiBody "Internal Error"
+// @Router /plugins/github/transformation_rules/{id} [GET]
+func GetTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOutput, errors.Error) {
+	transformationRuleId, err := strconv.ParseUint(input.Params["id"], 10, 64)
+	if err != nil {
+		return nil, errors.Default.Wrap(err, "the transformation rule ID should be an integer")
+	}
+	var rule models.TransformationRules
+	err = basicRes.GetDal().First(&rule, dal.Where("id = ?", transformationRuleId))
+	if err != nil {
+		return nil, errors.Default.Wrap(err, "error on get TransformationRule")
+	}
+	return &core.ApiResourceOutput{Body: rule, Status: http.StatusOK}, nil
+}
+
+// GetTransformationRuleList return all transformation rules
+// @Summary return all transformation rules
+// @Description return all transformation rules
+// @Tags plugins/github
+// @Success 200  {object} []models.TransformationRules
+// @Failure 400  {object} shared.ApiBody "Bad Request"
+// @Failure 500  {object} shared.ApiBody "Internal Error"
+// @Router /plugins/github/transformation_rules [GET]
+func GetTransformationRuleList(input *core.ApiResourceInput) (*core.ApiResourceOutput, errors.Error) {
+	var rules []models.TransformationRules
+	err := basicRes.GetDal().All(&rules)
+	if err != nil {
+		return nil, errors.Default.Wrap(err, "error on get TransformationRule list")
+	}
+	return &core.ApiResourceOutput{Body: rules, Status: http.StatusOK}, nil
+}

--- a/plugins/github/api/utils.go
+++ b/plugins/github/api/utils.go
@@ -1,0 +1,48 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"net/url"
+	"strconv"
+)
+
+const pageSize = 50
+
+func getPageParam(q url.Values) (int, int) {
+	var size, page int
+	if ps := q["pageSize"]; len(ps) > 0 {
+		size, _ = strconv.Atoi(ps[0])
+	}
+	if p := q["page"]; len(p) > 0 {
+		page, _ = strconv.Atoi(p[0])
+	}
+	if size < 1 {
+		size = pageSize
+	}
+	if page < 1 {
+		page = 1
+	}
+	return size, page
+}
+
+func getLimitOffset(q url.Values) (int, int) {
+	limit, page := getPageParam(q)
+	offset := (page - 1) * limit
+	return limit, offset
+}

--- a/plugins/github/e2e/cicd_test.go
+++ b/plugins/github/e2e/cicd_test.go
@@ -34,9 +34,10 @@ func TestGithubCICDDataFlow(t *testing.T) {
 
 	taskData := &tasks.GithubTaskData{
 		Options: &tasks.GithubOptions{
-			ConnectionId: 1,
-			Owner:        "panjf2000",
-			Repo:         "ants",
+			ConnectionId:        1,
+			Owner:               "panjf2000",
+			Repo:                "ants",
+			TransformationRules: new(models.TransformationRules),
 		},
 		Repo: &models.GithubRepo{
 			GithubId: 134018330,

--- a/plugins/github/e2e/comment_test.go
+++ b/plugins/github/e2e/comment_test.go
@@ -20,13 +20,12 @@ package e2e
 import (
 	"testing"
 
+	"github.com/apache/incubator-devlake/helpers/e2ehelper"
 	"github.com/apache/incubator-devlake/models/domainlayer/code"
 	"github.com/apache/incubator-devlake/models/domainlayer/ticket"
+	"github.com/apache/incubator-devlake/plugins/github/impl"
 	"github.com/apache/incubator-devlake/plugins/github/models"
 	"github.com/apache/incubator-devlake/plugins/github/tasks"
-
-	"github.com/apache/incubator-devlake/helpers/e2ehelper"
-	"github.com/apache/incubator-devlake/plugins/github/impl"
 )
 
 func TestCommentDataFlow(t *testing.T) {
@@ -41,7 +40,7 @@ func TestCommentDataFlow(t *testing.T) {
 			ConnectionId: 1,
 			Owner:        "panjf2000",
 			Repo:         "ants",
-			TransformationRules: models.TransformationRules{
+			TransformationRules: &models.TransformationRules{
 				PrType:               "type/(.*)$",
 				PrComponent:          "component/(.*)$",
 				PrBodyClosePattern:   "(?mi)(fix|close|resolve|fixes|closes|resolves|fixed|closed|resolved)[\\s]*.*(((and )?(#|https:\\/\\/github.com\\/%s\\/%s\\/issues\\/)\\d+[ ]*)+)",

--- a/plugins/github/e2e/issue_test.go
+++ b/plugins/github/e2e/issue_test.go
@@ -20,11 +20,10 @@ package e2e
 import (
 	"testing"
 
-	"github.com/apache/incubator-devlake/models/domainlayer/ticket"
-	"github.com/apache/incubator-devlake/plugins/github/models"
-
 	"github.com/apache/incubator-devlake/helpers/e2ehelper"
+	"github.com/apache/incubator-devlake/models/domainlayer/ticket"
 	"github.com/apache/incubator-devlake/plugins/github/impl"
+	"github.com/apache/incubator-devlake/plugins/github/models"
 	"github.com/apache/incubator-devlake/plugins/github/tasks"
 )
 
@@ -40,7 +39,7 @@ func TestIssueDataFlow(t *testing.T) {
 			ConnectionId: 1,
 			Owner:        "panjf2000",
 			Repo:         "ants",
-			TransformationRules: models.TransformationRules{
+			TransformationRules: &models.TransformationRules{
 				PrType:               "type/(.*)$",
 				PrComponent:          "component/(.*)$",
 				PrBodyClosePattern:   "(?mi)(fix|close|resolve|fixes|closes|resolves|fixed|closed|resolved)[\\s]*.*(((and )?(#|https:\\/\\/github.com\\/%s\\/%s\\/issues\\/)\\d+[ ]*)+)",

--- a/plugins/github/e2e/milestone_test.go
+++ b/plugins/github/e2e/milestone_test.go
@@ -44,7 +44,7 @@ func TestMilestoneDataFlow(t *testing.T) {
 			ConnectionId: 1,
 			Owner:        "panjf2000",
 			Repo:         "ants",
-			TransformationRules: models.TransformationRules{
+			TransformationRules: &models.TransformationRules{
 				PrType:               "type/(.*)$",
 				PrComponent:          "component/(.*)$",
 				PrBodyClosePattern:   "(?mi)(fix|close|resolve|fixes|closes|resolves|fixed|closed|resolved)[\\s]*.*(((and )?(#|https:\\/\\/github.com\\/%s\\/%s\\/issues\\/)\\d+[ ]*)+)",

--- a/plugins/github/e2e/pr_enrich_issue_test.go
+++ b/plugins/github/e2e/pr_enrich_issue_test.go
@@ -18,12 +18,12 @@ limitations under the License.
 package e2e
 
 import (
-	"github.com/apache/incubator-devlake/models/domainlayer/crossdomain"
-	"github.com/apache/incubator-devlake/plugins/github/models"
 	"testing"
 
 	"github.com/apache/incubator-devlake/helpers/e2ehelper"
+	"github.com/apache/incubator-devlake/models/domainlayer/crossdomain"
 	"github.com/apache/incubator-devlake/plugins/github/impl"
+	"github.com/apache/incubator-devlake/plugins/github/models"
 	"github.com/apache/incubator-devlake/plugins/github/tasks"
 )
 
@@ -39,7 +39,7 @@ func TestPrEnrichIssueDataFlow(t *testing.T) {
 			ConnectionId: 1,
 			Owner:        "panjf2000",
 			Repo:         "ants",
-			TransformationRules: models.TransformationRules{
+			TransformationRules: &models.TransformationRules{
 				PrType:               "type/(.*)$",
 				PrComponent:          "component/(.*)$",
 				PrBodyClosePattern:   "(?mi)(fix|close|resolve|fixes|closes|resolves|fixed|closed|resolved)[\\s]*.*(((and )?(#|https:\\/\\/github.com\\/%s\\/%s\\/issues\\/)\\d+[ ]*)+)",

--- a/plugins/github/e2e/pr_test.go
+++ b/plugins/github/e2e/pr_test.go
@@ -20,11 +20,10 @@ package e2e
 import (
 	"testing"
 
-	"github.com/apache/incubator-devlake/models/domainlayer/code"
-	"github.com/apache/incubator-devlake/plugins/github/models"
-
 	"github.com/apache/incubator-devlake/helpers/e2ehelper"
+	"github.com/apache/incubator-devlake/models/domainlayer/code"
 	"github.com/apache/incubator-devlake/plugins/github/impl"
+	"github.com/apache/incubator-devlake/plugins/github/models"
 	"github.com/apache/incubator-devlake/plugins/github/tasks"
 )
 
@@ -40,7 +39,7 @@ func TestPrDataFlow(t *testing.T) {
 			ConnectionId: 1,
 			Owner:        "panjf2000",
 			Repo:         "ants",
-			TransformationRules: models.TransformationRules{
+			TransformationRules: &models.TransformationRules{
 				PrType:             "type/(.*)$",
 				PrComponent:        "component/(.*)$",
 				PrBodyClosePattern: "(?mi)(fix|close|resolve|fixes|closes|resolves|fixed|closed|resolved)[\\s]*.*(((and )?(#|https:\\/\\/github.com\\/%s\\/%s\\/issues\\/)\\d+[ ]*)+)",

--- a/plugins/github/e2e/repo_test.go
+++ b/plugins/github/e2e/repo_test.go
@@ -18,17 +18,16 @@ limitations under the License.
 package e2e
 
 import (
-	"github.com/apache/incubator-devlake/models/common"
-	"github.com/apache/incubator-devlake/models/domainlayer/devops"
 	"testing"
 
+	"github.com/apache/incubator-devlake/helpers/e2ehelper"
+	"github.com/apache/incubator-devlake/models/common"
 	"github.com/apache/incubator-devlake/models/domainlayer/code"
 	"github.com/apache/incubator-devlake/models/domainlayer/crossdomain"
+	"github.com/apache/incubator-devlake/models/domainlayer/devops"
 	"github.com/apache/incubator-devlake/models/domainlayer/ticket"
-	"github.com/apache/incubator-devlake/plugins/github/models"
-
-	"github.com/apache/incubator-devlake/helpers/e2ehelper"
 	"github.com/apache/incubator-devlake/plugins/github/impl"
+	"github.com/apache/incubator-devlake/plugins/github/models"
 	"github.com/apache/incubator-devlake/plugins/github/tasks"
 )
 
@@ -44,7 +43,7 @@ func TestRepoDataFlow(t *testing.T) {
 			ConnectionId: 1,
 			Owner:        "panjf2000",
 			Repo:         "ants",
-			TransformationRules: models.TransformationRules{
+			TransformationRules: &models.TransformationRules{
 				PrType:      "type/(.*)$",
 				PrComponent: "component/(.*)$",
 			},

--- a/plugins/github/impl/impl.go
+++ b/plugins/github/impl/impl.go
@@ -40,8 +40,21 @@ var _ core.PluginApi = (*Github)(nil)
 var _ core.PluginModel = (*Github)(nil)
 var _ core.PluginBlueprintV100 = (*Github)(nil)
 var _ core.CloseablePluginTask = (*Github)(nil)
+var _ core.PluginSource = (*Github)(nil)
 
 type Github struct{}
+
+func (plugin Github) Connection() interface{} {
+	return &models.GithubConnection{}
+}
+
+func (plugin Github) Scope() interface{} {
+	return &models.GithubRepo{}
+}
+
+func (plugin Github) TransformationRule() interface{} {
+	return &models.TransformationRules{}
+}
 
 func (plugin Github) Init(config *viper.Viper, logger core.Logger, db *gorm.DB) errors.Error {
 	api.Init(config, logger, db)
@@ -81,6 +94,8 @@ func (plugin Github) Description() string {
 
 func (plugin Github) SubTaskMetas() []core.SubTaskMeta {
 	return []core.SubTaskMeta{
+		tasks.CollectApiRepoMeta,
+		tasks.ExtractApiRepoMeta,
 		tasks.CollectApiIssuesMeta,
 		tasks.ExtractApiIssuesMeta,
 		tasks.CollectApiPullRequestsMeta,

--- a/plugins/github/impl/impl.go
+++ b/plugins/github/impl/impl.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/plugins/core"
+	"github.com/apache/incubator-devlake/plugins/core/dal"
 	"github.com/apache/incubator-devlake/plugins/github/api"
 	"github.com/apache/incubator-devlake/plugins/github/models"
 	"github.com/apache/incubator-devlake/plugins/github/models/migrationscripts"
@@ -80,8 +81,6 @@ func (plugin Github) Description() string {
 
 func (plugin Github) SubTaskMetas() []core.SubTaskMeta {
 	return []core.SubTaskMeta{
-		tasks.CollectApiRepoMeta,
-		tasks.ExtractApiRepoMeta,
 		tasks.CollectApiIssuesMeta,
 		tasks.ExtractApiIssuesMeta,
 		tasks.CollectApiPullRequestsMeta,
@@ -153,7 +152,19 @@ func (plugin Github) PrepareTaskData(taskCtx core.TaskContext, options map[strin
 			return nil, errors.BadInput.Wrap(err, "invalid value for `since`")
 		}
 	}
-
+	if op.TransformationRules == nil && op.TransformationRuleId != 0 {
+		var transformationRule models.TransformationRules
+		err = taskCtx.GetDal().First(&transformationRule, dal.Where("id = ?", op.TransformationRuleId))
+		if err != nil {
+			return nil, errors.BadInput.Wrap(err, "fail to get transformationRule")
+		}
+		op.TransformationRules = &transformationRule
+	}
+	var repo models.GithubRepo
+	err = taskCtx.GetDal().First(&repo, dal.Where("name = ? AND owner_login = ", op.Repo, op.Owner))
+	if err != nil {
+		return nil, errors.BadInput.Wrap(err, "fail to get repo")
+	}
 	apiClient, err := tasks.CreateApiClient(taskCtx, connection)
 	if err != nil {
 		return nil, errors.Default.Wrap(err, "unable to get github API client instance")
@@ -161,6 +172,7 @@ func (plugin Github) PrepareTaskData(taskCtx core.TaskContext, options map[strin
 	taskData := &tasks.GithubTaskData{
 		Options:   op,
 		ApiClient: apiClient,
+		Repo:      &repo,
 	}
 
 	if !since.IsZero() {
@@ -191,6 +203,22 @@ func (plugin Github) ApiResources() map[string]map[string]core.ApiResourceHandle
 			"GET":    api.GetConnection,
 			"PATCH":  api.PatchConnection,
 			"DELETE": api.DeleteConnection,
+		},
+		"connections/:connectionId/scopes/:repoId": {
+			"GET":   api.GetScope,
+			"PUT":   api.PutScope,
+			"PATCH": api.UpdateScope,
+		},
+		"connections/:connectionId/scopes": {
+			"GET": api.GetScopeList,
+		},
+		"transformation_rules": {
+			"POST": api.CreateTransformationRule,
+			"GET":  api.GetTransformationRuleList,
+		},
+		"transformation_rules/:id": {
+			"PATCH": api.UpdateTransformationRule,
+			"GET":   api.GetTransformationRule,
 		},
 		"connections/:connectionId/proxy/rest/*path": {
 			"GET": api.Proxy,

--- a/plugins/github/models/connection.go
+++ b/plugins/github/models/connection.go
@@ -33,19 +33,6 @@ type GithubConnection struct {
 	EnableGraphql         bool `mapstructure:"enableGraphql" json:"enableGraphql"`
 }
 
-type TransformationRules struct {
-	PrType               string `mapstructure:"prType" json:"prType"`
-	PrComponent          string `mapstructure:"prComponent" json:"prComponent"`
-	PrBodyClosePattern   string `mapstructure:"prBodyClosePattern" json:"prBodyClosePattern"`
-	IssueSeverity        string `mapstructure:"issueSeverity" json:"issueSeverity"`
-	IssuePriority        string `mapstructure:"issuePriority" json:"issuePriority"`
-	IssueComponent       string `mapstructure:"issueComponent" json:"issueComponent"`
-	IssueTypeBug         string `mapstructure:"issueTypeBug" json:"issueTypeBug"`
-	IssueTypeIncident    string `mapstructure:"issueTypeIncident" json:"issueTypeIncident"`
-	IssueTypeRequirement string `mapstructure:"issueTypeRequirement" json:"issueTypeRequirement"`
-	DeploymentPattern    string `mapstructure:"deploymentPattern" json:"deploymentPattern"`
-}
-
 func (GithubConnection) TableName() string {
 	return "_tool_github_connections"
 }

--- a/plugins/github/models/migrationscripts/20221116_add_trasformation_rule_table.go
+++ b/plugins/github/models/migrationscripts/20221116_add_trasformation_rule_table.go
@@ -1,0 +1,48 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"github.com/apache/incubator-devlake/errors"
+	"github.com/apache/incubator-devlake/helpers/migrationhelper"
+	"github.com/apache/incubator-devlake/plugins/core"
+	"github.com/apache/incubator-devlake/plugins/github/models/migrationscripts/archived"
+)
+
+type githubRepo20221124 struct {
+	TransformationRuleId uint64
+	ScopeId              string `gorm:"type:varchar(255)"`
+}
+
+func (githubRepo20221124) TableName() string {
+	return "_tool_github_repos"
+}
+
+type addTransformationRule20221124 struct{}
+
+func (*addTransformationRule20221124) Up(basicRes core.BasicRes) errors.Error {
+	return migrationhelper.AutoMigrateTables(basicRes, &githubRepo20221124{}, &archived.TransformationRules{})
+}
+
+func (*addTransformationRule20221124) Version() uint64 {
+	return 20221124095900
+}
+
+func (*addTransformationRule20221124) Name() string {
+	return "add table _tool_github_transformation_rules, add transformation_rule_id to _tool_github_repos"
+}

--- a/plugins/github/models/migrationscripts/20221124_add_trasformation_rule_table.go
+++ b/plugins/github/models/migrationscripts/20221124_add_trasformation_rule_table.go
@@ -26,7 +26,6 @@ import (
 
 type githubRepo20221124 struct {
 	TransformationRuleId uint64
-	ScopeId              string `gorm:"type:varchar(255)"`
 }
 
 func (githubRepo20221124) TableName() string {

--- a/plugins/github/models/migrationscripts/archived/transformation_rules.go
+++ b/plugins/github/models/migrationscripts/archived/transformation_rules.go
@@ -18,21 +18,24 @@ limitations under the License.
 package archived
 
 import (
+	"encoding/json"
+
 	"github.com/apache/incubator-devlake/models/migrationscripts/archived"
 )
 
 type TransformationRules struct {
 	archived.Model
-	PrType               string `mapstructure:"prType" json:"prType" gorm:"type:varchar(255)"`
-	PrComponent          string `mapstructure:"prComponent" json:"prComponent" gorm:"type:varchar(255)"`
-	PrBodyClosePattern   string `mapstructure:"prBodyClosePattern" json:"prBodyClosePattern" gorm:"type:varchar(255)"`
-	IssueSeverity        string `mapstructure:"issueSeverity" json:"issueSeverity" gorm:"type:varchar(255)"`
-	IssuePriority        string `mapstructure:"issuePriority" json:"issuePriority" gorm:"type:varchar(255)"`
-	IssueComponent       string `mapstructure:"issueComponent" json:"issueComponent" gorm:"type:varchar(255)"`
-	IssueTypeBug         string `mapstructure:"issueTypeBug" json:"issueTypeBug" gorm:"type:varchar(255)"`
-	IssueTypeIncident    string `mapstructure:"issueTypeIncident" json:"issueTypeIncident" gorm:"type:varchar(255)"`
-	IssueTypeRequirement string `mapstructure:"issueTypeRequirement" json:"issueTypeRequirement" gorm:"type:varchar(255)"`
-	DeploymentPattern    string `mapstructure:"deploymentPattern" json:"deploymentPattern" gorm:"type:varchar(255)"`
+	PrType               string          `mapstructure:"prType" json:"prType" gorm:"type:varchar(255)"`
+	PrComponent          string          `mapstructure:"prComponent" json:"prComponent" gorm:"type:varchar(255)"`
+	PrBodyClosePattern   string          `mapstructure:"prBodyClosePattern" json:"prBodyClosePattern" gorm:"type:varchar(255)"`
+	IssueSeverity        string          `mapstructure:"issueSeverity" json:"issueSeverity" gorm:"type:varchar(255)"`
+	IssuePriority        string          `mapstructure:"issuePriority" json:"issuePriority" gorm:"type:varchar(255)"`
+	IssueComponent       string          `mapstructure:"issueComponent" json:"issueComponent" gorm:"type:varchar(255)"`
+	IssueTypeBug         string          `mapstructure:"issueTypeBug" json:"issueTypeBug" gorm:"type:varchar(255)"`
+	IssueTypeIncident    string          `mapstructure:"issueTypeIncident" json:"issueTypeIncident" gorm:"type:varchar(255)"`
+	IssueTypeRequirement string          `mapstructure:"issueTypeRequirement" json:"issueTypeRequirement" gorm:"type:varchar(255)"`
+	DeploymentPattern    string          `mapstructure:"deploymentPattern" json:"deploymentPattern" gorm:"type:varchar(255)"`
+	RefdiffRule          json.RawMessage `mapstructure:"refdiffRule" json:"refdiffRule"`
 }
 
 func (TransformationRules) TableName() string {

--- a/plugins/github/models/migrationscripts/archived/transformation_rules.go
+++ b/plugins/github/models/migrationscripts/archived/transformation_rules.go
@@ -1,0 +1,40 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package archived
+
+import (
+	"github.com/apache/incubator-devlake/models/migrationscripts/archived"
+)
+
+type TransformationRules struct {
+	archived.Model
+	PrType               string `mapstructure:"prType" json:"prType" gorm:"type:varchar(255)"`
+	PrComponent          string `mapstructure:"prComponent" json:"prComponent" gorm:"type:varchar(255)"`
+	PrBodyClosePattern   string `mapstructure:"prBodyClosePattern" json:"prBodyClosePattern" gorm:"type:varchar(255)"`
+	IssueSeverity        string `mapstructure:"issueSeverity" json:"issueSeverity" gorm:"type:varchar(255)"`
+	IssuePriority        string `mapstructure:"issuePriority" json:"issuePriority" gorm:"type:varchar(255)"`
+	IssueComponent       string `mapstructure:"issueComponent" json:"issueComponent" gorm:"type:varchar(255)"`
+	IssueTypeBug         string `mapstructure:"issueTypeBug" json:"issueTypeBug" gorm:"type:varchar(255)"`
+	IssueTypeIncident    string `mapstructure:"issueTypeIncident" json:"issueTypeIncident" gorm:"type:varchar(255)"`
+	IssueTypeRequirement string `mapstructure:"issueTypeRequirement" json:"issueTypeRequirement" gorm:"type:varchar(255)"`
+	DeploymentPattern    string `mapstructure:"deploymentPattern" json:"deploymentPattern" gorm:"type:varchar(255)"`
+}
+
+func (TransformationRules) TableName() string {
+	return "_tool_github_transformation_rules"
+}

--- a/plugins/github/models/migrationscripts/register.go
+++ b/plugins/github/models/migrationscripts/register.go
@@ -31,5 +31,6 @@ func All() []core.MigrationScript {
 		new(deleteGithubPipelineTable),
 		new(addHeadRepoIdFieldInGithubPr),
 		new(addEnableGraphqlForConnection),
+		new(addTransformationRule20221124),
 	}
 }

--- a/plugins/github/models/repo.go
+++ b/plugins/github/models/repo.go
@@ -25,7 +25,6 @@ import (
 type GithubRepo struct {
 	ConnectionId         uint64 `gorm:"primaryKey"`
 	GithubId             int    `gorm:"primaryKey"`
-	ScopeId              string `gorm:"type:varchar(255)"`
 	TransformationRuleId uint64
 	Name                 string `gorm:"type:varchar(255)"`
 	HTMLUrl              string `gorm:"type:varchar(255)"`

--- a/plugins/github/models/repo.go
+++ b/plugins/github/models/repo.go
@@ -23,18 +23,20 @@ import (
 )
 
 type GithubRepo struct {
-	ConnectionId   uint64 `gorm:"primaryKey"`
-	GithubId       int    `gorm:"primaryKey"`
-	Name           string `gorm:"type:varchar(255)"`
-	HTMLUrl        string `gorm:"type:varchar(255)"`
-	Description    string
-	OwnerId        int        `json:"ownerId"`
-	OwnerLogin     string     `json:"ownerLogin" gorm:"type:varchar(255)"`
-	Language       string     `json:"language" gorm:"type:varchar(255)"`
-	ParentGithubId int        `json:"parentId"`
-	ParentHTMLUrl  string     `json:"parentHtmlUrl"`
-	CreatedDate    time.Time  `json:"createdDate"`
-	UpdatedDate    *time.Time `json:"updatedDate"`
+	ConnectionId         uint64 `gorm:"primaryKey"`
+	GithubId             int    `gorm:"primaryKey"`
+	ScopeId              string `gorm:"type:varchar(255)"`
+	TransformationRuleId uint64
+	Name                 string `gorm:"type:varchar(255)"`
+	HTMLUrl              string `gorm:"type:varchar(255)"`
+	Description          string
+	OwnerId              int        `json:"ownerId"`
+	OwnerLogin           string     `json:"ownerLogin" gorm:"type:varchar(255)"`
+	Language             string     `json:"language" gorm:"type:varchar(255)"`
+	ParentGithubId       int        `json:"parentId"`
+	ParentHTMLUrl        string     `json:"parentHtmlUrl"`
+	CreatedDate          time.Time  `json:"createdDate"`
+	UpdatedDate          *time.Time `json:"updatedDate"`
 	common.NoPKModel
 }
 

--- a/plugins/github/models/transformation_rule.go
+++ b/plugins/github/models/transformation_rule.go
@@ -17,20 +17,25 @@ limitations under the License.
 
 package models
 
-import "github.com/apache/incubator-devlake/models/common"
+import (
+	"encoding/json"
+
+	"github.com/apache/incubator-devlake/models/common"
+)
 
 type TransformationRules struct {
 	common.Model
-	PrType               string `mapstructure:"prType" json:"prType" gorm:"type:varchar(255)"`
-	PrComponent          string `mapstructure:"prComponent" json:"prComponent" gorm:"type:varchar(255)"`
-	PrBodyClosePattern   string `mapstructure:"prBodyClosePattern" json:"prBodyClosePattern" gorm:"type:varchar(255)"`
-	IssueSeverity        string `mapstructure:"issueSeverity" json:"issueSeverity" gorm:"type:varchar(255)"`
-	IssuePriority        string `mapstructure:"issuePriority" json:"issuePriority" gorm:"type:varchar(255)"`
-	IssueComponent       string `mapstructure:"issueComponent" json:"issueComponent" gorm:"type:varchar(255)"`
-	IssueTypeBug         string `mapstructure:"issueTypeBug" json:"issueTypeBug" gorm:"type:varchar(255)"`
-	IssueTypeIncident    string `mapstructure:"issueTypeIncident" json:"issueTypeIncident" gorm:"type:varchar(255)"`
-	IssueTypeRequirement string `mapstructure:"issueTypeRequirement" json:"issueTypeRequirement" gorm:"type:varchar(255)"`
-	DeploymentPattern    string `mapstructure:"deploymentPattern" json:"deploymentPattern" gorm:"type:varchar(255)"`
+	PrType               string          `mapstructure:"prType" json:"prType" gorm:"type:varchar(255)"`
+	PrComponent          string          `mapstructure:"prComponent" json:"prComponent" gorm:"type:varchar(255)"`
+	PrBodyClosePattern   string          `mapstructure:"prBodyClosePattern" json:"prBodyClosePattern" gorm:"type:varchar(255)"`
+	IssueSeverity        string          `mapstructure:"issueSeverity" json:"issueSeverity" gorm:"type:varchar(255)"`
+	IssuePriority        string          `mapstructure:"issuePriority" json:"issuePriority" gorm:"type:varchar(255)"`
+	IssueComponent       string          `mapstructure:"issueComponent" json:"issueComponent" gorm:"type:varchar(255)"`
+	IssueTypeBug         string          `mapstructure:"issueTypeBug" json:"issueTypeBug" gorm:"type:varchar(255)"`
+	IssueTypeIncident    string          `mapstructure:"issueTypeIncident" json:"issueTypeIncident" gorm:"type:varchar(255)"`
+	IssueTypeRequirement string          `mapstructure:"issueTypeRequirement" json:"issueTypeRequirement" gorm:"type:varchar(255)"`
+	DeploymentPattern    string          `mapstructure:"deploymentPattern" json:"deploymentPattern" gorm:"type:varchar(255)"`
+	RefdiffRule          json.RawMessage `mapstructure:"refdiffRule" json:"refdiffRule"`
 }
 
 func (TransformationRules) TableName() string {

--- a/plugins/github/models/transformation_rule.go
+++ b/plugins/github/models/transformation_rule.go
@@ -1,0 +1,38 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package models
+
+import "github.com/apache/incubator-devlake/models/common"
+
+type TransformationRules struct {
+	common.Model
+	PrType               string `mapstructure:"prType" json:"prType" gorm:"type:varchar(255)"`
+	PrComponent          string `mapstructure:"prComponent" json:"prComponent" gorm:"type:varchar(255)"`
+	PrBodyClosePattern   string `mapstructure:"prBodyClosePattern" json:"prBodyClosePattern" gorm:"type:varchar(255)"`
+	IssueSeverity        string `mapstructure:"issueSeverity" json:"issueSeverity" gorm:"type:varchar(255)"`
+	IssuePriority        string `mapstructure:"issuePriority" json:"issuePriority" gorm:"type:varchar(255)"`
+	IssueComponent       string `mapstructure:"issueComponent" json:"issueComponent" gorm:"type:varchar(255)"`
+	IssueTypeBug         string `mapstructure:"issueTypeBug" json:"issueTypeBug" gorm:"type:varchar(255)"`
+	IssueTypeIncident    string `mapstructure:"issueTypeIncident" json:"issueTypeIncident" gorm:"type:varchar(255)"`
+	IssueTypeRequirement string `mapstructure:"issueTypeRequirement" json:"issueTypeRequirement" gorm:"type:varchar(255)"`
+	DeploymentPattern    string `mapstructure:"deploymentPattern" json:"deploymentPattern" gorm:"type:varchar(255)"`
+}
+
+func (TransformationRules) TableName() string {
+	return "_tool_github_transformation_rules"
+}

--- a/plugins/github/tasks/issue_extractor.go
+++ b/plugins/github/tasks/issue_extractor.go
@@ -223,7 +223,7 @@ func convertGithubLabels(issueRegexes *IssueRegexes, issue *IssuesResponse, gith
 	return results, nil
 }
 
-func NewIssueRegexes(config models.TransformationRules) (*IssueRegexes, errors.Error) {
+func NewIssueRegexes(config *models.TransformationRules) (*IssueRegexes, errors.Error) {
 	var issueRegexes IssueRegexes
 	var issueSeverity = config.IssueSeverity
 	var err error

--- a/plugins/github/tasks/repo_extractor.go
+++ b/plugins/github/tasks/repo_extractor.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/apache/incubator-devlake/errors"
+	"strconv"
 
 	"github.com/apache/incubator-devlake/plugins/core"
 	"github.com/apache/incubator-devlake/plugins/github/models"
@@ -81,6 +82,7 @@ func ExtractApiRepositories(taskCtx core.SubTaskContext) errors.Error {
 			results := make([]interface{}, 0, 1)
 			githubRepository := &models.GithubRepo{
 				ConnectionId: data.Options.ConnectionId,
+				ScopeId:      strconv.Itoa(body.GithubId),
 				GithubId:     body.GithubId,
 				Name:         body.Name,
 				HTMLUrl:      body.HTMLUrl,

--- a/plugins/github/tasks/repo_extractor.go
+++ b/plugins/github/tasks/repo_extractor.go
@@ -21,8 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/apache/incubator-devlake/errors"
-	"strconv"
-
 	"github.com/apache/incubator-devlake/plugins/core"
 	"github.com/apache/incubator-devlake/plugins/github/models"
 	"github.com/apache/incubator-devlake/plugins/helper"
@@ -82,7 +80,6 @@ func ExtractApiRepositories(taskCtx core.SubTaskContext) errors.Error {
 			results := make([]interface{}, 0, 1)
 			githubRepository := &models.GithubRepo{
 				ConnectionId: data.Options.ConnectionId,
-				ScopeId:      strconv.Itoa(body.GithubId),
 				GithubId:     body.GithubId,
 				Name:         body.Name,
 				HTMLUrl:      body.HTMLUrl,

--- a/plugins/github/tasks/task_data.go
+++ b/plugins/github/tasks/task_data.go
@@ -27,12 +27,13 @@ import (
 )
 
 type GithubOptions struct {
-	ConnectionId               uint64   `json:"connectionId"`
-	Tasks                      []string `json:"tasks,omitempty"`
-	Since                      string
-	Owner                      string
-	Repo                       string
-	models.TransformationRules `mapstructure:"transformationRules" json:"transformationRules"`
+	ConnectionId                uint64   `json:"connectionId"`
+	TransformationRuleId        uint64   `json:"transformationRuleId"`
+	Tasks                       []string `json:"tasks,omitempty"`
+	Since                       string
+	Owner                       string
+	Repo                        string
+	*models.TransformationRules `mapstructure:"transformationRules" json:"transformationRules"`
 }
 
 type GithubTaskData struct {
@@ -55,40 +56,43 @@ func DecodeAndValidateTaskOptions(options map[string]interface{}) (*GithubOption
 	if op.Repo == "" {
 		return nil, errors.BadInput.New("repo is required for GitHub execution")
 	}
-	if op.PrType == "" {
-		op.PrType = "type/(.*)$"
-	}
-	if op.PrComponent == "" {
-		op.PrComponent = "component/(.*)$"
-	}
-	if op.PrBodyClosePattern == "" {
-		op.PrBodyClosePattern = "(?mi)(fix|close|resolve|fixes|closes|resolves|fixed|closed|resolved)[\\s]*.*(((and )?(#|https:\\/\\/github.com\\/%s\\/%s\\/issues\\/)\\d+[ ]*)+)"
-	}
-	if op.IssueSeverity == "" {
-		op.IssueSeverity = "severity/(.*)$"
-	}
-	if op.IssuePriority == "" {
-		op.IssuePriority = "^(highest|high|medium|low)$"
-	}
-	if op.IssueComponent == "" {
-		op.IssueComponent = "component/(.*)$"
-	}
-	if op.IssueTypeBug == "" {
-		op.IssueTypeBug = "^(bug|failure|error)$"
-	}
-	if op.IssueTypeIncident == "" {
-		op.IssueTypeIncident = ""
-	}
-	if op.IssueTypeRequirement == "" {
-		op.IssueTypeRequirement = "^(feat|feature|proposal|requirement)$"
-	}
-	if op.DeploymentPattern == "" {
-		op.DeploymentPattern = "(?i)deploy"
-	}
-
 	// find the needed GitHub now
 	if op.ConnectionId == 0 {
 		return nil, errors.BadInput.New("connectionId is invalid")
 	}
+	if op.TransformationRules == nil && op.TransformationRuleId == 0 {
+		op.TransformationRules = new(models.TransformationRules)
+		if op.PrType == "" {
+			op.PrType = "type/(.*)$"
+		}
+		if op.PrComponent == "" {
+			op.PrComponent = "component/(.*)$"
+		}
+		if op.PrBodyClosePattern == "" {
+			op.PrBodyClosePattern = "(?mi)(fix|close|resolve|fixes|closes|resolves|fixed|closed|resolved)[\\s]*.*(((and )?(#|https:\\/\\/github.com\\/%s\\/%s\\/issues\\/)\\d+[ ]*)+)"
+		}
+		if op.IssueSeverity == "" {
+			op.IssueSeverity = "severity/(.*)$"
+		}
+		if op.IssuePriority == "" {
+			op.IssuePriority = "^(highest|high|medium|low)$"
+		}
+		if op.IssueComponent == "" {
+			op.IssueComponent = "component/(.*)$"
+		}
+		if op.IssueTypeBug == "" {
+			op.IssueTypeBug = "^(bug|failure|error)$"
+		}
+		if op.IssueTypeIncident == "" {
+			op.IssueTypeIncident = ""
+		}
+		if op.IssueTypeRequirement == "" {
+			op.IssueTypeRequirement = "^(feat|feature|proposal|requirement)$"
+		}
+		if op.DeploymentPattern == "" {
+			op.DeploymentPattern = "(?i)deploy"
+		}
+	}
+
 	return &op, nil
 }

--- a/plugins/github/tasks/task_data.go
+++ b/plugins/github/tasks/task_data.go
@@ -62,37 +62,6 @@ func DecodeAndValidateTaskOptions(options map[string]interface{}) (*GithubOption
 	}
 	if op.TransformationRules == nil && op.TransformationRuleId == 0 {
 		op.TransformationRules = new(models.TransformationRules)
-		if op.PrType == "" {
-			op.PrType = "type/(.*)$"
-		}
-		if op.PrComponent == "" {
-			op.PrComponent = "component/(.*)$"
-		}
-		if op.PrBodyClosePattern == "" {
-			op.PrBodyClosePattern = "(?mi)(fix|close|resolve|fixes|closes|resolves|fixed|closed|resolved)[\\s]*.*(((and )?(#|https:\\/\\/github.com\\/%s\\/%s\\/issues\\/)\\d+[ ]*)+)"
-		}
-		if op.IssueSeverity == "" {
-			op.IssueSeverity = "severity/(.*)$"
-		}
-		if op.IssuePriority == "" {
-			op.IssuePriority = "^(highest|high|medium|low)$"
-		}
-		if op.IssueComponent == "" {
-			op.IssueComponent = "component/(.*)$"
-		}
-		if op.IssueTypeBug == "" {
-			op.IssueTypeBug = "^(bug|failure|error)$"
-		}
-		if op.IssueTypeIncident == "" {
-			op.IssueTypeIncident = ""
-		}
-		if op.IssueTypeRequirement == "" {
-			op.IssueTypeRequirement = "^(feat|feature|proposal|requirement)$"
-		}
-		if op.DeploymentPattern == "" {
-			op.DeploymentPattern = "(?i)deploy"
-		}
 	}
-
 	return &op, nil
 }

--- a/plugins/jira/api/scope.go
+++ b/plugins/jira/api/scope.go
@@ -157,8 +157,5 @@ func verifyBoard(board *models.JiraBoard) errors.Error {
 	if board.BoardId == 0 {
 		return errors.BadInput.New("invalid boardId")
 	}
-	if board.ScopeId != strconv.FormatUint(board.BoardId, 10) {
-		return errors.BadInput.New("the scope_id does not match the board_id")
-	}
 	return nil
 }

--- a/plugins/jira/impl/impl.go
+++ b/plugins/jira/impl/impl.go
@@ -95,6 +95,9 @@ func (plugin Jira) Description() string {
 
 func (plugin Jira) SubTaskMetas() []core.SubTaskMeta {
 	return []core.SubTaskMeta{
+		tasks.CollectBoardMeta,
+		tasks.ExtractBoardMeta,
+
 		tasks.CollectStatusMeta,
 		tasks.ExtractStatusMeta,
 

--- a/plugins/jira/models/board.go
+++ b/plugins/jira/models/board.go
@@ -25,7 +25,6 @@ type JiraBoard struct {
 	common.NoPKModel
 	ConnectionId         uint64 `gorm:"primaryKey"`
 	BoardId              uint64 `gorm:"primaryKey"`
-	ScopeId              string `gorm:"type:varchar(255)"`
 	TransformationRuleId uint64
 	ProjectId            uint
 	Name                 string `gorm:"type:varchar(255)"`

--- a/plugins/jira/models/board.go
+++ b/plugins/jira/models/board.go
@@ -25,7 +25,7 @@ type JiraBoard struct {
 	common.NoPKModel
 	ConnectionId         uint64 `gorm:"primaryKey"`
 	BoardId              uint64 `gorm:"primaryKey"`
-	ScopeId              string
+	ScopeId              string `gorm:"type:varchar(255)"`
 	TransformationRuleId uint64
 	ProjectId            uint
 	Name                 string `gorm:"type:varchar(255)"`

--- a/plugins/jira/models/migrationscripts/20221116_add_trasformation_rule_table.go
+++ b/plugins/jira/models/migrationscripts/20221116_add_trasformation_rule_table.go
@@ -26,7 +26,6 @@ import (
 
 type jiraBoard20221116 struct {
 	TransformationRuleId uint64
-	ScopeId              string `gorm:"type:varchar(255)"`
 }
 
 func (jiraBoard20221116) TableName() string {

--- a/plugins/jira/models/migrationscripts/archived/transformation_rules.go
+++ b/plugins/jira/models/migrationscripts/archived/transformation_rules.go
@@ -30,3 +30,7 @@ type JiraTransformationRule struct {
 	RemotelinkCommitShaPattern string          `json:"remotelinkCommitShaPattern" gorm:"type:varchar(255)"`
 	TypeMappings               json.RawMessage `json:"typeMappings"`
 }
+
+func (JiraTransformationRule) TableName() string {
+	return "_tool_jira_transformation_rules"
+}

--- a/plugins/jira/models/transformation_rules.go
+++ b/plugins/jira/models/transformation_rules.go
@@ -30,3 +30,7 @@ type JiraTransformationRule struct {
 	RemotelinkCommitShaPattern string          `json:"remotelinkCommitShaPattern" gorm:"type:varchar(255)"`
 	TypeMappings               json.RawMessage `json:"typeMappings"`
 }
+
+func (JiraTransformationRule) TableName() string {
+	return "_tool_jira_transformation_rules"
+}


### PR DESCRIPTION
### Summary
1. add table `_tool_github_transformation_rules`
2. add `transformation_rule_id`  to `_tool_github_repos`
3. remove default transformation rules
4. supply HTTP endpoints for the entities `transformation rules` and `GitHub repos`


### Does this close any open issues?
No, partially fulfilled issue #3468

### Screenshots
![image](https://user-images.githubusercontent.com/8455907/203881618-f98f363f-4513-4e91-bab5-f922de36c3ff.png)
![image](https://user-images.githubusercontent.com/8455907/203881634-51ee2c7f-1cbf-42f5-a0e9-0c9783870669.png)


