### PR TITLE
Project api support rename

### DIFF
--- a/models/project.go
+++ b/models/project.go
@@ -20,12 +20,12 @@ package models
 import "github.com/apache/incubator-devlake/models/common"
 
 type BaseProject struct {
-	Name        string `json:"name" gorm:"primaryKey;type:varchar(255)"`
-	Description string `json:"description" gorm:"type:text"`
+	Name        string `json:"name" mapstructure:"name" gorm:"primaryKey;type:varchar(255)"`
+	Description string `json:"description" mapstructure:"description" gorm:"type:text"`
 }
 
 type Project struct {
-	BaseProject
+	BaseProject `mapstructure:",squash"`
 	common.NoPKModel
 }
 
@@ -34,18 +34,18 @@ func (Project) TableName() string {
 }
 
 type BaseMetric struct {
-	PluginName   string `json:"pluginName" gorm:"primaryKey;type:varchar(255)"`
-	PluginOption string `json:"pluginOption" gorm:"type:text"`
-	Enable       bool   `json:"enable" gorm:"type:boolean"`
+	PluginName   string `json:"pluginName" mapstructure:"pluginName" gorm:"primaryKey;type:varchar(255)"`
+	PluginOption string `json:"pluginOption" mapstructure:"pluginOption" gorm:"type:text"`
+	Enable       bool   `json:"enable" mapstructure:"enable" gorm:"type:boolean"`
 }
 
 type BaseProjectMetric struct {
-	ProjectName string `json:"projectName" gorm:"primaryKey;type:varchar(255)"`
-	BaseMetric
+	ProjectName string `json:"projectName" mapstructure:"projectName" gorm:"primaryKey;type:varchar(255)"`
+	BaseMetric  `mapstructure:",squash"`
 }
 
 type ProjectMetric struct {
-	BaseProjectMetric
+	BaseProjectMetric `mapstructure:",squash"`
 	common.NoPKModel
 }
 
@@ -54,13 +54,13 @@ func (ProjectMetric) TableName() string {
 }
 
 type ApiInputProject struct {
-	BaseProject
-	Enable  *bool         `json:"enable"`
-	Metrics *[]BaseMetric `json:"metrics"`
+	BaseProject `mapstructure:",squash"`
+	Enable      *bool         `json:"enable" mapstructure:"enable"`
+	Metrics     *[]BaseMetric `json:"metrics" mapstructure:"metrics"`
 }
 
 type ApiOutputProject struct {
-	BaseProject
-	Metrics   *[]BaseMetric `json:"metrics"`
-	Blueprint *Blueprint    `json:"blueprint"`
+	BaseProject `mapstructure:",squash"`
+	Metrics     *[]BaseMetric `json:"metrics" mapstructure:"metrics"`
+	Blueprint   *Blueprint    `json:"blueprint" mapstructure:"blueprint"`
 }

--- a/plugins/core/plugin_handle.go
+++ b/plugins/core/plugin_handle.go
@@ -1,0 +1,28 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"github.com/apache/incubator-devlake/errors"
+)
+
+type PluginHandle interface {
+	// When the projectName in the framework layer is changed
+	// this interface will be checked and this method will be called to synchronize the projectName of each plugin
+	RenameProjectName(oldName string, newName string) errors.Error
+}

--- a/plugins/helper/connection.go
+++ b/plugins/helper/connection.go
@@ -20,10 +20,11 @@ package helper
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/apache/incubator-devlake/errors"
 	"reflect"
 	"strconv"
 	"strings"
+
+	"github.com/apache/incubator-devlake/errors"
 
 	"github.com/apache/incubator-devlake/models/common"
 	"github.com/apache/incubator-devlake/plugins/core"
