### PR TITLE
fix: add name to transformation rules

### DIFF
--- a/plugins/github/api/blueprint_V200_test.go
+++ b/plugins/github/api/blueprint_V200_test.go
@@ -92,6 +92,7 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 			Model: common.Model{
 				ID: 1,
 			},
+			Name:    "github transformation rule",
 			PrType:  "hey,man,wasup",
 			Refdiff: json.RawMessage(`{"tagsPattern": "pattern", "tagsLimit": 10, "tagsOrder": "reverse semver"}`),
 		}
@@ -112,6 +113,7 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 					"owner":        "test",
 					"repo":         "testRepo",
 					"transformationRules": map[string]interface{}{
+						"name":    "github transformation rule",
 						"prType":  "hey,man,wasup",
 						"refdiff": json.RawMessage(`{"tagsPattern": "pattern", "tagsLimit": 10, "tagsOrder": "reverse semver"}`),
 					},

--- a/plugins/github/models/migrationscripts/archived/transformation_rules.go
+++ b/plugins/github/models/migrationscripts/archived/transformation_rules.go
@@ -25,6 +25,7 @@ import (
 
 type TransformationRules struct {
 	archived.Model
+	Name                 string          `gorm:"type:varchar(255)"`
 	PrType               string          `mapstructure:"prType" json:"prType" gorm:"type:varchar(255)"`
 	PrComponent          string          `mapstructure:"prComponent" json:"prComponent" gorm:"type:varchar(255)"`
 	PrBodyClosePattern   string          `mapstructure:"prBodyClosePattern" json:"prBodyClosePattern" gorm:"type:varchar(255)"`

--- a/plugins/github/models/migrationscripts/archived/transformation_rules.go
+++ b/plugins/github/models/migrationscripts/archived/transformation_rules.go
@@ -25,7 +25,7 @@ import (
 
 type TransformationRules struct {
 	archived.Model
-	Name                 string          `gorm:"type:varchar(255)"`
+	Name                 string          `mapstructure:"name" json:"name" gorm:"type:varchar(255)"`
 	PrType               string          `mapstructure:"prType" json:"prType" gorm:"type:varchar(255)"`
 	PrComponent          string          `mapstructure:"prComponent" json:"prComponent" gorm:"type:varchar(255)"`
 	PrBodyClosePattern   string          `mapstructure:"prBodyClosePattern" json:"prBodyClosePattern" gorm:"type:varchar(255)"`

--- a/plugins/github/models/transformation_rule.go
+++ b/plugins/github/models/transformation_rule.go
@@ -25,6 +25,7 @@ import (
 
 type TransformationRules struct {
 	common.Model         `mapstructure:"-"`
+	Name                 string          `gorm:"type:varchar(255)"`
 	PrType               string          `mapstructure:"prType,omitempty" json:"prType" gorm:"type:varchar(255)"`
 	PrComponent          string          `mapstructure:"prComponent,omitempty" json:"prComponent" gorm:"type:varchar(255)"`
 	PrBodyClosePattern   string          `mapstructure:"prBodyClosePattern,omitempty" json:"prBodyClosePattern" gorm:"type:varchar(255)"`

--- a/plugins/github/models/transformation_rule.go
+++ b/plugins/github/models/transformation_rule.go
@@ -25,7 +25,7 @@ import (
 
 type TransformationRules struct {
 	common.Model         `mapstructure:"-"`
-	Name                 string          `gorm:"type:varchar(255)"`
+	Name                 string          `mapstructure:"name" json:"name" gorm:"type:varchar(255)"`
 	PrType               string          `mapstructure:"prType,omitempty" json:"prType" gorm:"type:varchar(255)"`
 	PrComponent          string          `mapstructure:"prComponent,omitempty" json:"prComponent" gorm:"type:varchar(255)"`
 	PrBodyClosePattern   string          `mapstructure:"prBodyClosePattern,omitempty" json:"prBodyClosePattern" gorm:"type:varchar(255)"`

--- a/plugins/gitlab/models/migrationscripts/archived/transformation_rules.go
+++ b/plugins/gitlab/models/migrationscripts/archived/transformation_rules.go
@@ -23,6 +23,7 @@ import (
 
 type TransformationRules struct {
 	archived.Model
+	Name                 string `gorm:"type:varchar(255)"`
 	PrType               string `mapstructure:"prType" json:"prType" gorm:"type:varchar(255)"`
 	PrComponent          string `mapstructure:"prComponent" json:"prComponent" gorm:"type:varchar(255)"`
 	PrBodyClosePattern   string `mapstructure:"prBodyClosePattern" json:"prBodyClosePattern" gorm:"type:varchar(255)"`

--- a/plugins/gitlab/models/transformation_rule.go
+++ b/plugins/gitlab/models/transformation_rule.go
@@ -21,6 +21,7 @@ import "github.com/apache/incubator-devlake/models/common"
 
 type TransformationRules struct {
 	common.Model
+	Name                 string `gorm:"type:varchar(255)"`
 	PrType               string `mapstructure:"prType" json:"prType"`
 	PrComponent          string `mapstructure:"prComponent" json:"prComponent"`
 	PrBodyClosePattern   string `mapstructure:"prBodyClosePattern" json:"prBodyClosePattern"`

--- a/plugins/jenkins/impl/impl.go
+++ b/plugins/jenkins/impl/impl.go
@@ -164,7 +164,7 @@ func (plugin Jenkins) ApiResources() map[string]map[string]core.ApiResourceHandl
 			"DELETE": api.DeleteConnection,
 			"GET":    api.GetConnection,
 		},
-		"connections/:connectionId/scopes/*fullName": {
+		"connections/:connectionId/scopes/:fullName": {
 			"GET":   api.GetScope,
 			"PUT":   api.PutScope,
 			"PATCH": api.UpdateScope,

--- a/plugins/jenkins/models/migrationscripts/archived/transformation_rules.go
+++ b/plugins/jenkins/models/migrationscripts/archived/transformation_rules.go
@@ -23,6 +23,7 @@ import (
 
 type TransformationRules struct {
 	archived.Model
+	Name              string `gorm:"type:varchar(255)"`
 	DeploymentPattern string `gorm:"type:varchar(255)" mapstructure:"deploymentPattern" json:"deploymentPattern"`
 }
 

--- a/plugins/jenkins/models/transformation_rule.go
+++ b/plugins/jenkins/models/transformation_rule.go
@@ -21,6 +21,7 @@ import "github.com/apache/incubator-devlake/models/common"
 
 type TransformationRules struct {
 	common.Model
+	Name              string `gorm:"type:varchar(255)"`
 	DeploymentPattern string `gorm:"type:varchar(255)" mapstructure:"deploymentPattern" json:"deploymentPattern"`
 }
 

--- a/plugins/jira/api/transformation_rule.go
+++ b/plugins/jira/api/transformation_rule.go
@@ -18,7 +18,6 @@ limitations under the License.
 package api
 
 import (
-	"encoding/json"
 	"net/http"
 	"strconv"
 
@@ -92,19 +91,7 @@ func makeDbTransformationRuleFromInput(input *core.ApiResourceInput) (*models.Ji
 	if err != nil {
 		return nil, errors.Default.Wrap(err, "error decoding map into transformationRule")
 	}
-	return makeDbTransformationRule(&req)
-}
-func makeDbTransformationRule(rule *tasks.TransformationRules) (*models.JiraTransformationRule, errors.Error) {
-	blob, err := json.Marshal(rule.TypeMappings)
-	if err != nil {
-		return nil, errors.Default.Wrap(err, "error marshaling TypeMappings")
-	}
-	return &models.JiraTransformationRule{
-		EpicKeyField:               rule.EpicKeyField,
-		StoryPointField:            rule.StoryPointField,
-		RemotelinkCommitShaPattern: rule.RemotelinkCommitShaPattern,
-		TypeMappings:               blob,
-	}, nil
+	return req.ToDb()
 }
 
 // GetTransformationRule return one transformation rule

--- a/plugins/jira/models/migrationscripts/archived/transformation_rules.go
+++ b/plugins/jira/models/migrationscripts/archived/transformation_rules.go
@@ -25,6 +25,7 @@ import (
 
 type JiraTransformationRule struct {
 	archived.Model
+	Name                       string          `gorm:"type:varchar(255)"`
 	EpicKeyField               string          `json:"epicKeyField" gorm:"type:varchar(255)"`
 	StoryPointField            string          `json:"storyPointField" gorm:"type:varchar(255)"`
 	RemotelinkCommitShaPattern string          `json:"remotelinkCommitShaPattern" gorm:"type:varchar(255)"`

--- a/plugins/jira/models/transformation_rules.go
+++ b/plugins/jira/models/transformation_rules.go
@@ -25,6 +25,7 @@ import (
 
 type JiraTransformationRule struct {
 	common.Model
+	Name                       string          `gorm:"type:varchar(255)"`
 	EpicKeyField               string          `json:"epicKeyField" gorm:"type:varchar(255)"`
 	StoryPointField            string          `json:"storyPointField" gorm:"type:varchar(255)"`
 	RemotelinkCommitShaPattern string          `json:"remotelinkCommitShaPattern" gorm:"type:varchar(255)"`

--- a/plugins/jira/tasks/task_data.go
+++ b/plugins/jira/tasks/task_data.go
@@ -41,6 +41,7 @@ type TypeMapping struct {
 type TypeMappings map[string]TypeMapping
 
 type TransformationRules struct {
+	Name                       string       `gorm:"type:varchar(255)"`
 	EpicKeyField               string       `json:"epicKeyField"`
 	StoryPointField            string       `json:"storyPointField"`
 	RemotelinkCommitShaPattern string       `json:"remotelinkCommitShaPattern"`
@@ -53,6 +54,7 @@ func (r *TransformationRules) ToDb() (rule *models.JiraTransformationRule, error
 		return nil, errors.Default.Wrap(err, "error marshaling TypeMappings")
 	}
 	return &models.JiraTransformationRule{
+		Name:                       r.Name,
 		EpicKeyField:               r.EpicKeyField,
 		StoryPointField:            r.StoryPointField,
 		RemotelinkCommitShaPattern: r.RemotelinkCommitShaPattern,
@@ -65,6 +67,7 @@ func (r *TransformationRules) FromDb(rule *models.JiraTransformationRule) (*Tran
 	if err != nil {
 		return nil, errors.Default.Wrap(err, "error marshaling TypeMappings")
 	}
+	r.Name = rule.Name
 	r.EpicKeyField = rule.EpicKeyField
 	r.StoryPointField = rule.StoryPointField
 	r.RemotelinkCommitShaPattern = rule.RemotelinkCommitShaPattern
@@ -79,6 +82,7 @@ func MakeTransformationRules(rule models.JiraTransformationRule) (*Transformatio
 		return nil, errors.Default.Wrap(err, "unable to unmarshal the typeMapping")
 	}
 	result := &TransformationRules{
+		Name:                       rule.Name,
 		EpicKeyField:               rule.EpicKeyField,
 		StoryPointField:            rule.StoryPointField,
 		RemotelinkCommitShaPattern: rule.RemotelinkCommitShaPattern,


### PR DESCRIPTION

### Summary
The frontend needs a name to display to the user
1. add `name` to `_tool_github_transformation_rules`
2. add `name` to `_tool_gitlab_transformation_rules`
3. add `name` to `_tool_jira_transformation_rules`
4. add `name` to `_tool_jenkins_transformation_rules`

### Does this close any open issues?
No


