### PR TITLE
feat(config-ui): add global connections store

### DIFF
--- a/config-ui/src/store/connections/api.ts
+++ b/config-ui/src/store/connections/api.ts
@@ -16,9 +16,21 @@
  *
  */
 
-type ID = string | number
+import request from '@/components/utils/request'
 
-declare module '*.svg' {
-  const content: any
-  export default content
+type TestConnectionPayload = {
+  endpoint: string
+  proxy: string
+  token?: string
+  username?: string
+  password?: string
 }
+
+export const getConnection = (plugin: string) =>
+  request(`/plugins/${plugin}/connections`)
+
+export const testConnection = (plugin: string, data: TestConnectionPayload) =>
+  request(`/plugins/${plugin}/test`, {
+    method: 'post',
+    data
+  })

--- a/config-ui/src/store/connections/index.ts
+++ b/config-ui/src/store/connections/index.ts
@@ -16,9 +16,5 @@
  *
  */
 
-type ID = string | number
-
-declare module '*.svg' {
-  const content: any
-  export default content
-}
+export * from './use-connections'
+export * from './types'

--- a/config-ui/src/store/connections/types.ts
+++ b/config-ui/src/store/connections/types.ts
@@ -16,9 +16,25 @@
  *
  */
 
-type ID = string | number
+export enum ConnectionStatusEnum {
+  ONLINE = 'online',
+  OFFLINE = 'offline',
+  WAITING = 'waiting',
+  TESTING = 'testing',
+  NULL = 'null'
+}
 
-declare module '*.svg' {
-  const content: any
-  export default content
+export type ConnectionItemType = {
+  unique: string
+  status: ConnectionStatusEnum
+  plugin: string
+  id: ID
+  name: string
+  icon: string
+  entities: string[]
+  endpoint: string
+  proxy: string
+  token?: string
+  username?: string
+  password?: string
 }

--- a/config-ui/src/store/connections/use-connections.ts
+++ b/config-ui/src/store/connections/use-connections.ts
@@ -25,6 +25,7 @@ import { ConnectionStatusEnum } from './types'
 import { getConnection, testConnection } from './api'
 
 export const useConnections = (plugin?: string | string[]) => {
+  const [loading, setLoading] = useState(false)
   const [connections, setConnections] = useState<ConnectionItemType[]>([])
 
   const allConnections = useMemo(
@@ -37,39 +38,45 @@ export const useConnections = (plugin?: string | string[]) => {
   )
 
   const handleRefresh = useCallback(async () => {
-    const res = await Promise.all(
-      allConnections.map((cs) => getConnection(cs.id))
-    )
+    setLoading(true)
 
-    const resWithPlugin = res.map((cs, i) =>
-      cs.map((it: any) => {
-        const { id, icon, availableDataDomains } = allConnections[i] as any
+    try {
+      const res = await Promise.all(
+        allConnections.map((cs) => getConnection(cs.id))
+      )
 
-        return {
-          ...it,
-          plugin: id,
-          icon: `/${icon}`,
-          entities: availableDataDomains
-        }
-      })
-    )
+      const resWithPlugin = res.map((cs, i) =>
+        cs.map((it: any) => {
+          const { id, icon, availableDataDomains } = allConnections[i] as any
 
-    setConnections(
-      resWithPlugin.flat().map((it) => ({
-        unique: `${it.plugin}-${it.id}`,
-        status: ConnectionStatusEnum.NULL,
-        plugin: it.plugin,
-        id: it.id,
-        name: it.name,
-        icon: it.icon,
-        entities: it.entities,
-        endpoint: it.endpoint,
-        proxy: it.proxy,
-        token: it.token,
-        username: it.username,
-        password: it.password
-      }))
-    )
+          return {
+            ...it,
+            plugin: id,
+            icon: `/${icon}`,
+            entities: availableDataDomains
+          }
+        })
+      )
+
+      setConnections(
+        resWithPlugin.flat().map((it) => ({
+          unique: `${it.plugin}-${it.id}`,
+          status: ConnectionStatusEnum.NULL,
+          plugin: it.plugin,
+          id: it.id,
+          name: it.name,
+          icon: it.icon,
+          entities: it.entities,
+          endpoint: it.endpoint,
+          proxy: it.proxy,
+          token: it.token,
+          username: it.username,
+          password: it.password
+        }))
+      )
+    } finally {
+      setLoading(false)
+    }
   }, [allConnections])
 
   useEffect(() => {
@@ -138,10 +145,11 @@ export const useConnections = (plugin?: string | string[]) => {
 
   return useMemo(
     () => ({
+      loading,
       connections,
       onRefresh: handleRefresh,
       onTest: handleTest
     }),
-    [connections]
+    [loading, connections]
   )
 }

--- a/config-ui/src/store/connections/use-connections.ts
+++ b/config-ui/src/store/connections/use-connections.ts
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { useState, useEffect, useCallback, useMemo } from 'react'
+
+import { Plugins } from '@/registry'
+
+import type { ConnectionItemType } from './types'
+import { ConnectionStatusEnum } from './types'
+import { getConnection, testConnection } from './api'
+
+export const useConnections = (plugin?: string | string[]) => {
+  const [connections, setConnections] = useState<ConnectionItemType[]>([])
+
+  const allConnections = useMemo(
+    () =>
+      Plugins.filter((p) => p.type === 'integration').filter((p) => {
+        if (!plugin) return true
+        return Array.isArray(plugin) ? plugin.includes(p.id) : p.id === plugin
+      }),
+    [plugin]
+  )
+
+  const handleRefresh = useCallback(async () => {
+    const res = await Promise.all(
+      allConnections.map((cs) => getConnection(cs.id))
+    )
+
+    const resWithPlugin = res.map((cs, i) =>
+      cs.map((it: any) => {
+        const { id, icon, availableDataDomains } = allConnections[i] as any
+
+        return {
+          ...it,
+          plugin: id,
+          icon: `/${icon}`,
+          entities: availableDataDomains
+        }
+      })
+    )
+
+    setConnections(
+      resWithPlugin.flat().map((it) => ({
+        unique: `${it.plugin}-${it.id}`,
+        status: ConnectionStatusEnum.NULL,
+        plugin: it.plugin,
+        id: it.id,
+        name: it.name,
+        icon: it.icon,
+        entities: it.entities,
+        endpoint: it.endpoint,
+        proxy: it.proxy,
+        token: it.token,
+        username: it.username,
+        password: it.password
+      }))
+    )
+  }, [allConnections])
+
+  useEffect(() => {
+    handleRefresh()
+  }, [])
+
+  const handleTest = useCallback(
+    async (selectedConnections: ConnectionItemType[]) => {
+      const uniqueList = selectedConnections.map((cs) => cs.unique)
+
+      const initConnections = connections.map((cs) =>
+        uniqueList.includes(cs.unique) &&
+        cs.status === ConnectionStatusEnum.NULL
+          ? {
+              ...cs,
+              status: ConnectionStatusEnum.WAITING
+            }
+          : cs
+      )
+
+      setConnections(initConnections)
+
+      const [updatedConnection] = await Promise.all(
+        initConnections
+          .filter((cs) => cs.status === ConnectionStatusEnum.WAITING)
+          .map(async (cs) => {
+            setConnections(
+              initConnections.map((it) =>
+                it.unique === cs.unique
+                  ? { ...it, status: ConnectionStatusEnum.TESTING }
+                  : it
+              )
+            )
+            const { plugin, endpoint, proxy, token, username, password } = cs
+            let status
+
+            try {
+              const res = await testConnection(plugin, {
+                endpoint,
+                proxy,
+                token,
+                username,
+                password
+              })
+              status = res.success
+                ? ConnectionStatusEnum.ONLINE
+                : ConnectionStatusEnum.OFFLINE
+            } catch {
+              status = ConnectionStatusEnum.OFFLINE
+            }
+
+            return { ...cs, status }
+          })
+      )
+
+      if (updatedConnection) {
+        setConnections((connections) =>
+          connections.map((cs) =>
+            cs.unique === updatedConnection.unique ? updatedConnection : cs
+          )
+        )
+      }
+    },
+    [connections]
+  )
+
+  return useMemo(
+    () => ({
+      connections,
+      onRefresh: handleRefresh,
+      onTest: handleTest
+    }),
+    [connections]
+  )
+}

--- a/config-ui/src/store/index.ts
+++ b/config-ui/src/store/index.ts
@@ -16,9 +16,4 @@
  *
  */
 
-type ID = string | number
-
-declare module '*.svg' {
-  const content: any
-  export default content
-}
+export * from './connections'


### PR DESCRIPTION
### Summary

Add global **connections** store.

### Why add this store？

Connections are used in many places throughout the config UI. And every time it is used, a request will be sent to get this information. This results in meaningless requests and performance loss. Maintaining connections in multiple places also causes inconsistency.
