### PR TITLE
fix: add refdiff; change typo in model

### DIFF
--- a/plugins/github/api/blueprint_V200_test.go
+++ b/plugins/github/api/blueprint_V200_test.go
@@ -93,7 +93,7 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 				ID: 1,
 			},
 			PrType: "hey,man,wasup",
-			ReffdiffRule: json.RawMessage(`{
+			RefdiffRule: json.RawMessage(`{
                 "tagsPattern": "pattern",
                 "tagsLimit": 10,
                 "tagsOrder": "reverse semver"
@@ -117,6 +117,11 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 					"repo":         "testRepo",
 					"transformationRules": map[string]interface{}{
 						"prType": "hey,man,wasup",
+						"refdiff": json.RawMessage(`{
+                "tagsPattern": "pattern",
+                "tagsLimit": 10,
+                "tagsOrder": "reverse semver"
+              }`),
 					},
 				},
 			},

--- a/plugins/github/api/blueprint_v200.go
+++ b/plugins/github/api/blueprint_v200.go
@@ -112,14 +112,14 @@ func makeDataSourcePipelinePlanV200(
 	var repo *tasks.GithubApiRepo
 	scopes := make([]core.Scope, 0)
 	// refdiff
-	if transformationRule != nil && transformationRule.ReffdiffRule != nil {
+	if transformationRule != nil && transformationRule.RefdiffRule != nil {
 		// add a new task to next stage
 		j := i + 1
 		if j == len(plan) {
 			plan = append(plan, nil)
 		}
 		refdiffOp := map[string]interface{}{}
-		err = errors.Convert(json.Unmarshal(transformationRule.ReffdiffRule, &refdiffOp))
+		err = errors.Convert(json.Unmarshal(transformationRule.RefdiffRule, &refdiffOp))
 		if err != nil {
 			return nil, nil, err
 		}

--- a/plugins/github/models/transformation_rule.go
+++ b/plugins/github/models/transformation_rule.go
@@ -35,7 +35,7 @@ type TransformationRules struct {
 	IssueTypeIncident    string          `mapstructure:"issueTypeIncident,omitempty" json:"issueTypeIncident" gorm:"type:varchar(255)"`
 	IssueTypeRequirement string          `mapstructure:"issueTypeRequirement,omitempty" json:"issueTypeRequirement" gorm:"type:varchar(255)"`
 	DeploymentPattern    string          `mapstructure:"deploymentPattern,omitempty" json:"deploymentPattern" gorm:"type:varchar(255)"`
-	ReffdiffRule         json.RawMessage `mapstructure:"-" json:"refdiff"`
+	RefdiffRule          json.RawMessage `mapstructure:"refdiff,omitempty" json:"refdiff"`
 }
 
 func (TransformationRules) TableName() string {


### PR DESCRIPTION
### Summary

1. add refdiff column in `CREATE transformations API`
2. change typo in model