### PR TITLE
fix(github): update domain types for subtasks

### DIFF
--- a/plugins/github/tasks/repo_collector.go
+++ b/plugins/github/tasks/repo_collector.go
@@ -37,7 +37,7 @@ var CollectApiRepoMeta = core.SubTaskMeta{
 	EntryPoint:  CollectApiRepositories,
 	Required:    true,
 	Description: "Collect repositories data from Github api",
-	DomainTypes: []string{core.DOMAIN_TYPE_CODE},
+	DomainTypes: []string{core.DOMAIN_TYPE_CODE, core.DOMAIN_TYPE_TICKET, core.DOMAIN_TYPE_CICD, core.DOMAIN_TYPE_CODE_REVIEW, core.DOMAIN_TYPE_CROSS},
 }
 
 func CollectApiRepositories(taskCtx core.SubTaskContext) errors.Error {

--- a/plugins/github/tasks/repo_convertor.go
+++ b/plugins/github/tasks/repo_convertor.go
@@ -40,7 +40,7 @@ var ConvertRepoMeta = core.SubTaskMeta{
 	EntryPoint:       ConvertRepo,
 	EnabledByDefault: true,
 	Description:      "Convert tool layer table github_repos into  domain layer table repos and boards",
-	DomainTypes:      []string{core.DOMAIN_TYPE_CODE},
+	DomainTypes:      []string{core.DOMAIN_TYPE_CODE, core.DOMAIN_TYPE_TICKET, core.DOMAIN_TYPE_CICD, core.DOMAIN_TYPE_CODE_REVIEW, core.DOMAIN_TYPE_CROSS},
 }
 
 func ConvertRepo(taskCtx core.SubTaskContext) errors.Error {

--- a/plugins/github/tasks/repo_extractor.go
+++ b/plugins/github/tasks/repo_extractor.go
@@ -31,7 +31,7 @@ var ExtractApiRepoMeta = core.SubTaskMeta{
 	EntryPoint:  ExtractApiRepositories,
 	Required:    true,
 	Description: "Extract raw Repositories data into tool layer table github_repos",
-	DomainTypes: []string{core.DOMAIN_TYPE_CODE},
+	DomainTypes: []string{core.DOMAIN_TYPE_CODE, core.DOMAIN_TYPE_TICKET, core.DOMAIN_TYPE_CICD, core.DOMAIN_TYPE_CODE_REVIEW, core.DOMAIN_TYPE_CROSS},
 }
 
 type ApiRepoResponse GithubApiRepo

--- a/plugins/github_graphql/tasks/repo_collector.go
+++ b/plugins/github_graphql/tasks/repo_collector.go
@@ -60,7 +60,7 @@ var CollectRepoMeta = core.SubTaskMeta{
 	EntryPoint:       CollectRepo,
 	EnabledByDefault: true,
 	Description:      "Collect Repo data from GithubGraphql api",
-	DomainTypes:      []string{core.DOMAIN_TYPE_CODE},
+	DomainTypes:      []string{core.DOMAIN_TYPE_CODE, core.DOMAIN_TYPE_TICKET, core.DOMAIN_TYPE_CICD, core.DOMAIN_TYPE_CODE_REVIEW, core.DOMAIN_TYPE_CROSS},
 }
 
 func CollectRepo(taskCtx core.SubTaskContext) errors.Error {

--- a/services/blueprint_makeplan_v100.go
+++ b/services/blueprint_makeplan_v100.go
@@ -69,7 +69,7 @@ func GeneratePlanJsonV100(settings *models.BlueprintSettings) (core.PipelinePlan
 		plan := core.PipelineStage{
 			&core.PipelineTask{
 				Plugin:   "dora",
-				Subtasks: []string{"calculateChangeLeadTime", "ConnectIssueDeploy"},
+				Subtasks: []string{"calculateChangeLeadTime", "ConnectIncidentToDeployment"},
 				Options:  doraRules,
 			},
 		}


### PR DESCRIPTION
### Summary
According to #3804 , I found that if we only choose `ticket` to collect, devlake will not collect repo info , then we cannot get githubId of repo to collect issues.
So in this pr, I update `DomainTypes` for repo collector&extractor&convertor in both github and graphQL


### Does this close any open issues?
Closes #3804 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
