### PR TITLE
feat: add scope for cicd in webhook

### DIFF
--- a/plugins/webhook/api/blueprint_v200.go
+++ b/plugins/webhook/api/blueprint_v200.go
@@ -1,0 +1,57 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"fmt"
+	"github.com/apache/incubator-devlake/errors"
+	"github.com/apache/incubator-devlake/models/domainlayer"
+	"github.com/apache/incubator-devlake/models/domainlayer/devops"
+	"github.com/apache/incubator-devlake/plugins/core"
+	"github.com/apache/incubator-devlake/plugins/webhook/models"
+	"github.com/apache/incubator-devlake/utils"
+)
+
+func MakeDataSourcePipelinePlanV200(_ []core.SubTaskMeta, connectionId uint64, bpScopes []*core.BlueprintScopeV200) (core.PipelinePlan, []core.Scope, errors.Error) {
+	// get the connection info for url
+	connection := &models.WebhookConnection{}
+	err := connectionHelper.FirstById(connection, connectionId)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	plan := make(core.PipelinePlan, 0, len(bpScopes))
+	scopes := make([]core.Scope, 0, len(bpScopes))
+	for _, bpScope := range bpScopes {
+		// add cicd_scope to scopes
+		if utils.StringsContains(bpScope.Entities, core.DOMAIN_TYPE_CICD) {
+			scopeCICD := &devops.CicdScope{
+				DomainEntity: domainlayer.DomainEntity{
+					Id: fmt.Sprintf("%s:%d", "webhook", connection.ID),
+				},
+				Name: connection.Name,
+			}
+			scopes = append(scopes, scopeCICD)
+		}
+		// NOTICE:
+		//if utils.StringsContains(bpScope.Entities, core.DOMAIN_TYPE_TICKET) {}
+		// issue board will be created when post issue
+	}
+
+	return plan, scopes, nil
+}

--- a/plugins/webhook/api/blueprint_v200.go
+++ b/plugins/webhook/api/blueprint_v200.go
@@ -24,10 +24,9 @@ import (
 	"github.com/apache/incubator-devlake/models/domainlayer/devops"
 	"github.com/apache/incubator-devlake/plugins/core"
 	"github.com/apache/incubator-devlake/plugins/webhook/models"
-	"github.com/apache/incubator-devlake/utils"
 )
 
