### PR TITLE
fix: adjust the case of parameters and fix missing error messages

### DIFF
--- a/api/shared/api_output.go
+++ b/api/shared/api_output.go
@@ -47,7 +47,7 @@ func ApiOutputError(c *gin.Context, err error) {
 		messages := e.Messages()
 		c.JSON(e.GetType().GetHttpCode(), &ApiBody{
 			Success: false,
-			Message: messages.Get(),
+			Message: e.Error(),
 			Causes:  messages.Causes(),
 		})
 	} else {

--- a/models/project.go
+++ b/models/project.go
@@ -20,8 +20,8 @@ package models
 import "github.com/apache/incubator-devlake/models/common"
 
 type BaseProject struct {
-	Name        string `gorm:"primaryKey;type:varchar(255)"`
-	Description string `gorm:"type:text"`
+	Name        string `json:"name" gorm:"primaryKey;type:varchar(255)"`
+	Description string `json:"description" gorm:"type:text"`
 }
 
 type Project struct {
@@ -34,13 +34,13 @@ func (Project) TableName() string {
 }
 
 type BaseMetric struct {
-	PluginName   string `gorm:"primaryKey;type:varchar(255)"`
-	PluginOption string `gorm:"type:text"`
-	Enable       bool   `gorm:"type:boolean"`
+	PluginName   string `json:"pluginName" gorm:"primaryKey;type:varchar(255)"`
+	PluginOption string `json:"pluginOption" gorm:"type:text"`
+	Enable       bool   `json:"enable" gorm:"type:boolean"`
 }
 
 type BaseProjectMetric struct {
-	ProjectName string `gorm:"primaryKey;type:varchar(255)"`
+	ProjectName string `json:"projectName" gorm:"primaryKey;type:varchar(255)"`
 	BaseMetric
 }
 
@@ -55,12 +55,12 @@ func (ProjectMetric) TableName() string {
 
 type ApiInputProject struct {
 	BaseProject
-	Enable  *bool
-	Metrics *[]BaseMetric
+	Enable  *bool         `json:"enable"`
+	Metrics *[]BaseMetric `json:"metrics"`
 }
 
 type ApiOutputProject struct {
 	BaseProject
-	Metrics   *[]BaseMetric
-	Blueprint *Blueprint
+	Metrics   *[]BaseMetric `json:"metrics"`
+	Blueprint *Blueprint    `json:"blueprint"`
 }

--- a/services/project_helper.go
+++ b/services/project_helper.go
@@ -20,6 +20,7 @@ package services
 import (
 	goerror "errors"
 	"fmt"
+	"strings"
 
 	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/models"
@@ -30,6 +31,9 @@ import (
 func CreateDbProject(project *models.Project) errors.Error {
 	err := db.Create(project).Error
 	if err != nil {
+		if strings.Contains(err.Error(), "duplicate") {
+			return errors.BadInput.New("The project [%s] already exists,cannot be created again")
+		}
 		return errors.Default.Wrap(err, "error creating DB project")
 	}
 	return nil


### PR DESCRIPTION
### Summary
To maintain the consistency of the interface, after communicating with the front end, it is now decided to adjust the case of the relevant parameters of the project interface, adjust the return value when an error occurs in some interfaces, and fix a problem that causes HTTP to lose necessary error details.

projects_post.sh
```bash
#!/bin/sh
curl --location --request POST 'devlake:8080/projects' \
--header 'Content-Type: application/json' \
--data-raw '{
    "name":"TestProject",
    "description":"this is one of test project"
}'

echo "\r\n"
```

projects_patch.sh
``` bash
#!/bin/sh
curl --location --request PATCH 'devlake:8080/projects/TestProject' \
--header 'Content-Type: application/json' \
--data-raw '{
    "name":"TestProject",
    "description":"this is one of test project witch been patch",
    "enable": false,
    "metrics": [
        {
            "pluginName": "dora",
            "pluginOption": "{}",
            "enable": true
        }
    ]
}'

echo "\r\n"
```

projects_get.sh
```bash
#!/bin/sh
curl --location --request GET 'devlake:8080/projects' \
--header 'Content-Type: application/json' \
--data-raw '{
}'

echo "\r\n"
```

projects_get_one.sh
```bash
#!/bin/sh
curl --location --request GET 'devlake:8080/projects/TestProject' \
--header 'Content-Type: application/json' \
--data-raw '{
}'

echo "\r\n"
```

### Does this close any open issues?
Closes #3854 
Relate #3468 

### Screenshots
![image](https://user-images.githubusercontent.com/2921251/205623624-b45712e1-e7d9-424b-bc51-15494a4b30a7.png)
![image](https://user-images.githubusercontent.com/2921251/205623901-80ffc8f7-0b32-44ee-9040-9ed526065365.png)
![image](https://user-images.githubusercontent.com/2921251/205624278-7ea507ab-d730-4116-816a-994138514a42.png)
![image](https://user-images.githubusercontent.com/2921251/205624360-4c07c1a5-4bcd-4f57-b39d-bdfade613efe.png)


