### PR TITLE
Feat: jenkins time filter

### DIFF
--- a/plugins/helper/api_collector.go
+++ b/plugins/helper/api_collector.go
@@ -283,7 +283,7 @@ func (collector *ApiCollector) fetchPagesUndetermined(reqData *RequestData) {
 					return nil
 				}
 				apiClient.NextTick(func() errors.Error {
-					reqDataCopy.Pager.Skip += collector.args.PageSize
+					reqDataCopy.Pager.Skip += collector.args.PageSize * concurrency
 					reqDataCopy.Pager.Page += concurrency
 					return collect()
 				})

--- a/plugins/jenkins/jenkins.go
+++ b/plugins/jenkins/jenkins.go
@@ -30,12 +30,14 @@ func main() {
 	connectionId := jenkinsCmd.Flags().Uint64P("connection", "c", 1, "jenkins connection id")
 	jobFullName := jenkinsCmd.Flags().StringP("jobFullName", "j", "", "jenkins job full name")
 	deployTagPattern := jenkinsCmd.Flags().String("deployTagPattern", "(?i)deploy", "deploy tag name")
+	CreatedDateAfter := jenkinsCmd.Flags().StringP("createdDateAfter", "a", "", "collect data that are updated after specified time, ie 2006-05-06T07:08:09Z")
 
 	jenkinsCmd.Run = func(cmd *cobra.Command, args []string) {
 		runner.DirectRun(cmd, args, PluginEntry, map[string]interface{}{
 			"connectionId":     *connectionId,
 			"jobFullName":      jobFullName,
 			"deployTagPattern": *deployTagPattern,
+			"createdDateAfter": *CreatedDateAfter,
 		})
 	}
 	runner.RunCmd(jenkinsCmd)

--- a/plugins/jenkins/tasks/stage_collector.go
+++ b/plugins/jenkins/tasks/stage_collector.go
@@ -77,7 +77,6 @@ func CollectApiStages(taskCtx core.SubTaskContext) errors.Error {
 			Table: RAW_STAGE_TABLE,
 		},
 		ApiClient:   data.ApiClient,
-		PageSize:    100,
 		Input:       iterator,
 		UrlTemplate: fmt.Sprintf("%sjob/%s/{{ .Input.Number }}/wfapi/describe", data.Options.JobPath, data.Options.JobName),
 		/*

--- a/plugins/jenkins/tasks/stage_collector.go
+++ b/plugins/jenkins/tasks/stage_collector.go
@@ -52,8 +52,12 @@ func CollectApiStages(taskCtx core.SubTaskContext) errors.Error {
 	clauses := []dal.Clause{
 		dal.Select("tjb.number,tjb.full_name"),
 		dal.From("_tool_jenkins_builds as tjb"),
-		dal.Where(`tjb.connection_id = ? and tjb.job_path = ? and tjb.job_name = ? and tjb.class = ? `,
+		dal.Where(`tjb.connection_id = ? and tjb.job_path = ? and tjb.job_name = ? and tjb.class = ?`,
 			data.Options.ConnectionId, data.Options.JobPath, data.Options.JobName, "WorkflowRun"),
+	}
+	createdDateAfter := data.CreatedDateAfter
+	if createdDateAfter != nil {
+		clauses = append(clauses, dal.Where(`tjb.start_time >= ?`, createdDateAfter.Format("2006/01/02 15:04")))
 	}
 
 	cursor, err := db.Cursor(clauses...)

--- a/plugins/jenkins/tasks/task_data.go
+++ b/plugins/jenkins/tasks/task_data.go
@@ -47,7 +47,6 @@ type JenkinsTaskData struct {
 	ApiClient  *helper.ApiAsyncClient
 	Connection *models.JenkinsConnection
 	Since      *time.Time
-	Job        *models.JenkinsJob
 }
 
 func DecodeAndValidateTaskOptions(options map[string]interface{}) (*JenkinsOptions, errors.Error) {

--- a/plugins/jenkins/tasks/task_data.go
+++ b/plugins/jenkins/tasks/task_data.go
@@ -37,16 +37,16 @@ type JenkinsOptions struct {
 	JobFullName                       string `json:"JobFullName"` // "path1/path2/job name"
 	JobName                           string `json:"jobName"`     // "job name"
 	JobPath                           string `json:"jobPath"`     // "job/path1/job/path2"
-	Since                             string
+	CreatedDateAfter                  string
 	Tasks                             []string `json:"tasks,omitempty"`
 	*models.JenkinsTransformationRule `mapstructure:"transformationRules" json:"transformationRules"`
 }
 
 type JenkinsTaskData struct {
-	Options    *JenkinsOptions
-	ApiClient  *helper.ApiAsyncClient
-	Connection *models.JenkinsConnection
-	Since      *time.Time
+	Options          *JenkinsOptions
+	ApiClient        *helper.ApiAsyncClient
+	Connection       *models.JenkinsConnection
+	CreatedDateAfter *time.Time
 }
 
 func DecodeAndValidateTaskOptions(options map[string]interface{}) (*JenkinsOptions, errors.Error) {

--- a/plugins/jira/impl/impl.go
+++ b/plugins/jira/impl/impl.go
@@ -175,7 +175,7 @@ func (plugin Jira) PrepareTaskData(taskCtx core.TaskContext, options map[string]
 	if op.CreatedDateAfter != "" {
 		createdDateAfter, err = time.Parse("2006-01-02T15:04:05Z", op.CreatedDateAfter)
 		if err != nil {
-			return nil, errors.BadInput.Wrap(err, "invalid value for `since`")
+			return nil, errors.BadInput.Wrap(err, "invalid value for `createdDateAfter`")
 		}
 	}
 	if op.BoardId == 0 && op.ScopeId != "" {

--- a/plugins/jira/jira.go
+++ b/plugins/jira/jira.go
@@ -32,7 +32,7 @@ func main() {
 	boardId := cmd.Flags().Uint64P("board", "b", 0, "jira board id")
 	_ = cmd.MarkFlagRequired("connection")
 	_ = cmd.MarkFlagRequired("board")
-	CreatedDateAfter := cmd.Flags().StringP("created_date_after", "a", "", "collect data that are updated after specified time, ie 2006-05-06T07:08:09Z")
+	CreatedDateAfter := cmd.Flags().StringP("createdDateAfter", "a", "", "collect data that are updated after specified time, ie 2006-05-06T07:08:09Z")
 	cmd.Run = func(c *cobra.Command, args []string) {
 		runner.DirectRun(c, args, PluginEntry, map[string]interface{}{
 			"connectionId":     *connectionId,


### PR DESCRIPTION
### Summary
1. add CreatedDateAfter for Jenkins. Build collect 100/page and have no time filter params, so not changed. Just collects stages for the build start after `CreatedDateAfter`
2. fix some bugs #3860

### Does this close any open issues?
Closes #3860