@@ -165,7 +166,7 @@ func (c *ConnectionApiHelper) save(connection interface{}) errors.Error {
 
 	err := c.db.CreateOrUpdate(connection)
 	if err != nil {
-		if strings.Contains(err.Error(), "duplicate") {
+		if strings.Contains(strings.ToLower(err.Error()), "duplicate") {
 			return errors.BadInput.Wrap(err, "duplicated Connection Name")
 		}
 		return err

--- a/services/blueprint_helper.go
+++ b/services/blueprint_helper.go
@@ -137,13 +137,13 @@ func GetDbBlueprintByProjectName(projectName string) (*models.DbBlueprint, error
 
 // RenameProjectNameForBlueprint FIXME ...
 func RenameProjectNameForBlueprint(oldProjectName string, newProjectName string) errors.Error {
-	err := db.Model(&models.Blueprint{}).
+	err := db.Model(&models.DbBlueprint{}).
 		Where("project_name = ?", oldProjectName).
 		Updates(map[string]interface{}{
 			"project_name": newProjectName,
 		}).Error
 	if err != nil {
-		return errors.Default.Wrap(err, fmt.Sprintf("Failed to RenameProjectNameForBlueprint for [%s] to [%s]", oldProjectName, newProjectName))
+		return errors.Default.Wrap(err, fmt.Sprintf("Failed to RenameProjectNameForBlueprint from [%s] to [%s]", oldProjectName, newProjectName))
 	}
 
 	return nil

--- a/services/blueprint_helper.go
+++ b/services/blueprint_helper.go
@@ -135,6 +135,20 @@ func GetDbBlueprintByProjectName(projectName string) (*models.DbBlueprint, error
 	return dbBlueprint, nil
 }
 
+// RenameProjectNameForBlueprint FIXME ...
+func RenameProjectNameForBlueprint(oldProjectName string, newProjectName string) errors.Error {
+	err := db.Model(&models.Blueprint{}).
+		Where("project_name = ?", oldProjectName).
+		Updates(map[string]interface{}{
+			"project_name": newProjectName,
+		}).Error
+	if err != nil {
+		return errors.Default.Wrap(err, fmt.Sprintf("Failed to RenameProjectNameForBlueprint for [%s] to [%s]", oldProjectName, newProjectName))
+	}
+
+	return nil
+}
+
 // DeleteDbBlueprint deletes blueprint by id
 func DeleteDbBlueprint(id uint64) errors.Error {
 	err := db.Delete(&models.DbBlueprint{}, "id = ?", id).Error

--- a/services/project_helper.go
+++ b/services/project_helper.go
@@ -26,6 +26,7 @@ import (
 	"github.com/apache/incubator-devlake/models"
 	"github.com/apache/incubator-devlake/models/domainlayer/crossdomain"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // CreateDbProject accepts a project instance and insert it to database
@@ -33,7 +34,7 @@ func CreateDbProject(project *models.Project) errors.Error {
 	err := db.Create(project).Error
 	if err != nil {
 		if strings.Contains(strings.ToLower(err.Error()), "duplicate") {
-			return errors.BadInput.New("The project [%s] already exists,cannot be created again")
+			return errors.BadInput.New(fmt.Sprintf("The project [%s] already exists,cannot be created again", project.Name))
 		}
 		return errors.Default.Wrap(err, "error creating DB project")
 	}
@@ -143,6 +144,21 @@ func GetDbProjectMetrics(projectName string) (*[]models.ProjectMetric, int64, er
 	return &projectMetrics, count, nil
 }
 
+// RenameProjectName FIXME ...
+func RenameProjectName(oldProjectName string, newProjectName string) errors.Error {
+	err := db.Exec(
+		"UPDATE ? SET name = ? WHERE name = ?",
+		clause.Table{Name: models.Project{}.TableName()},
+		newProjectName,
+		oldProjectName,
+	).Error
+	if err != nil {
+		return errors.Default.Wrap(err, fmt.Sprintf("Failed to RenameProjectNameForProjectMetric from [%s] to [%s]", oldProjectName, newProjectName))
+	}
+
+	return nil
+}
+
 // RenameProjectNameForProjectMetric FIXME ...
 func RenameProjectNameForProjectMetric(oldProjectName string, newProjectName string) errors.Error {
 	err := db.Model(&models.ProjectMetric{}).
@@ -151,7 +167,7 @@ func RenameProjectNameForProjectMetric(oldProjectName string, newProjectName str
 			"project_name": newProjectName,
 		}).Error
 	if err != nil {
-		return errors.Default.Wrap(err, fmt.Sprintf("Failed to RenameProjectNameForProjectMetric for [%s] to [%s]", oldProjectName, newProjectName))
+		return errors.Default.Wrap(err, fmt.Sprintf("Failed to RenameProjectNameForProjectMetric from [%s] to [%s]", oldProjectName, newProjectName))
 	}
 
 	return nil
@@ -165,7 +181,7 @@ func RenameProjectNameForProjectPrMetric(oldProjectName string, newProjectName s
 			"project_name": newProjectName,
 		}).Error
 	if err != nil {
-		return errors.Default.Wrap(err, fmt.Sprintf("Failed to RenameProjectNameForProjectPrMetric for [%s] to [%s]", oldProjectName, newProjectName))
+		return errors.Default.Wrap(err, fmt.Sprintf("Failed to RenameProjectNameForProjectPrMetric from [%s] to [%s]", oldProjectName, newProjectName))
 	}
 
 	return nil
@@ -179,7 +195,7 @@ func RenameProjectNameForProjectIssueMetric(oldProjectName string, newProjectNam
 			"project_name": newProjectName,
 		}).Error
 	if err != nil {
-		return errors.Default.Wrap(err, fmt.Sprintf("Failed to RenameProjectNameForProjectIssueMetric for [%s] to [%s]", oldProjectName, newProjectName))
+		return errors.Default.Wrap(err, fmt.Sprintf("Failed to RenameProjectNameForProjectIssueMetric from [%s] to [%s]", oldProjectName, newProjectName))
 	}
 
 	return nil
@@ -193,7 +209,7 @@ func RenameProjectNameForProjectMapping(oldProjectName string, newProjectName st
 			"project_name": newProjectName,
 		}).Error
 	if err != nil {
-		return errors.Default.Wrap(err, fmt.Sprintf("Failed to RenameProjectNameForProjectMapping for [%s] to [%s]", oldProjectName, newProjectName))
+		return errors.Default.Wrap(err, fmt.Sprintf("Failed to RenameProjectNameForProjectMapping from [%s] to [%s]", oldProjectName, newProjectName))
 	}
 
 	return nil

--- a/services/project_helper.go
+++ b/services/project_helper.go
@@ -31,7 +31,7 @@ import (
 func CreateDbProject(project *models.Project) errors.Error {
 	err := db.Create(project).Error
 	if err != nil {
-		if strings.Contains(err.Error(), "duplicate") {
+		if strings.Contains(strings.ToLower(err.Error()), "duplicate") {
 			return errors.BadInput.New("The project [%s] already exists,cannot be created again")
 		}
 		return errors.Default.Wrap(err, "error creating DB project")

--- a/services/project_helper.go
+++ b/services/project_helper.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/models"
+	"github.com/apache/incubator-devlake/models/domainlayer/crossdomain"
 	"gorm.io/gorm"
 )
 
@@ -140,6 +141,62 @@ func GetDbProjectMetrics(projectName string) (*[]models.ProjectMetric, int64, er
 	}
 
 	return &projectMetrics, count, nil
+}
+
+// RenameProjectNameForProjectMetric FIXME ...
+func RenameProjectNameForProjectMetric(oldProjectName string, newProjectName string) errors.Error {
+	err := db.Model(&models.ProjectMetric{}).
+		Where("project_name = ?", oldProjectName).
+		Updates(map[string]interface{}{
+			"project_name": newProjectName,
+		}).Error
+	if err != nil {
+		return errors.Default.Wrap(err, fmt.Sprintf("Failed to RenameProjectNameForProjectMetric for [%s] to [%s]", oldProjectName, newProjectName))
+	}
+
+	return nil
+}
+
+// RenameProjectNameForProjectPrMetric FIXME ...
+func RenameProjectNameForProjectPrMetric(oldProjectName string, newProjectName string) errors.Error {
+	err := db.Model(&crossdomain.ProjectPrMetric{}).
+		Where("project_name = ?", oldProjectName).
+		Updates(map[string]interface{}{
+			"project_name": newProjectName,
+		}).Error
+	if err != nil {
+		return errors.Default.Wrap(err, fmt.Sprintf("Failed to RenameProjectNameForProjectPrMetric for [%s] to [%s]", oldProjectName, newProjectName))
+	}
+
+	return nil
+}
+
+// RenameProjectNameForProjectIssueMetric FIXME ...
+func RenameProjectNameForProjectIssueMetric(oldProjectName string, newProjectName string) errors.Error {
+	err := db.Model(&crossdomain.ProjectIssueMetric{}).
+		Where("project_name = ?", oldProjectName).
+		Updates(map[string]interface{}{
+			"project_name": newProjectName,
+		}).Error
+	if err != nil {
+		return errors.Default.Wrap(err, fmt.Sprintf("Failed to RenameProjectNameForProjectIssueMetric for [%s] to [%s]", oldProjectName, newProjectName))
+	}
+
+	return nil
+}
+
+// RenameProjectNameForProjectMapping FIXME ...
+func RenameProjectNameForProjectMapping(oldProjectName string, newProjectName string) errors.Error {
+	err := db.Model(&crossdomain.ProjectMapping{}).
+		Where("project_name = ?", oldProjectName).
+		Updates(map[string]interface{}{
+			"project_name": newProjectName,
+		}).Error
+	if err != nil {
+		return errors.Default.Wrap(err, fmt.Sprintf("Failed to RenameProjectNameForProjectMapping for [%s] to [%s]", oldProjectName, newProjectName))
+	}
+
+	return nil
 }
 
 func removeAllDbProjectMetricsByProjectName(projectName string) errors.Error {


### PR DESCRIPTION
### Summary
To allow the front end to modify the project name, now the back end adds support for project renaming.
Other tables associated with the project will also be renamed synchronously when the project is renamed.
Added the PluginHandle interface, through which the plug-in can synchronize the relevant modifications of the framework layer.

project_patch_rename.sh
```
#!/bin/sh
curl --location --request PATCH 'devlake:8080/projects/TestProject' \
--header 'Content-Type: application/json' \
--data-raw '{
    "name":"NewTestProject",
    "description":"this is one of test project witch been patch",
    "enable": false,
    "metrics": [
        {
            "pluginName": "dora",
            "pluginOption": "{}",
            "enable": true
        }
    ]
}'

echo "\r\n"

```

project_get_newone.sh
```
#!/bin/sh
curl --location --request GET 'devlake:8080/projects/NewTestProject' \
--header 'Content-Type: application/json' \
--data-raw '{
}'

echo "\r\n"
```

project_post.sh
```
#!/bin/sh
curl --location --request POST 'devlake:8080/projects' \
--header 'Content-Type: application/json' \
--data-raw '{
    "name":"TestProject",
    "description":"this is one of test project"
}'

echo "\r\n"
```

### Does this close any open issues?
Closes #3865 

### Screenshots
![image](https://user-images.githubusercontent.com/2921251/206167559-46dccc27-e393-4f10-a6ee-551ad9c6f460.png)
![image](https://user-images.githubusercontent.com/2921251/206167642-94eb2989-58d7-445b-b3d4-d3dc93f9f2d0.png)
![image](https://user-images.githubusercontent.com/2921251/206167760-0fb96b66-0674-40a2-987c-1dfcd61a5521.png)
![image](https://user-images.githubusercontent.com/2921251/206168153-018750d6-461c-43fe-856f-e24274ba4b78.png)
![image](https://user-images.githubusercontent.com/2921251/206169319-46b4beff-88f3-41b5-85f8-df76836cb652.png)
![image](https://user-images.githubusercontent.com/2921251/206169509-d7a06b6f-ba5c-4d82-a3c8-88be18e2ca51.png)
