### PR TITLE
fix: set `DomainTypes` for PR review comment

### DIFF
--- a/plugins/github/tasks/pr_review_comment_collector.go
+++ b/plugins/github/tasks/pr_review_comment_collector.go
@@ -110,5 +110,5 @@ var CollectApiPrReviewCommentsMeta = core.SubTaskMeta{
 	EntryPoint:       CollectPrReviewComments,
 	EnabledByDefault: true,
 	Description:      "Collect pr review comments data from Github api",
-	DomainTypes:      []string{core.DOMAIN_TYPE_CODE},
+	DomainTypes:      []string{core.DOMAIN_TYPE_CODE_REVIEW},
 }

--- a/plugins/github/tasks/pr_review_comment_extractor.go
+++ b/plugins/github/tasks/pr_review_comment_extractor.go
@@ -38,7 +38,7 @@ var ExtractApiPrReviewCommentsMeta = core.SubTaskMeta{
 	EnabledByDefault: true,
 	Description: "Extract raw comment data  into tool layer table github_pull_request_comments" +
 		"and github_issue_comments",
-	DomainTypes: []string{core.DOMAIN_TYPE_CODE},
+	DomainTypes: []string{core.DOMAIN_TYPE_CODE_REVIEW},
 }
 
 func ExtractApiPrReviewComments(taskCtx core.SubTaskContext) errors.Error {


### PR DESCRIPTION
### Summary
fix #3720 ([Bug][Pipeline] GitHub pipeline failed when only CODE entities were specified)

The reason for the bug was described in the comment on the original issue #3720, from where the quote below was taken 

> The error was caused by the missing records in the table `_tool_github_pull_requests` during extracting PR review comments. Every subtask belongs to some domain type, for `ExtractApiPrReviewComments` it is `CODE`, and for `CollectApiPullRequests` it is `CODEREVIEW`. If we only collect the `CODE` entities, the pull requests will not be collected, this caused the original error. To fix this problem we need to set the domain type of `CollectApiPullRequests` to `CODEREVIEW`, in the same way as `CollectApiPullRequests`

1. set `DomainTypes` of `CollectApiPrReviewCommentsMeta` to `CODEREVIEW`
2. set `DomainTypes` of `ExtractApiPrReviewCommentsMeta` to `CODEREVIEW`

### Does this close any open issues?
Closes #3720 