-func MakeDataSourcePipelinePlanV200(_ []core.SubTaskMeta, connectionId uint64, bpScopes []*core.BlueprintScopeV200) (core.PipelinePlan, []core.Scope, errors.Error) {
+func MakeDataSourcePipelinePlanV200(connectionId uint64) (core.PipelinePlan, []core.Scope, errors.Error) {
 	// get the connection info for url
 	connection := &models.WebhookConnection{}
 	err := connectionHelper.FirstById(connection, connectionId)
@@ -35,23 +34,16 @@ func MakeDataSourcePipelinePlanV200(_ []core.SubTaskMeta, connectionId uint64, b
 		return nil, nil, err
 	}
 
-	plan := make(core.PipelinePlan, 0, len(bpScopes))
-	scopes := make([]core.Scope, 0, len(bpScopes))
-	for _, bpScope := range bpScopes {
-		// add cicd_scope to scopes
-		if utils.StringsContains(bpScope.Entities, core.DOMAIN_TYPE_CICD) {
-			scopeCICD := &devops.CicdScope{
-				DomainEntity: domainlayer.DomainEntity{
-					Id: fmt.Sprintf("%s:%d", "webhook", connection.ID),
-				},
-				Name: connection.Name,
-			}
-			scopes = append(scopes, scopeCICD)
-		}
-		// NOTICE:
-		//if utils.StringsContains(bpScope.Entities, core.DOMAIN_TYPE_TICKET) {}
-		// issue board will be created when post issue
+	scopes := make([]core.Scope, 0, 1)
+	// add cicd_scope to scopes
+	scopes[0] = &devops.CicdScope{
+		DomainEntity: domainlayer.DomainEntity{
+			Id: fmt.Sprintf("%s:%d", "webhook", connection.ID),
+		},
+		Name: connection.Name,
 	}
-
-	return plan, scopes, nil
+	// NOTICE:
+	//if utils.StringsContains(bpScope.Entities, core.DOMAIN_TYPE_TICKET) {}
+	// issue board will be created when post issue
+	return nil, scopes, nil
 }

--- a/plugins/webhook/api/cicd_pipeline.go
+++ b/plugins/webhook/api/cicd_pipeline.go
@@ -299,6 +299,7 @@ func PostDeploymentCicdTask(input *core.ApiResourceInput) (*core.ApiResourceOutp
 
 	db := basicRes.GetDal()
 	urlHash16 := fmt.Sprintf("%x", md5.Sum([]byte(request.RepoUrl)))[:16]
+	scopeId := fmt.Sprintf("%s:%d", "webhook", connection.ID)
 	pipelineId := fmt.Sprintf("%s:%d:%s:%s:%s", "webhook", connection.ID, `pipeline`, urlHash16, request.CommitSha)
 
 	taskId := fmt.Sprintf("%s:%d:%s:%s", "webhook", connection.ID, urlHash16, request.CommitSha)
@@ -312,6 +313,7 @@ func PostDeploymentCicdTask(input *core.ApiResourceInput) (*core.ApiResourceOutp
 		Status:      devops.DONE,
 		Type:        devops.DEPLOYMENT,
 		Environment: request.Environment,
+		CicdScopeId: scopeId,
 	}
 	now := time.Now()
 	if request.StartedDate != nil {
@@ -341,6 +343,7 @@ func PostDeploymentCicdTask(input *core.ApiResourceInput) (*core.ApiResourceOutp
 		FinishedDate: domainCicdTask.FinishedDate,
 		DurationSec:  domainCicdTask.DurationSec,
 		Environment:  domainCicdTask.Environment,
+		CicdScopeId:  scopeId,
 	}
 
 	domainPipelineCommit := &devops.CiCDPipelineCommit{

--- a/plugins/webhook/impl/impl.go
+++ b/plugins/webhook/impl/impl.go
@@ -48,6 +48,10 @@ func (plugin Webhook) GetTablesInfo() []core.Tabler {
 	return []core.Tabler{}
 }
 
+func (plugin Webhook) MakeDataSourcePipelinePlanV200(connectionId uint64, scopes []*core.BlueprintScopeV200) (pp core.PipelinePlan, sc []core.Scope, err errors.Error) {
+	return api.MakeDataSourcePipelinePlanV200(nil, connectionId, scopes)
+}
+
 // PkgPath information lost when compiled as plugin(.so)
 func (plugin Webhook) RootPkgPath() string {
 	return "github.com/apache/incubator-devlake/plugins/webhook"

--- a/plugins/webhook/impl/impl.go
+++ b/plugins/webhook/impl/impl.go
@@ -48,8 +48,8 @@ func (plugin Webhook) GetTablesInfo() []core.Tabler {
 	return []core.Tabler{}
 }
 
-func (plugin Webhook) MakeDataSourcePipelinePlanV200(connectionId uint64, scopes []*core.BlueprintScopeV200) (pp core.PipelinePlan, sc []core.Scope, err errors.Error) {
-	return api.MakeDataSourcePipelinePlanV200(nil, connectionId, scopes)
+func (plugin Webhook) MakeDataSourcePipelinePlanV200(connectionId uint64, _ []*core.BlueprintScopeV200) (pp core.PipelinePlan, sc []core.Scope, err errors.Error) {
+	return api.MakeDataSourcePipelinePlanV200(connectionId)
 }
 
 // PkgPath information lost when compiled as plugin(.so)


### PR DESCRIPTION
### Summary
add scope for cicd in webhook. Just create a virtual scope to keep pace with other plugin and blueprint v200.

This is the implementation of Webhook for data source plugins to support the PluginBlueprintV200 interface.
You can know more detail about the PluginBlueprintV200 interface on issue https://github.com/apache/incubator-devlake/pull/3613

### Does this close any open issues?
Related to https://github.com/apache/incubator-devlake/pull/3613
