### PR TITLE
feat: gitlab plan v200

### DIFF
--- a/helpers/unithelper/dummy_baesres.go
+++ b/helpers/unithelper/dummy_baesres.go
@@ -22,16 +22,16 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-// DummyLogger FIXME ...
-func DummyLogger() *mocks.Logger {
-	logger := new(mocks.Logger)
-	logger.On("IsLevelEnabled", mock.Anything).Return(false).Maybe()
-	logger.On("Printf", mock.Anything, mock.Anything).Maybe()
-	logger.On("Log", mock.Anything, mock.Anything, mock.Anything).Maybe()
-	logger.On("Debug", mock.Anything, mock.Anything).Maybe()
-	logger.On("Info", mock.Anything, mock.Anything).Maybe()
-	logger.On("Warn", mock.Anything, mock.Anything).Maybe()
-	logger.On("Error", mock.Anything, mock.Anything, mock.Anything).Maybe()
-	logger.On("Nested", mock.Anything).Return(logger).Maybe()
-	return logger
+// DummyBasicRes FIXME ...
+func DummyBasicRes(callback func(mockDal *mocks.Dal)) *mocks.BasicRes {
+	mockRes := new(mocks.BasicRes)
+	mockLog := DummyLogger()
+	mockDal := new(mocks.Dal)
+
+	callback(mockDal)
+
+	mockRes.On("GetDal").Return(mockDal)
+	mockRes.On("GetLogger").Return(mockLog)
+	mockRes.On("GetConfig", mock.Anything).Return("")
+	return mockRes
 }

--- a/helpers/unithelper/dummy_logger.go
+++ b/helpers/unithelper/dummy_logger.go
@@ -31,7 +31,21 @@ func DummyLogger() *mocks.Logger {
 	logger.On("Debug", mock.Anything, mock.Anything).Maybe()
 	logger.On("Info", mock.Anything, mock.Anything).Maybe()
 	logger.On("Warn", mock.Anything, mock.Anything).Maybe()
-	logger.On("Error", mock.Anything, mock.Anything).Maybe()
+	logger.On("Error", mock.Anything, mock.Anything, mock.Anything).Maybe()
 	logger.On("Nested", mock.Anything).Return(logger).Maybe()
 	return logger
+}
+
+// NewMockBasicRes FIXME ...
+func NewMockBasicRes(callback func(mockDal *mocks.Dal)) *mocks.BasicRes {
+	mockRes := new(mocks.BasicRes)
+	mockLog := DummyLogger()
+	mockDal := new(mocks.Dal)
+
+	callback(mockDal)
+
+	mockRes.On("GetDal").Return(mockDal)
+	mockRes.On("GetLogger").Return(mockLog)
+	mockRes.On("GetConfig", mock.Anything).Return("")
+	return mockRes
 }

--- a/impl/dalgorm/dalgorm.go
+++ b/impl/dalgorm/dalgorm.go
@@ -355,6 +355,11 @@ func (d *Dalgorm) Begin() dal.Transaction {
 	return newTransaction(d)
 }
 
+// IsErrorNotFound checking if the sql error is not found.
+func (d *Dalgorm) IsErrorNotFound(err errors.Error) bool {
+	return errors.Is(err, gorm.ErrRecordNotFound)
+}
+
 // NewDalgorm creates a *Dalgorm
 func NewDalgorm(db *gorm.DB) *Dalgorm {
 	return &Dalgorm{db}

--- a/models/common/base.go
+++ b/models/common/base.go
@@ -45,6 +45,14 @@ type RawDataOrigin struct {
 	RawDataRemark string `gorm:"column:_raw_data_remark" json:"_raw_data_remark"`
 }
 
+func NewNoPKModel() NoPKModel {
+	now := time.Now()
+	return NoPKModel{
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
 var (
 	DUPLICATE_REGEX = regexp.MustCompile(`(?i)\bduplicate\b`)
 )

--- a/models/domainlayer/code/repo.go
+++ b/models/domainlayer/code/repo.go
@@ -60,3 +60,15 @@ func (r *Repo) ScopeId() string {
 func (r *Repo) ScopeName() string {
 	return r.Name
 }
+
+func NewRepo(id string, name string) *Repo {
+	repo := &Repo{
+		DomainEntity: domainlayer.NewDomainEntity(id),
+	}
+
+	repo.Name = name
+	repo.CreatedDate = &repo.CreatedAt
+	repo.UpdatedDate = &repo.UpdatedAt
+
+	return repo
+}

--- a/models/domainlayer/devops/cicd_scope.go
+++ b/models/domainlayer/devops/cicd_scope.go
@@ -18,9 +18,10 @@ limitations under the License.
 package devops
 
 import (
+	"time"
+
 	"github.com/apache/incubator-devlake/models/domainlayer"
 	"github.com/apache/incubator-devlake/plugins/core"
-	"time"
 )
 
 var _ core.Scope = (*CicdScope)(nil)
@@ -44,4 +45,16 @@ func (r *CicdScope) ScopeId() string {
 
 func (r *CicdScope) ScopeName() string {
 	return r.Name
+}
+
+func NewCicdScope(id string, name string) *CicdScope {
+	cicdScope := &CicdScope{
+		DomainEntity: domainlayer.NewDomainEntity(id),
+	}
+
+	cicdScope.Name = name
+	cicdScope.CreatedDate = &cicdScope.CreatedAt
+	cicdScope.UpdatedDate = &cicdScope.UpdatedAt
+
+	return cicdScope
 }

--- a/models/domainlayer/domainlayer.go
+++ b/models/domainlayer/domainlayer.go
@@ -25,3 +25,10 @@ type DomainEntity struct {
 	Id string `json:"id" gorm:"primaryKey;type:varchar(255);comment:This key is generated based on details from the original plugin"` // format: <Plugin>:<Entity>:<PK0>:<PK1>
 	common.NoPKModel
 }
+
+func NewDomainEntity(id string) DomainEntity {
+	return DomainEntity{
+		Id:        id,
+		NoPKModel: common.NewNoPKModel(),
+	}
+}

--- a/models/domainlayer/ticket/board.go
+++ b/models/domainlayer/ticket/board.go
@@ -49,6 +49,17 @@ func (r *Board) ScopeName() string {
 	return r.Name
 }
 
+func NewBoard(id string, name string) *Board {
+	board := &Board{
+		DomainEntity: domainlayer.NewDomainEntity(id),
+	}
+
+	board.Name = name
+	board.CreatedDate = &board.CreatedAt
+
+	return board
+}
+
 type BoardSprint struct {
 	common.NoPKModel
 	BoardId  string `gorm:"primaryKey;type:varchar(255)"`

--- a/plugins/core/dal/dal.go
+++ b/plugins/core/dal/dal.go
@@ -140,6 +140,8 @@ type Dal interface {
 	Session(config SessionConfig) Dal
 	// Begin create a new transaction
 	Begin() Transaction
+	// checking if the sql error is not found.
+	IsErrorNotFound(err errors.Error) bool
 }
 
 type Transaction interface {

--- a/plugins/gitlab/api/blueprint_V200_test.go
+++ b/plugins/gitlab/api/blueprint_V200_test.go
@@ -117,15 +117,6 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	var expectPlans core.PipelinePlan = core.PipelinePlan{
 		{
 			{
-				Plugin:     "refdiff",
-				SkipOnFail: false,
-				Options: map[string]interface{}{
-					"tagsLimit":   10,
-					"tagsOrder":   "reverse semver",
-					"tagsPattern": "pattern",
-				},
-			},
-			{
 				Plugin: "gitlab",
 				Subtasks: []string{
 					tasks.CollectProjectMeta.Name,
@@ -143,7 +134,7 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 				SkipOnFail: false,
 				Options: map[string]interface{}{
 					"connectionId": uint64(1),
-					"scopeId":      testID,
+					"projectId":    testID,
 					"entities":     bpScopes[0].Entities,
 				},
 			},
@@ -154,6 +145,15 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 					"proxy":  "",
 					"repoId": expectRepoId,
 					"url":    "https://git:nddtf@this_is_cloneUrl",
+				},
+			},
+			{
+				Plugin:     "refdiff",
+				SkipOnFail: false,
+				Options: map[string]interface{}{
+					"tagsLimit":   10,
+					"tagsOrder":   "reverse semver",
+					"tagsPattern": "pattern",
 				},
 			},
 		},

--- a/plugins/gitlab/api/blueprint_V200_test.go
+++ b/plugins/gitlab/api/blueprint_V200_test.go
@@ -39,59 +39,59 @@ import (
 )
 
 func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
-	const TestConnectionID uint64 = 1
-	const TestTransformationRuleId uint64 = 2
-	const TestID int = 37
-	const TestGitlabEndPoint string = "https://gitlab.com/api/v4/"
-	const TestHHttpUrlToRepo string = "https://this_is_cloneUrl"
-	const TestToken string = "nddtf"
-	const TestName string = "gitlab-test"
-	const TestTransformationRuleName string = "github transformation rule"
-	const TestProxy string = ""
+	const testConnectionID uint64 = 1
+	const testTransformationRuleId uint64 = 2
+	const testID int = 37
+	const testGitlabEndPoint string = "https://gitlab.com/api/v4/"
+	const testHHttpUrlToRepo string = "https://this_is_cloneUrl"
+	const testToken string = "nddtf"
+	const testName string = "gitlab-test"
+	const testTransformationRuleName string = "github transformation rule"
+	const testProxy string = ""
 
-	var TestGitlabProject *models.GitlabProject = &models.GitlabProject{
-		ConnectionId: TestConnectionID,
-		GitlabId:     TestID,
-		Name:         TestName,
+	var testGitlabProject *models.GitlabProject = &models.GitlabProject{
+		ConnectionId: testConnectionID,
+		GitlabId:     testID,
+		Name:         testName,
 
-		TransformationRuleId: TestTransformationRuleId,
+		TransformationRuleId: testTransformationRuleId,
 		CreatedDate:          time.Time{},
-		HttpUrlToRepo:        TestHHttpUrlToRepo,
+		HttpUrlToRepo:        testHHttpUrlToRepo,
 	}
 
-	var TestTransformationRule *models.GitlabTransformationRule = &models.GitlabTransformationRule{
+	var testTransformationRule *models.GitlabTransformationRule = &models.GitlabTransformationRule{
 		Model: common.Model{
-			ID: TestTransformationRuleId,
+			ID: testTransformationRuleId,
 		},
-		Name:   TestTransformationRuleName,
+		Name:   testTransformationRuleName,
 		PrType: "hey,man,wasup",
-		RefdiffRule: map[string]interface{}{
+		Refdiff: map[string]interface{}{
 			"tagsPattern": "pattern",
 			"tagsLimit":   10,
 			"tagsOrder":   "reverse semver",
 		},
 	}
 
-	var TestGitlabConnection *models.GitlabConnection = &models.GitlabConnection{
+	var testGitlabConnection *models.GitlabConnection = &models.GitlabConnection{
 		RestConnection: helper.RestConnection{
 			BaseConnection: helper.BaseConnection{
-				Name: TestName,
+				Name: testName,
 				Model: common.Model{
-					ID: TestConnectionID,
+					ID: testConnectionID,
 				},
 			},
-			Endpoint:         TestGitlabEndPoint,
-			Proxy:            TestProxy,
+			Endpoint:         testGitlabEndPoint,
+			Proxy:            testProxy,
 			RateLimitPerHour: 0,
 		},
 		AccessToken: helper.AccessToken{
-			Token: TestToken,
+			Token: testToken,
 		},
 	}
 
-	var ExpectRepoId = "gitlab:GitlabProject:1:37"
+	var expectRepoId = "gitlab:GitlabProject:1:37"
 
-	var TestSubTaskMeta = []core.SubTaskMeta{
+	var testSubTaskMeta = []core.SubTaskMeta{
 		tasks.CollectProjectMeta,
 		tasks.ExtractProjectMeta,
 		tasks.ConvertProjectMeta,
@@ -101,7 +101,7 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 		tasks.ConvertIssueLabelsMeta,
 	}
 
-	var ExpectPlans core.PipelinePlan = core.PipelinePlan{
+	var expectPlans core.PipelinePlan = core.PipelinePlan{
 		{
 			{
 				Plugin:     "refdiff",
@@ -126,9 +126,9 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 				SkipOnFail: false,
 				Options: map[string]interface{}{
 					"connectionId":         uint64(1),
-					"projectId":            TestID,
-					"transformationRuleId": TestTransformationRuleId,
-					"transformationRules":  TestTransformationRule,
+					"projectId":            testID,
+					"transformationRuleId": testTransformationRuleId,
+					"transformationRules":  testTransformationRule,
 				},
 			},
 			{
@@ -136,25 +136,25 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 				SkipOnFail: false,
 				Options: map[string]interface{}{
 					"proxy":  "",
-					"repoId": ExpectRepoId,
+					"repoId": expectRepoId,
 					"url":    "https://git:nddtf@this_is_cloneUrl",
 				},
 			},
 		},
 	}
 
-	var ExpectScopes []core.Scope = []core.Scope{
+	var expectScopes []core.Scope = []core.Scope{
 		&code.Repo{
 			DomainEntity: domainlayer.DomainEntity{
-				Id: ExpectRepoId,
+				Id: expectRepoId,
 			},
-			Name: TestName,
+			Name: testName,
 		},
 		&ticket.Board{
 			DomainEntity: domainlayer.DomainEntity{
-				Id: ExpectRepoId,
+				Id: expectRepoId,
 			},
-			Name:        TestName,
+			Name:        testName,
 			Description: "",
 			Url:         "",
 			CreatedDate: nil,
@@ -167,8 +167,8 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	bpScopes := []*core.BlueprintScopeV200{
 		{
 			Entities: []string{"CODE", "TICKET"},
-			Id:       strconv.Itoa(TestID),
-			Name:     TestName,
+			Id:       strconv.Itoa(testID),
+			Name:     testName,
 		},
 	}
 
@@ -182,17 +182,17 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	BasicRes = unithelper.NewMockBasicRes(func(mockDal *mocks.Dal) {
 		mockDal.On("First", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 			dst := args.Get(0).(*models.GitlabConnection)
-			*dst = *TestGitlabConnection
+			*dst = *testGitlabConnection
 		}).Return(nil).Once()
 
 		mockDal.On("First", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 			dst := args.Get(0).(*models.GitlabProject)
-			*dst = *TestGitlabProject
+			*dst = *testGitlabProject
 		}).Return(nil).Once()
 
 		mockDal.On("First", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 			dst := args.Get(0).(*models.GitlabTransformationRule)
-			*dst = *TestTransformationRule
+			*dst = *testTransformationRule
 		}).Return(nil).Once()
 	})
 	connectionHelper = helper.NewConnectionHelper(
@@ -200,9 +200,9 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 		validator.New(),
 	)
 
-	plans, scopes, err := MakePipelinePlanV200(TestSubTaskMeta, TestConnectionID, bpScopes)
+	plans, scopes, err := MakePipelinePlanV200(testSubTaskMeta, testConnectionID, bpScopes)
 	assert.Equal(t, err, nil)
 
-	assert.Equal(t, ExpectPlans, plans)
-	assert.Equal(t, ExpectScopes, scopes)
+	assert.Equal(t, expectPlans, plans)
+	assert.Equal(t, expectScopes, scopes)
 }

--- a/plugins/gitlab/api/blueprint_V200_test.go
+++ b/plugins/gitlab/api/blueprint_V200_test.go
@@ -1,0 +1,263 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/apache/incubator-devlake/errors"
+	"github.com/apache/incubator-devlake/helpers/unithelper"
+	"github.com/apache/incubator-devlake/mocks"
+	"github.com/apache/incubator-devlake/models/common"
+	"github.com/apache/incubator-devlake/models/domainlayer"
+	"github.com/apache/incubator-devlake/models/domainlayer/code"
+	"github.com/apache/incubator-devlake/models/domainlayer/ticket"
+	"github.com/apache/incubator-devlake/plugins/core"
+	"github.com/apache/incubator-devlake/plugins/gitlab/models"
+	"github.com/apache/incubator-devlake/plugins/gitlab/tasks"
+	"github.com/apache/incubator-devlake/plugins/helper"
+	"github.com/go-playground/validator/v10"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+const TestConnectionID uint64 = 1
+const TestTransformationRuleId uint64 = 2
+const TestID int = 37
+const TestGitlabEndPoint string = "https://gitlab.com/api/v4/"
+const TestHHttpUrlToRepo string = "https://this_is_cloneUrl"
+const TestToken string = "nddtf"
+const TestName string = "gitlab-test"
+const TestTransformationRuleName string = "github transformation rule"
+const TestProxy string = ""
+
+var TestGitlabProject *models.GitlabProject = &models.GitlabProject{
+	ConnectionId: TestConnectionID,
+	GitlabId:     TestID,
+	Name:         TestName,
+
+	TransformationRuleId: TestTransformationRuleId,
+	CreatedDate:          time.Time{},
+	HttpUrlToRepo:        TestHHttpUrlToRepo,
+}
+
+var TestTransformationRule *models.GitlabTransformationRule = &models.GitlabTransformationRule{
+	Model: common.Model{
+		ID: TestTransformationRuleId,
+	},
+	Name:   TestTransformationRuleName,
+	PrType: "hey,man,wasup",
+	RefdiffRule: map[string]interface{}{
+		"tagsPattern": "pattern",
+		"tagsLimit":   10,
+		"tagsOrder":   "reverse semver",
+	},
+}
+
+var TestGitlabConnection *models.GitlabConnection = &models.GitlabConnection{
+	RestConnection: helper.RestConnection{
+		BaseConnection: helper.BaseConnection{
+			Name: TestName,
+			Model: common.Model{
+				ID: TestConnectionID,
+			},
+		},
+		Endpoint:         TestGitlabEndPoint,
+		Proxy:            TestProxy,
+		RateLimitPerHour: 0,
+	},
+	AccessToken: helper.AccessToken{
+		Token: TestToken,
+	},
+}
+
+var ExpectRepoId = "gitlab:GitlabProject:1:37"
+
+var TestSubTaskMeta = []core.SubTaskMeta{
+	tasks.CollectProjectMeta,
+	tasks.ExtractProjectMeta,
+	tasks.ConvertProjectMeta,
+	tasks.CollectApiIssuesMeta,
+	tasks.ExtractApiIssuesMeta,
+	tasks.ConvertIssuesMeta,
+	tasks.CollectApiMergeRequestsMeta,
+	tasks.ExtractApiMergeRequestsMeta,
+	tasks.ConvertApiMergeRequestsMeta,
+	tasks.CollectApiMrNotesMeta,
+	tasks.ExtractApiMrNotesMeta,
+	tasks.CollectApiMrCommitsMeta,
+	tasks.ExtractApiMrCommitsMeta,
+	tasks.ConvertApiMrCommitsMeta,
+	tasks.CollectApiPipelinesMeta,
+	tasks.ExtractApiPipelinesMeta,
+	tasks.CollectApiJobsMeta,
+	tasks.ExtractApiJobsMeta,
+	tasks.EnrichMergeRequestsMeta,
+	tasks.CollectAccountsMeta,
+	tasks.ExtractAccountsMeta,
+	tasks.ConvertAccountsMeta,
+	tasks.ConvertCommitsMeta,
+	tasks.ConvertIssueLabelsMeta,
+	tasks.ConvertJobMeta,
+	tasks.ConvertMrCommentMeta,
+	tasks.ConvertMrLabelsMeta,
+	tasks.ConvertPipelineMeta,
+	tasks.ConvertPipelineCommitMeta,
+}
+
+var ExpectPlans core.PipelinePlan = core.PipelinePlan{
+	{
+		{
+			Plugin:     "refdiff",
+			SkipOnFail: false,
+			Options: map[string]interface{}{
+				"tagsLimit":   10,
+				"tagsOrder":   "reverse semver",
+				"tagsPattern": "pattern",
+			},
+		},
+		{
+			Plugin: "gitlab",
+			Subtasks: []string{
+				tasks.CollectProjectMeta.Name,
+				tasks.ExtractProjectMeta.Name,
+				tasks.ConvertProjectMeta.Name,
+				tasks.CollectApiIssuesMeta.Name,
+				tasks.ExtractApiIssuesMeta.Name,
+				tasks.ConvertIssuesMeta.Name,
+				tasks.CollectApiMergeRequestsMeta.Name,
+				tasks.ExtractApiMergeRequestsMeta.Name,
+				tasks.ConvertApiMergeRequestsMeta.Name,
+				tasks.CollectApiMrNotesMeta.Name,
+				tasks.ExtractApiMrNotesMeta.Name,
+				tasks.CollectApiMrCommitsMeta.Name,
+				tasks.ExtractApiMrCommitsMeta.Name,
+				tasks.ConvertApiMrCommitsMeta.Name,
+				tasks.CollectApiPipelinesMeta.Name,
+				tasks.ExtractApiPipelinesMeta.Name,
+				tasks.CollectApiJobsMeta.Name,
+				tasks.ExtractApiJobsMeta.Name,
+				tasks.EnrichMergeRequestsMeta.Name,
+				tasks.CollectAccountsMeta.Name,
+				tasks.ExtractAccountsMeta.Name,
+				tasks.ConvertAccountsMeta.Name,
+				tasks.ConvertIssueLabelsMeta.Name,
+				tasks.ConvertJobMeta.Name,
+				tasks.ConvertMrCommentMeta.Name,
+				tasks.ConvertMrLabelsMeta.Name,
+				tasks.ConvertPipelineMeta.Name,
+				tasks.ConvertPipelineCommitMeta.Name,
+			},
+			SkipOnFail: false,
+			Options: map[string]interface{}{
+				"connectionId":         uint64(1),
+				"projectId":            TestID,
+				"transformationRuleId": TestTransformationRuleId,
+				"transformationRules":  TestTransformationRule,
+			},
+		},
+		{
+			Plugin:     "gitextractor",
+			SkipOnFail: false,
+			Options: map[string]interface{}{
+				"proxy":  "",
+				"repoId": ExpectRepoId,
+				"url":    "https://git:nddtf@this_is_cloneUrl",
+			},
+		},
+	},
+}
+
+var ExpectScopes []core.Scope = []core.Scope{
+	&code.Repo{
+		DomainEntity: domainlayer.DomainEntity{
+			Id: ExpectRepoId,
+		},
+		Name: TestName,
+	},
+	&ticket.Board{
+		DomainEntity: domainlayer.DomainEntity{
+			Id: ExpectRepoId,
+		},
+		Name:        TestName,
+		Description: "",
+		Url:         "",
+		CreatedDate: nil,
+		Type:        "",
+	},
+}
+
+func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
+	var err errors.Error
+
+	bpScopes := []*core.BlueprintScopeV200{
+		{
+			Entities: []string{"CODE", "TICKET", "CODEREVIEW", "CROSS", "CICD"},
+			Id:       strconv.Itoa(TestID),
+			Name:     TestName,
+		},
+	}
+	// register gitlab plugin for NewDomainIdGenerator
+	mockMeta := mocks.NewPluginMeta(t)
+	mockMeta.On("RootPkgPath").Return("github.com/apache/incubator-devlake/plugins/gitlab")
+	err = core.RegisterPlugin("gitlab", mockMeta)
+	assert.Equal(t, err, nil)
+
+	// Refresh Global Variables and set the sql mock
+	BasicRes = unithelper.NewMockBasicRes(func(mockDal *mocks.Dal) {
+		mockDal.On("First", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			dst := args.Get(0).(*models.GitlabConnection)
+			*dst = *TestGitlabConnection
+		}).Return(nil).Once()
+
+		mockDal.On("First", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			dst := args.Get(0).(*models.GitlabProject)
+			*dst = *TestGitlabProject
+		}).Return(nil).Once()
+
+		mockDal.On("First", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			dst := args.Get(0).(*models.GitlabTransformationRule)
+			*dst = *TestTransformationRule
+		}).Return(nil).Once()
+	})
+	connectionHelper = helper.NewConnectionHelper(
+		BasicRes,
+		validator.New(),
+	)
+
+	plans, scopes, err := MakePipelinePlanV200(TestSubTaskMeta, TestConnectionID, bpScopes)
+	assert.Equal(t, err, nil)
+
+	expectPlansJson, err1 := json.Marshal(plans)
+	assert.Equal(t, err1, nil)
+
+	plansJson, err1 := json.Marshal(ExpectPlans)
+	assert.Equal(t, err1, nil)
+
+	expectScopesJson, err1 := json.Marshal(ExpectScopes)
+	assert.Equal(t, err1, nil)
+
+	scopesJson, err1 := json.Marshal(scopes)
+	assert.Equal(t, err1, nil)
+
+	assert.Equal(t, string(expectPlansJson), string(plansJson))
+	assert.Equal(t, string(expectScopesJson), string(scopesJson))
+}

--- a/plugins/gitlab/api/blueprint_V200_test.go
+++ b/plugins/gitlab/api/blueprint_V200_test.go
@@ -18,7 +18,6 @@ limitations under the License.
 package api
 
 import (
-	"encoding/json"
 	"strconv"
 	"testing"
 	"time"
@@ -39,182 +38,140 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-const TestConnectionID uint64 = 1
-const TestTransformationRuleId uint64 = 2
-const TestID int = 37
-const TestGitlabEndPoint string = "https://gitlab.com/api/v4/"
-const TestHHttpUrlToRepo string = "https://this_is_cloneUrl"
-const TestToken string = "nddtf"
-const TestName string = "gitlab-test"
-const TestTransformationRuleName string = "github transformation rule"
-const TestProxy string = ""
-
-var TestGitlabProject *models.GitlabProject = &models.GitlabProject{
-	ConnectionId: TestConnectionID,
-	GitlabId:     TestID,
-	Name:         TestName,
-
-	TransformationRuleId: TestTransformationRuleId,
-	CreatedDate:          time.Time{},
-	HttpUrlToRepo:        TestHHttpUrlToRepo,
-}
-
-var TestTransformationRule *models.GitlabTransformationRule = &models.GitlabTransformationRule{
-	Model: common.Model{
-		ID: TestTransformationRuleId,
-	},
-	Name:   TestTransformationRuleName,
-	PrType: "hey,man,wasup",
-	RefdiffRule: map[string]interface{}{
-		"tagsPattern": "pattern",
-		"tagsLimit":   10,
-		"tagsOrder":   "reverse semver",
-	},
-}
-
-var TestGitlabConnection *models.GitlabConnection = &models.GitlabConnection{
-	RestConnection: helper.RestConnection{
-		BaseConnection: helper.BaseConnection{
-			Name: TestName,
-			Model: common.Model{
-				ID: TestConnectionID,
-			},
-		},
-		Endpoint:         TestGitlabEndPoint,
-		Proxy:            TestProxy,
-		RateLimitPerHour: 0,
-	},
-	AccessToken: helper.AccessToken{
-		Token: TestToken,
-	},
-}
-
-var ExpectRepoId = "gitlab:GitlabProject:1:37"
-
-var TestSubTaskMeta = []core.SubTaskMeta{
-	tasks.CollectProjectMeta,
-	tasks.ExtractProjectMeta,
-	tasks.ConvertProjectMeta,
-	tasks.CollectApiIssuesMeta,
-	tasks.ExtractApiIssuesMeta,
-	tasks.ConvertIssuesMeta,
-	tasks.CollectApiMergeRequestsMeta,
-	tasks.ExtractApiMergeRequestsMeta,
-	tasks.ConvertApiMergeRequestsMeta,
-	tasks.CollectApiMrNotesMeta,
-	tasks.ExtractApiMrNotesMeta,
-	tasks.CollectApiMrCommitsMeta,
-	tasks.ExtractApiMrCommitsMeta,
-	tasks.ConvertApiMrCommitsMeta,
-	tasks.CollectApiPipelinesMeta,
-	tasks.ExtractApiPipelinesMeta,
-	tasks.CollectApiJobsMeta,
-	tasks.ExtractApiJobsMeta,
-	tasks.EnrichMergeRequestsMeta,
-	tasks.CollectAccountsMeta,
-	tasks.ExtractAccountsMeta,
-	tasks.ConvertAccountsMeta,
-	tasks.ConvertCommitsMeta,
-	tasks.ConvertIssueLabelsMeta,
-	tasks.ConvertJobMeta,
-	tasks.ConvertMrCommentMeta,
-	tasks.ConvertMrLabelsMeta,
-	tasks.ConvertPipelineMeta,
-	tasks.ConvertPipelineCommitMeta,
-}
-
-var ExpectPlans core.PipelinePlan = core.PipelinePlan{
-	{
-		{
-			Plugin:     "refdiff",
-			SkipOnFail: false,
-			Options: map[string]interface{}{
-				"tagsLimit":   10,
-				"tagsOrder":   "reverse semver",
-				"tagsPattern": "pattern",
-			},
-		},
-		{
-			Plugin: "gitlab",
-			Subtasks: []string{
-				tasks.CollectProjectMeta.Name,
-				tasks.ExtractProjectMeta.Name,
-				tasks.ConvertProjectMeta.Name,
-				tasks.CollectApiIssuesMeta.Name,
-				tasks.ExtractApiIssuesMeta.Name,
-				tasks.ConvertIssuesMeta.Name,
-				tasks.CollectApiMergeRequestsMeta.Name,
-				tasks.ExtractApiMergeRequestsMeta.Name,
-				tasks.ConvertApiMergeRequestsMeta.Name,
-				tasks.CollectApiMrNotesMeta.Name,
-				tasks.ExtractApiMrNotesMeta.Name,
-				tasks.CollectApiMrCommitsMeta.Name,
-				tasks.ExtractApiMrCommitsMeta.Name,
-				tasks.ConvertApiMrCommitsMeta.Name,
-				tasks.CollectApiPipelinesMeta.Name,
-				tasks.ExtractApiPipelinesMeta.Name,
-				tasks.CollectApiJobsMeta.Name,
-				tasks.ExtractApiJobsMeta.Name,
-				tasks.EnrichMergeRequestsMeta.Name,
-				tasks.CollectAccountsMeta.Name,
-				tasks.ExtractAccountsMeta.Name,
-				tasks.ConvertAccountsMeta.Name,
-				tasks.ConvertIssueLabelsMeta.Name,
-				tasks.ConvertJobMeta.Name,
-				tasks.ConvertMrCommentMeta.Name,
-				tasks.ConvertMrLabelsMeta.Name,
-				tasks.ConvertPipelineMeta.Name,
-				tasks.ConvertPipelineCommitMeta.Name,
-			},
-			SkipOnFail: false,
-			Options: map[string]interface{}{
-				"connectionId":         uint64(1),
-				"projectId":            TestID,
-				"transformationRuleId": TestTransformationRuleId,
-				"transformationRules":  TestTransformationRule,
-			},
-		},
-		{
-			Plugin:     "gitextractor",
-			SkipOnFail: false,
-			Options: map[string]interface{}{
-				"proxy":  "",
-				"repoId": ExpectRepoId,
-				"url":    "https://git:nddtf@this_is_cloneUrl",
-			},
-		},
-	},
-}
-
-var ExpectScopes []core.Scope = []core.Scope{
-	&code.Repo{
-		DomainEntity: domainlayer.DomainEntity{
-			Id: ExpectRepoId,
-		},
-		Name: TestName,
-	},
-	&ticket.Board{
-		DomainEntity: domainlayer.DomainEntity{
-			Id: ExpectRepoId,
-		},
-		Name:        TestName,
-		Description: "",
-		Url:         "",
-		CreatedDate: nil,
-		Type:        "",
-	},
-}
-
 func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
+	const TestConnectionID uint64 = 1
+	const TestTransformationRuleId uint64 = 2
+	const TestID int = 37
+	const TestGitlabEndPoint string = "https://gitlab.com/api/v4/"
+	const TestHHttpUrlToRepo string = "https://this_is_cloneUrl"
+	const TestToken string = "nddtf"
+	const TestName string = "gitlab-test"
+	const TestTransformationRuleName string = "github transformation rule"
+	const TestProxy string = ""
+
+	var TestGitlabProject *models.GitlabProject = &models.GitlabProject{
+		ConnectionId: TestConnectionID,
+		GitlabId:     TestID,
+		Name:         TestName,
+
+		TransformationRuleId: TestTransformationRuleId,
+		CreatedDate:          time.Time{},
+		HttpUrlToRepo:        TestHHttpUrlToRepo,
+	}
+
+	var TestTransformationRule *models.GitlabTransformationRule = &models.GitlabTransformationRule{
+		Model: common.Model{
+			ID: TestTransformationRuleId,
+		},
+		Name:   TestTransformationRuleName,
+		PrType: "hey,man,wasup",
+		RefdiffRule: map[string]interface{}{
+			"tagsPattern": "pattern",
+			"tagsLimit":   10,
+			"tagsOrder":   "reverse semver",
+		},
+	}
+
+	var TestGitlabConnection *models.GitlabConnection = &models.GitlabConnection{
+		RestConnection: helper.RestConnection{
+			BaseConnection: helper.BaseConnection{
+				Name: TestName,
+				Model: common.Model{
+					ID: TestConnectionID,
+				},
+			},
+			Endpoint:         TestGitlabEndPoint,
+			Proxy:            TestProxy,
+			RateLimitPerHour: 0,
+		},
+		AccessToken: helper.AccessToken{
+			Token: TestToken,
+		},
+	}
+
+	var ExpectRepoId = "gitlab:GitlabProject:1:37"
+
+	var TestSubTaskMeta = []core.SubTaskMeta{
+		tasks.CollectProjectMeta,
+		tasks.ExtractProjectMeta,
+		tasks.ConvertProjectMeta,
+		tasks.CollectApiIssuesMeta,
+		tasks.ExtractApiIssuesMeta,
+		tasks.ConvertIssuesMeta,
+		tasks.ConvertIssueLabelsMeta,
+	}
+
+	var ExpectPlans core.PipelinePlan = core.PipelinePlan{
+		{
+			{
+				Plugin:     "refdiff",
+				SkipOnFail: false,
+				Options: map[string]interface{}{
+					"tagsLimit":   10,
+					"tagsOrder":   "reverse semver",
+					"tagsPattern": "pattern",
+				},
+			},
+			{
+				Plugin: "gitlab",
+				Subtasks: []string{
+					tasks.CollectProjectMeta.Name,
+					tasks.ExtractProjectMeta.Name,
+					tasks.ConvertProjectMeta.Name,
+					tasks.CollectApiIssuesMeta.Name,
+					tasks.ExtractApiIssuesMeta.Name,
+					tasks.ConvertIssuesMeta.Name,
+					tasks.ConvertIssueLabelsMeta.Name,
+				},
+				SkipOnFail: false,
+				Options: map[string]interface{}{
+					"connectionId":         uint64(1),
+					"projectId":            TestID,
+					"transformationRuleId": TestTransformationRuleId,
+					"transformationRules":  TestTransformationRule,
+				},
+			},
+			{
+				Plugin:     "gitextractor",
+				SkipOnFail: false,
+				Options: map[string]interface{}{
+					"proxy":  "",
+					"repoId": ExpectRepoId,
+					"url":    "https://git:nddtf@this_is_cloneUrl",
+				},
+			},
+		},
+	}
+
+	var ExpectScopes []core.Scope = []core.Scope{
+		&code.Repo{
+			DomainEntity: domainlayer.DomainEntity{
+				Id: ExpectRepoId,
+			},
+			Name: TestName,
+		},
+		&ticket.Board{
+			DomainEntity: domainlayer.DomainEntity{
+				Id: ExpectRepoId,
+			},
+			Name:        TestName,
+			Description: "",
+			Url:         "",
+			CreatedDate: nil,
+			Type:        "",
+		},
+	}
+
 	var err errors.Error
 
 	bpScopes := []*core.BlueprintScopeV200{
 		{
-			Entities: []string{"CODE", "TICKET", "CODEREVIEW", "CROSS", "CICD"},
+			Entities: []string{"CODE", "TICKET"},
 			Id:       strconv.Itoa(TestID),
 			Name:     TestName,
 		},
 	}
+
 	// register gitlab plugin for NewDomainIdGenerator
 	mockMeta := mocks.NewPluginMeta(t)
 	mockMeta.On("RootPkgPath").Return("github.com/apache/incubator-devlake/plugins/gitlab")
@@ -246,18 +203,6 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	plans, scopes, err := MakePipelinePlanV200(TestSubTaskMeta, TestConnectionID, bpScopes)
 	assert.Equal(t, err, nil)
 
-	expectPlansJson, err1 := json.Marshal(plans)
-	assert.Equal(t, err1, nil)
-
-	plansJson, err1 := json.Marshal(ExpectPlans)
-	assert.Equal(t, err1, nil)
-
-	expectScopesJson, err1 := json.Marshal(ExpectScopes)
-	assert.Equal(t, err1, nil)
-
-	scopesJson, err1 := json.Marshal(scopes)
-	assert.Equal(t, err1, nil)
-
-	assert.Equal(t, string(expectPlansJson), string(plansJson))
-	assert.Equal(t, string(expectScopesJson), string(scopesJson))
+	assert.Equal(t, ExpectPlans, plans)
+	assert.Equal(t, ExpectScopes, scopes)
 }

--- a/plugins/gitlab/api/blueprint_v200.go
+++ b/plugins/gitlab/api/blueprint_v200.go
@@ -126,7 +126,7 @@ func makePipelinePlanV200(subtaskMetas []core.SubTaskMeta, scopes []*core.Bluepr
 		options := make(map[string]interface{})
 		options["connectionId"] = connection.ID
 		options["projectId"] = intScopeId
-		options["transformationRules"] = transformationRules
+		options["transformationRules"] = &transformationRules
 		options["transformationRuleId"] = transformationRules.ID
 		// make sure task options is valid
 		_, err := tasks.DecodeAndValidateTaskOptions(options)

--- a/plugins/gitlab/api/blueprint_v200.go
+++ b/plugins/gitlab/api/blueprint_v200.go
@@ -132,15 +132,6 @@ func makePipelinePlanV200(subtaskMetas []core.SubTaskMeta, scopes []*core.Bluepr
 			return nil, err
 		}
 
-		// refdiff part
-		if transformationRules.Refdiff != nil {
-			task := &core.PipelineTask{
-				Plugin:  "refdiff",
-				Options: transformationRules.Refdiff,
-			}
-			stage = append(stage, task)
-		}
-
 		// get int scopeId
 		intScopeId, err1 := strconv.Atoi(scope.Id)
 		if err != nil {
@@ -150,7 +141,7 @@ func makePipelinePlanV200(subtaskMetas []core.SubTaskMeta, scopes []*core.Bluepr
 		// gitlab main part
 		options := make(map[string]interface{})
 		options["connectionId"] = connection.ID
-		options["scopeId"] = intScopeId
+		options["projectId"] = intScopeId
 		options["entities"] = scope.Entities
 
 		// construct subtasks
@@ -182,7 +173,17 @@ func makePipelinePlanV200(subtaskMetas []core.SubTaskMeta, scopes []*core.Bluepr
 			})
 		}
 
+		// refdiff part
+		if transformationRules.Refdiff != nil {
+			task := &core.PipelineTask{
+				Plugin:  "refdiff",
+				Options: transformationRules.Refdiff,
+			}
+			stage = append(stage, task)
+		}
+
 		plans = append(plans, stage)
+
 	}
 	return plans, nil
 }

--- a/plugins/gitlab/api/blueprint_v200.go
+++ b/plugins/gitlab/api/blueprint_v200.go
@@ -108,10 +108,10 @@ func makePipelinePlanV200(subtaskMetas []core.SubTaskMeta, scopes []*core.Bluepr
 		}
 
 		// refdiff part
-		if transformationRules.RefdiffRule != nil {
+		if transformationRules.Refdiff != nil {
 			task := &core.PipelineTask{
 				Plugin:  "refdiff",
-				Options: transformationRules.RefdiffRule,
+				Options: transformationRules.Refdiff,
 			}
 			stage = append(stage, task)
 		}

--- a/plugins/gitlab/impl/impl.go
+++ b/plugins/gitlab/impl/impl.go
@@ -65,8 +65,8 @@ func (plugin Gitlab) TransformationRule() interface{} {
 	return &models.GitlabTransformationRule{}
 }
 
-func (plugin Gitlab) MakeDataSourcePipelinePlanV200(connectionId uint64, scopes []*core.BlueprintScopeV200) (pp core.PipelinePlan, sc []core.Scope, err errors.Error) {
-	return api.MakeDataSourcePipelinePlanV200(connectionId, scopes)
+func (plugin Gitlab) MakeDataSourcePipelinePlanV200(connectionId uint64, scopes []*core.BlueprintScopeV200) (core.PipelinePlan, []core.Scope, errors.Error) {
+	return api.MakePipelinePlanV200(plugin.SubTaskMetas(), connectionId, scopes)
 }
 
 func (plugin Gitlab) GetTablesInfo() []core.Tabler {
@@ -210,11 +210,11 @@ func (plugin Gitlab) ApiResources() map[string]map[string]core.ApiResourceHandle
 		},
 		"connections/:connectionId/scopes/:projectId": {
 			"GET":   api.GetScope,
+			"PUT":   api.PutScope,
 			"PATCH": api.UpdateScope,
 		},
 		"connections/:connectionId/scopes": {
 			"GET": api.GetScopeList,
-			"PUT": api.PutScope,
 		},
 		"transformation_rules": {
 			"POST": api.CreateTransformationRule,

--- a/plugins/gitlab/models/project.go
+++ b/plugins/gitlab/models/project.go
@@ -38,6 +38,7 @@ type GitlabProject struct {
 	StarCount               int    `json:"starCount" mapstructure:"StarCount"`
 	ForkedFromProjectId     int    `json:"forkedFromProjectId" mapstructure:"forkedFromProjectId"`
 	ForkedFromProjectWebUrl string `json:"forkedFromProjectWebUrl" mapstructure:"forkedFromProjectWebUrl" gorm:"type:varchar(255)"`
+	HttpUrlToRepo           string `json:"http_url_to_repo" gorm:"varchar(255)"`
 
 	CreatedDate      time.Time  `json:"createdDate" mapstructure:"-"`
 	UpdatedDate      *time.Time `json:"updatedDate" mapstructure:"-"`

--- a/plugins/gitlab/models/transformation_rule.go
+++ b/plugins/gitlab/models/transformation_rule.go
@@ -35,7 +35,7 @@ type GitlabTransformationRule struct {
 	IssueTypeIncident    string            `mapstructure:"issueTypeIncident" json:"issueTypeIncident"`
 	IssueTypeRequirement string            `mapstructure:"issueTypeRequirement" json:"issueTypeRequirement"`
 	DeploymentPattern    string            `mapstructure:"deploymentPattern" json:"deploymentPattern"`
-	RefdiffRule          datatypes.JSONMap `mapstructure:"refdiff,omitempty" json:"refdiff" swaggertype:"object" format:"json"`
+	Refdiff              datatypes.JSONMap `mapstructure:"refdiff,omitempty" json:"refdiff" swaggertype:"object" format:"json"`
 }
 
 func (t GitlabTransformationRule) TableName() string {

--- a/plugins/gitlab/models/transformation_rule.go
+++ b/plugins/gitlab/models/transformation_rule.go
@@ -17,21 +17,25 @@ limitations under the License.
 
 package models
 
-import "github.com/apache/incubator-devlake/models/common"
+import (
+	"github.com/apache/incubator-devlake/models/common"
+	"gorm.io/datatypes"
+)
 
 type GitlabTransformationRule struct {
 	common.Model
-	Name                 string `gorm:"type:varchar(255)"`
-	PrType               string `mapstructure:"prType" json:"prType"`
-	PrComponent          string `mapstructure:"prComponent" json:"prComponent"`
-	PrBodyClosePattern   string `mapstructure:"prBodyClosePattern" json:"prBodyClosePattern"`
-	IssueSeverity        string `mapstructure:"issueSeverity" json:"issueSeverity"`
-	IssuePriority        string `mapstructure:"issuePriority" json:"issuePriority"`
-	IssueComponent       string `mapstructure:"issueComponent" json:"issueComponent"`
-	IssueTypeBug         string `mapstructure:"issueTypeBug" json:"issueTypeBug"`
-	IssueTypeIncident    string `mapstructure:"issueTypeIncident" json:"issueTypeIncident"`
-	IssueTypeRequirement string `mapstructure:"issueTypeRequirement" json:"issueTypeRequirement"`
-	DeploymentPattern    string `mapstructure:"deploymentPattern" json:"deploymentPattern"`
+	Name                 string            `gorm:"type:varchar(255)"`
+	PrType               string            `mapstructure:"prType" json:"prType"`
+	PrComponent          string            `mapstructure:"prComponent" json:"prComponent"`
+	PrBodyClosePattern   string            `mapstructure:"prBodyClosePattern" json:"prBodyClosePattern"`
+	IssueSeverity        string            `mapstructure:"issueSeverity" json:"issueSeverity"`
+	IssuePriority        string            `mapstructure:"issuePriority" json:"issuePriority"`
+	IssueComponent       string            `mapstructure:"issueComponent" json:"issueComponent"`
+	IssueTypeBug         string            `mapstructure:"issueTypeBug" json:"issueTypeBug"`
+	IssueTypeIncident    string            `mapstructure:"issueTypeIncident" json:"issueTypeIncident"`
+	IssueTypeRequirement string            `mapstructure:"issueTypeRequirement" json:"issueTypeRequirement"`
+	DeploymentPattern    string            `mapstructure:"deploymentPattern" json:"deploymentPattern"`
+	RefdiffRule          datatypes.JSONMap `mapstructure:"refdiff,omitempty" json:"refdiff" swaggertype:"object" format:"json"`
 }
 
 func (t GitlabTransformationRule) TableName() string {

--- a/plugins/gitlab/tasks/job_convertor.go
+++ b/plugins/gitlab/tasks/job_convertor.go
@@ -36,7 +36,7 @@ var ConvertJobMeta = core.SubTaskMeta{
 	EntryPoint:       ConvertJobs,
 	EnabledByDefault: true,
 	Description:      "Convert tool layer table gitlab_job into domain layer table job",
-	DomainTypes:      []string{core.DOMAIN_TYPE_CROSS},
+	DomainTypes:      []string{core.DOMAIN_TYPE_CICD},
 }
 
 func ConvertJobs(taskCtx core.SubTaskContext) (err errors.Error) {

--- a/plugins/gitlab/tasks/pipeline_commit_convertor.go
+++ b/plugins/gitlab/tasks/pipeline_commit_convertor.go
@@ -18,6 +18,8 @@ limitations under the License.
 package tasks
 
 import (
+	"reflect"
+
 	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/models/domainlayer/devops"
 	"github.com/apache/incubator-devlake/models/domainlayer/didgen"
@@ -25,7 +27,6 @@ import (
 	"github.com/apache/incubator-devlake/plugins/core/dal"
 	gitlabModels "github.com/apache/incubator-devlake/plugins/gitlab/models"
 	"github.com/apache/incubator-devlake/plugins/helper"
-	"reflect"
 )
 
 var ConvertPipelineCommitMeta = core.SubTaskMeta{
@@ -33,7 +34,7 @@ var ConvertPipelineCommitMeta = core.SubTaskMeta{
 	EntryPoint:       ConvertPipelineCommits,
 	EnabledByDefault: true,
 	Description:      "Convert tool layer table gitlab_pipeline_project into domain layer table pipeline",
-	DomainTypes:      []string{core.DOMAIN_TYPE_CROSS},
+	DomainTypes:      []string{core.DOMAIN_TYPE_CICD},
 }
 
 func ConvertPipelineCommits(taskCtx core.SubTaskContext) errors.Error {

--- a/plugins/gitlab/tasks/pipeline_convertor.go
+++ b/plugins/gitlab/tasks/pipeline_convertor.go
@@ -18,9 +18,10 @@ limitations under the License.
 package tasks
 
 import (
-	"github.com/apache/incubator-devlake/errors"
 	"reflect"
 	"time"
+
+	"github.com/apache/incubator-devlake/errors"
 
 	"github.com/apache/incubator-devlake/models/domainlayer"
 	"github.com/apache/incubator-devlake/models/domainlayer/devops"
@@ -36,7 +37,7 @@ var ConvertPipelineMeta = core.SubTaskMeta{
 	EntryPoint:       ConvertPipelines,
 	EnabledByDefault: true,
 	Description:      "Convert tool layer table gitlab_pipeline into domain layer table pipeline",
-	DomainTypes:      []string{core.DOMAIN_TYPE_CROSS},
+	DomainTypes:      []string{core.DOMAIN_TYPE_CICD},
 }
 
 func ConvertPipelines(taskCtx core.SubTaskContext) errors.Error {

--- a/services/blueprint_makeplan_v200.go
+++ b/services/blueprint_makeplan_v200.go
@@ -47,7 +47,8 @@ func GeneratePlanJsonV200(
 		for _, scope := range scopes {
 			e = basicRes.GetDal().CreateOrUpdate(scope)
 			if e != nil {
-				return nil, errors.Convert(err)
+				scopeInfo := fmt.Sprintf("[Id:%s][Name:%s][TableName:%s]", scope.ScopeId(), scope.ScopeName(), scope.TableName())
+				return nil, errors.Default.Wrap(e, fmt.Sprintf("failed to create scopes:[%s]", scopeInfo))
 			}
 		}
 	}

--- a/services/blueprint_makeplan_v200.go
+++ b/services/blueprint_makeplan_v200.go
@@ -42,7 +42,7 @@ func GeneratePlanJsonV200(
 	if len(scopes) > 0 {
 		e := db.Where("project_name = ?", projectName).Delete(&crossdomain.ProjectMapping{}).Error
 		if e != nil {
-			return nil, errors.Convert(err)
+			return nil, errors.Default.Wrap(e, fmt.Sprintf("projectName:[%s]", projectName))
 		}
 		for _, scope := range scopes {
 			e = basicRes.GetDal().CreateOrUpdate(scope)


### PR DESCRIPTION
### Summary
After `GitLab` supports `scope` and `transformation rule`, we need to add relevant content to `MakeDataSourcePipelinePlanV200` of `GitLab`, and we need to add unit tests for it to ensure that the relevant code can work correctly.

bp_post2.0.0.sh
```bash
#!/bin/sh
curl --location --request POST 'devlake:8080/blueprints' \
--header 'Content-Type: application/json' \
--data-raw '
{
    "name":"test-gitlab-nddtf-v200",
    "projectName":"TestProject",
    "cronConfig":"0 0 * * *",
    "plan":{},
    "settings":
    {
        "version":"2.0.0",
        "connections":
        [
            {
                "plugin":"gitlab",
                "connectionId":1,
                "scopes":[
                    {
                        "id": "37",
                        "name": "思码逸 / Lake",
                        "entities":["CODE","TICKET","CODEREVIEW","CROSS","CICD"]
                    }
                ]
            }
        ]
    },
    "enable":true,
    "mode":"NORMAL",
    "isManual":true
}'


echo "\r\n"
```

### Does this close any open issues?
related #3468 
closes #3900 
closes #3902 
closes #3914 

### Screenshots
![image](https://user-images.githubusercontent.com/2921251/205630232-0411e103-7031-4ad8-be46-09412159738b.png)
![image](https://user-images.githubusercontent.com/2921251/207048543-07acc6af-34e3-422f-92f3-6b7b80a1e2c1.png)
