### PR TITLE
Feat(framework): regenerate plan by blueprint settings before running blueprint

### DIFF
--- a/models/migrationscripts/20221201_add_project_pr_metric.go
+++ b/models/migrationscripts/20221201_add_project_pr_metric.go
@@ -26,9 +26,9 @@ import (
 
 type renameFiledsInProjectPrMetric struct{}
 
-func (u *renameFiledsInProjectPrMetric) Up(baseRes core.BasicRes) errors.Error {
+func (u *renameFiledsInProjectPrMetric) Up(basicRes core.BasicRes) errors.Error {
 	return migrationhelper.AutoMigrateTables(
-		baseRes,
+		basicRes,
 		&archived.ProjectPrMetric{},
 	)
 }


### PR DESCRIPTION
### Summary
This pr modify the process of handling blueprints.
For advanced mode bp, we keep the same process as before
For normal mode bp, we will not set plan for it, and convert bp.settings to pipeline plan for every trigger

In addition, we set all existed normal bp.plan to empty

### Does this close any open issues?
relate to #3468 

### Screenshots
<img width="933" alt="image" src="https://user-images.githubusercontent.com/39366025/205863709-8742e614-97e6-4d74-9f1c-ae957515415f.png">

Every time when we trigger the bp, we can see the following msg
<img width="556" alt="image" src="https://user-images.githubusercontent.com/39366025/205866428-22dcc483-de7d-400a-b9e3-86c5911c29ca.png">

### Other Information
Any other information that is important to this PR.
