### PR TITLE
refactor: add transformationRuleName to the scope APIs

### DIFF
--- a/plugins/github/models/repo.go
+++ b/plugins/github/models/repo.go
@@ -28,7 +28,7 @@ type GithubRepo struct {
 	Name                 string     `json:"name" gorm:"type:varchar(255)" mapstructure:"name,omitempty"`
 	HTMLUrl              string     `json:"HTMLUrl" gorm:"type:varchar(255)" mapstructure:"HTMLUrl,omitempty"`
 	Description          string     `json:"description" mapstructure:"description,omitempty"`
-	TransformationRuleId uint64     `json:"transformationRuleId" mapstructure:"transformationRuleId,omitempty"`
+	TransformationRuleId uint64     `json:"transformationRuleId,omitempty" mapstructure:"transformationRuleId,omitempty"`
 	OwnerId              int        `json:"ownerId" mapstructure:"ownerId,omitempty"`
 	OwnerLogin           string     `json:"ownerLogin" gorm:"type:varchar(255)" mapstructure:"ownerLogin,omitempty"`
 	Language             string     `json:"language" gorm:"type:varchar(255)" mapstructure:"language,omitempty"`

--- a/plugins/gitlab/models/project.go
+++ b/plugins/gitlab/models/project.go
@@ -25,7 +25,7 @@ import (
 
 type GitlabProject struct {
 	ConnectionId            uint64 `json:"connectionId" mapstructure:"connectionId" gorm:"primaryKey"`
-	TransformationRuleId    uint64 `json:"transformationRuleId" mapstructure:"transformationRuleId"`
+	TransformationRuleId    uint64 `json:"transformationRuleId,omitempty" mapstructure:"transformationRuleId"`
 	GitlabId                int    `json:"gitlabId" mapstructure:"gitlabId" gorm:"primaryKey"`
 	Name                    string `json:"name" mapstructure:"name" gorm:"type:varchar(255)"`
 	Description             string `json:"description" mapstructure:"description"`

--- a/plugins/jenkins/models/job.go
+++ b/plugins/jenkins/models/job.go
@@ -25,7 +25,7 @@ import (
 type JenkinsJob struct {
 	ConnectionId         uint64 `gorm:"primaryKey" mapstructure:"connectionId,omitempty" json:"connectionId"`
 	FullName             string `gorm:"primaryKey;type:varchar(255)" mapstructure:"jobFullName" json:"jobFullName"` // "path1/path2/job name"
-	TransformationRuleId uint64 `mapstructure:"transformationRules,omitempty" json:"transformationRuleId"`
+	TransformationRuleId uint64 `mapstructure:"transformationRules,omitempty" json:"transformationRuleId,omitempty"`
 	Name                 string `gorm:"index;type:varchar(255)" mapstructure:"-,omitempty" json:"-"` // "job name"
 	Path                 string `gorm:"index;type:varchar(511)" mapstructure:"-,omitempty" json:"-"` // "job/path1/job/path2"
 	Class                string `gorm:"type:varchar(255)" mapstructure:"class,omitempty" json:"class"`
@@ -34,7 +34,7 @@ type JenkinsJob struct {
 	Url                  string `mapstructure:"url,omitempty" json:"url"`
 	Description          string `mapstructure:"description,omitempty" json:"description"`
 	PrimaryView          string `gorm:"type:varchar(255)" mapstructure:"primaryView,omitempty" json:"primaryView"`
-	common.NoPKModel     `mapstructure:"-"`
+	common.NoPKModel     `json:"-" mapstructure:"-"`
 }
 
 func (JenkinsJob) TableName() string {

--- a/plugins/jira/models/board.go
+++ b/plugins/jira/models/board.go
@@ -22,10 +22,10 @@ import (
 )
 
 type JiraBoard struct {
-	common.NoPKModel     `mapstructure:"-"`
+	common.NoPKModel     `json:"-" mapstructure:"-"`
 	ConnectionId         uint64 `json:"connectionId" mapstructure:"connectionId" gorm:"primaryKey"`
 	BoardId              uint64 `json:"boardId" mapstructure:"boardId" gorm:"primaryKey"`
-	TransformationRuleId uint64 `json:"transformationRuleId" mapstructure:"transformationRuleId"`
+	TransformationRuleId uint64 `json:"transformationRuleId,omitempty" mapstructure:"transformationRuleId"`
 	ProjectId            uint   `json:"projectId" mapstructure:"projectId"`
 	Name                 string `json:"name" mapstructure:"name" gorm:"type:varchar(255)"`
 	Self                 string `json:"self" mapstructure:"self" gorm:"type:varchar(255)"`


### PR DESCRIPTION
### Summary
Add `transformationRuleName` to the response of the following API:

GET `/plugins/jira/connections/{connectionId}/scopes/`
GET `/plugins/jira/connections/{connectionId}/scopes/{scopeId}`
GET `/plugins/github/connections/{connectionId}/scopes/`
GET `/plugins/github/connections/{connectionId}/scopes/{scopeId}`
GET `/plugins/gitlab/connections/{connectionId}/scopes/`
GET `/plugins/gitlab/connections/{connectionId}/scopes/{scopeId}`
GET `/plugins/jenkins/connections/{connectionId}/scopes/`
GET `/plugins/jenkins/connections/{connectionId}/scopes/{scopeId}`

### Does this close any open issues?
No, related to #3468 

### Screenshots
![image](https://user-images.githubusercontent.com/8455907/205594421-8de82ab9-bde7-4a82-a9b6-e166ad71deea.png)


