### PR TITLE
feat: add time filter for github & github graphql; fix some bugs when running

### DIFF
--- a/plugins/github/github.go
+++ b/plugins/github/github.go
@@ -32,6 +32,7 @@ func main() {
 	connectionId := cmd.Flags().Uint64P("connectionId", "c", 0, "github connection id")
 	owner := cmd.Flags().StringP("owner", "o", "", "github owner")
 	repo := cmd.Flags().StringP("repo", "r", "", "github repo")
+	CreatedDateAfter := cmd.Flags().StringP("createdDateAfter", "a", "", "collect data that are created after specified time, ie 2006-05-06T07:08:09Z")
 	_ = cmd.MarkFlagRequired("connectionId")
 	_ = cmd.MarkFlagRequired("owner")
 	_ = cmd.MarkFlagRequired("repo")
@@ -49,9 +50,10 @@ func main() {
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		runner.DirectRun(cmd, args, PluginEntry, map[string]interface{}{
-			"connectionId": *connectionId,
-			"owner":        *owner,
-			"repo":         *repo,
+			"connectionId":     *connectionId,
+			"owner":            *owner,
+			"repo":             *repo,
+			"createdDateAfter": *CreatedDateAfter,
 			"transformationRules": map[string]interface{}{
 				"prType":               *prType,
 				"prComponent":          *prComponent,

--- a/plugins/github/impl/impl.go
+++ b/plugins/github/impl/impl.go
@@ -164,11 +164,11 @@ func (plugin Github) PrepareTaskData(taskCtx core.TaskContext, options map[strin
 		return nil, err
 	}
 
-	var since time.Time
-	if op.Since != "" {
-		since, err = errors.Convert01(time.Parse("2006-01-02T15:04:05Z", op.Since))
+	var createdDateAfter time.Time
+	if op.CreatedDateAfter != "" {
+		createdDateAfter, err = errors.Convert01(time.Parse("2006-01-02T15:04:05Z", op.CreatedDateAfter))
 		if err != nil {
-			return nil, errors.BadInput.Wrap(err, "invalid value for `since`")
+			return nil, errors.BadInput.Wrap(err, "invalid value for `createdDateAfter`")
 		}
 	}
 	apiClient, err := tasks.CreateApiClient(taskCtx, connection)
@@ -181,9 +181,9 @@ func (plugin Github) PrepareTaskData(taskCtx core.TaskContext, options map[strin
 		Repo:      githubRepo,
 	}
 
-	if !since.IsZero() {
-		taskData.Since = &since
-		logger.Debug("collect data updated since %s", since)
+	if !createdDateAfter.IsZero() {
+		taskData.CreatedDateAfter = &createdDateAfter
+		logger.Debug("collect data updated createdDateAfter %s", createdDateAfter)
 	}
 	return taskData, nil
 }

--- a/plugins/github/tasks/cicd_run_collector.go
+++ b/plugins/github/tasks/cicd_run_collector.go
@@ -41,20 +41,16 @@ var CollectRunsMeta = core.SubTaskMeta{
 func CollectRuns(taskCtx core.SubTaskContext) errors.Error {
 	data := taskCtx.GetData().(*GithubTaskData)
 
-	collectorWithState, err := helper.NewApiCollectorWithState(helper.RawDataSubTaskArgs{
-		Ctx: taskCtx,
-		Params: GithubApiParams{
-			ConnectionId: data.Options.ConnectionId,
-			Owner:        data.Options.Owner,
-			Repo:         data.Options.Repo,
+	collector, err := helper.NewApiCollector(helper.ApiCollectorArgs{
+		RawDataSubTaskArgs: helper.RawDataSubTaskArgs{
+			Ctx: taskCtx,
+			Params: GithubApiParams{
+				ConnectionId: data.Options.ConnectionId,
+				Owner:        data.Options.Owner,
+				Repo:         data.Options.Repo,
+			},
+			Table: RAW_RUN_TABLE,
 		},
-		Table: RAW_RUN_TABLE,
-	}, data.CreatedDateAfter)
-	if err != nil {
-		return err
-	}
-
-	err = collectorWithState.InitCollector(helper.ApiCollectorArgs{
 		ApiClient:   data.ApiClient,
 		PageSize:    30,
 		Incremental: false,
@@ -82,7 +78,7 @@ func CollectRuns(taskCtx core.SubTaskContext) errors.Error {
 		return err
 	}
 
-	return collectorWithState.Execute()
+	return collector.Execute()
 }
 
 type GithubRawRunsResult struct {

--- a/plugins/github/tasks/comment_collector.go
+++ b/plugins/github/tasks/comment_collector.go
@@ -20,13 +20,12 @@ package tasks
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/apache/incubator-devlake/errors"
 	"net/http"
 	"net/url"
 
-	"github.com/apache/incubator-devlake/plugins/helper"
-
+	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/plugins/core"
+	"github.com/apache/incubator-devlake/plugins/helper"
 )
 
 const RAW_COMMENTS_TABLE = "github_api_comments"

--- a/plugins/github/tasks/commit_collector.go
+++ b/plugins/github/tasks/commit_collector.go
@@ -21,16 +21,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/apache/incubator-devlake/errors"
+	"github.com/apache/incubator-devlake/plugins/helper"
 	"net/http"
 	"net/url"
-	"time"
-
-	"github.com/apache/incubator-devlake/plugins/core/dal"
-
-	"github.com/apache/incubator-devlake/plugins/helper"
 
 	"github.com/apache/incubator-devlake/plugins/core"
-	"github.com/apache/incubator-devlake/plugins/github/models"
 )
 
 const RAW_COMMIT_TABLE = "github_api_commits"
@@ -44,9 +39,7 @@ var CollectApiCommitsMeta = core.SubTaskMeta{
 }
 
 func CollectApiCommits(taskCtx core.SubTaskContext) errors.Error {
-	db := taskCtx.GetDal()
 	data := taskCtx.GetData().(*GithubTaskData)
-
 	collectorWithState, err := helper.NewApiCollectorWithState(helper.RawDataSubTaskArgs{
 		Ctx: taskCtx,
 		Params: GithubApiParams{
@@ -60,30 +53,7 @@ func CollectApiCommits(taskCtx core.SubTaskContext) errors.Error {
 		return err
 	}
 
-	var latestUpdatedTime *time.Time
 	incremental := collectorWithState.CanIncrementCollect()
-	// user didn't specify a time range to sync, try load from database
-	if incremental {
-		latestUpdated := &models.GithubCommit{}
-		err = db.All(
-			&latestUpdated,
-			dal.Join("left join _tool_github_repo_commits on _tool_github_commits.sha = _tool_github_repo_commits.commit_sha"),
-			dal.Join("left join _tool_github_repos on _tool_github_repo_commits.repo_id = _tool_github_repos.github_id"),
-			dal.Where("_tool_github_repo_commits.repo_id = ? AND _tool_github_repo_commits.connection_id = ?", data.Repo.GithubId, data.Repo.ConnectionId),
-			dal.Orderby("committed_date DESC"),
-			dal.Limit(1),
-		)
-		if err != nil {
-			return errors.Default.Wrap(err, "failed to get latest github commit record")
-		}
-		if latestUpdated.Sha != "" {
-			latestUpdatedTime = &latestUpdated.CommittedDate
-		} else {
-			incremental = false
-
-		}
-	}
-
 	err = collectorWithState.InitCollector(helper.ApiCollectorArgs{
 		ApiClient:   data.ApiClient,
 		PageSize:    100,
@@ -104,8 +74,8 @@ func CollectApiCommits(taskCtx core.SubTaskContext) errors.Error {
 		Query: func(reqData *helper.RequestData) (url.Values, errors.Error) {
 			query := url.Values{}
 			query.Set("state", "all")
-			if latestUpdatedTime != nil {
-				query.Set("since", latestUpdatedTime.String())
+			if incremental {
+				query.Set("since", collectorWithState.LatestState.LatestSuccessStart.String())
 			}
 			query.Set("direction", "asc")
 			query.Set("page", fmt.Sprintf("%v", reqData.Pager.Page))

--- a/plugins/github/tasks/commit_collector.go
+++ b/plugins/github/tasks/commit_collector.go
@@ -20,12 +20,12 @@ package tasks
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/apache/incubator-devlake/errors"
-	"github.com/apache/incubator-devlake/plugins/helper"
 	"net/http"
 	"net/url"
 
+	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/plugins/core"
+	"github.com/apache/incubator-devlake/plugins/helper"
 )
 
 const RAW_COMMIT_TABLE = "github_api_commits"

--- a/plugins/github/tasks/event_collector.go
+++ b/plugins/github/tasks/event_collector.go
@@ -21,16 +21,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/apache/incubator-devlake/errors"
+	"github.com/apache/incubator-devlake/plugins/helper"
 	"net/http"
 	"net/url"
-	"time"
-
-	"github.com/apache/incubator-devlake/plugins/core/dal"
-
-	"github.com/apache/incubator-devlake/plugins/helper"
 
 	"github.com/apache/incubator-devlake/plugins/core"
-	"github.com/apache/incubator-devlake/plugins/github/models"
 )
 
 const RAW_EVENTS_TABLE = "github_api_events"
@@ -46,9 +41,7 @@ var CollectApiEventsMeta = core.SubTaskMeta{
 }
 
 func CollectApiEvents(taskCtx core.SubTaskContext) errors.Error {
-	db := taskCtx.GetDal()
 	data := taskCtx.GetData().(*GithubTaskData)
-
 	collectorWithState, err := helper.NewApiCollectorWithState(helper.RawDataSubTaskArgs{
 		Ctx: taskCtx,
 		Params: GithubApiParams{
@@ -62,30 +55,7 @@ func CollectApiEvents(taskCtx core.SubTaskContext) errors.Error {
 		return err
 	}
 
-	var latestUpdatedTime *time.Time
 	incremental := collectorWithState.CanIncrementCollect()
-	// user didn't specify a time range to sync, try load from database
-	// actually, for github pull, since doesn't make any sense, github pull api doesn't support it
-	if incremental {
-		var latestUpdatedIssueEvent models.GithubIssueEvent
-		err := db.All(
-			&latestUpdatedIssueEvent,
-			dal.Join("left join _tool_github_issues on _tool_github_issues.github_id = _tool_github_issue_events.issue_id"),
-			dal.Where("_tool_github_issues.repo_id = ? and _tool_github_issues.repo_id = ?", data.Repo.GithubId, data.Repo.ConnectionId),
-			dal.Orderby("github_created_at DESC"),
-			dal.Limit(1),
-		)
-		if err != nil {
-			return errors.Default.Wrap(err, "failed to get latest github issue record")
-		}
-
-		if latestUpdatedIssueEvent.GithubId > 0 {
-			latestUpdatedTime = &latestUpdatedIssueEvent.GithubCreatedAt
-		} else {
-			incremental = false
-		}
-	}
-
 	err = collectorWithState.InitCollector(helper.ApiCollectorArgs{
 		ApiClient:   data.ApiClient,
 		PageSize:    100,
@@ -95,8 +65,8 @@ func CollectApiEvents(taskCtx core.SubTaskContext) errors.Error {
 		Query: func(reqData *helper.RequestData) (url.Values, errors.Error) {
 			query := url.Values{}
 			query.Set("state", "all")
-			if latestUpdatedTime != nil {
-				query.Set("since", latestUpdatedTime.String())
+			if incremental {
+				query.Set("since", collectorWithState.LatestState.LatestSuccessStart.String())
 			}
 			query.Set("page", fmt.Sprintf("%v", reqData.Pager.Page))
 			query.Set("direction", "asc")

--- a/plugins/github/tasks/event_collector.go
+++ b/plugins/github/tasks/event_collector.go
@@ -20,12 +20,12 @@ package tasks
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/apache/incubator-devlake/errors"
-	"github.com/apache/incubator-devlake/plugins/helper"
 	"net/http"
 	"net/url"
 
+	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/plugins/core"
+	"github.com/apache/incubator-devlake/plugins/helper"
 )
 
 const RAW_EVENTS_TABLE = "github_api_events"

--- a/plugins/github/tasks/issue_collector.go
+++ b/plugins/github/tasks/issue_collector.go
@@ -20,12 +20,12 @@ package tasks
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/apache/incubator-devlake/errors"
-	"github.com/apache/incubator-devlake/plugins/helper"
 	"net/http"
 	"net/url"
 
+	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/plugins/core"
+	"github.com/apache/incubator-devlake/plugins/helper"
 )
 
 const RAW_ISSUE_TABLE = "github_api_issues"

--- a/plugins/github/tasks/issue_collector.go
+++ b/plugins/github/tasks/issue_collector.go
@@ -23,6 +23,7 @@ import (
 	"github.com/apache/incubator-devlake/errors"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/apache/incubator-devlake/plugins/core/dal"
 
@@ -33,13 +34,6 @@ import (
 )
 
 const RAW_ISSUE_TABLE = "github_api_issues"
-
-// this struct should be moved to `gitub_api_common.go`
-type GithubApiParams struct {
-	ConnectionId uint64
-	Owner        string
-	Repo         string
-}
 
 var CollectApiIssuesMeta = core.SubTaskMeta{
 	Name:             "collectApiIssues",
@@ -53,12 +47,25 @@ func CollectApiIssues(taskCtx core.SubTaskContext) errors.Error {
 	db := taskCtx.GetDal()
 	data := taskCtx.GetData().(*GithubTaskData)
 
-	since := data.Since
-	incremental := false
-	// user didn't specify a time range to sync, try load from database
-	if since == nil {
+	collectorWithState, err := helper.NewApiCollectorWithState(helper.RawDataSubTaskArgs{
+		Ctx: taskCtx,
+		Params: GithubApiParams{
+			ConnectionId: data.Options.ConnectionId,
+			Owner:        data.Options.Owner,
+			Repo:         data.Options.Repo,
+		},
+		Table: RAW_ISSUE_TABLE,
+	}, data.CreatedDateAfter)
+	if err != nil {
+		return err
+	}
+
+	var latestUpdatedTime *time.Time
+	incremental := collectorWithState.CanIncrementCollect()
+	if incremental {
+		// try load from database
 		var latestUpdated models.GithubIssue
-		err := db.All(
+		err = db.All(
 			&latestUpdated,
 			dal.Where("repo_id = ? and connection_id = ?", data.Repo.GithubId, data.Repo.ConnectionId),
 			dal.Orderby("github_updated_at DESC"),
@@ -68,28 +75,13 @@ func CollectApiIssues(taskCtx core.SubTaskContext) errors.Error {
 			return errors.Default.Wrap(err, "failed to get latest github issue record")
 		}
 		if latestUpdated.GithubId > 0 {
-			since = &latestUpdated.GithubUpdatedAt
-			incremental = true
+			latestUpdatedTime = &latestUpdated.GithubUpdatedAt
+		} else {
+			incremental = false
 		}
 	}
 
-	collector, err := helper.NewApiCollector(helper.ApiCollectorArgs{
-		RawDataSubTaskArgs: helper.RawDataSubTaskArgs{
-			Ctx: taskCtx,
-			/*
-				This struct will be JSONEncoded and stored into database along with raw data itself, to identity minimal
-				set of data to be process, for example, we process JiraIssues by Board
-			*/
-			Params: GithubApiParams{
-				ConnectionId: data.Options.ConnectionId,
-				Owner:        data.Options.Owner,
-				Repo:         data.Options.Repo,
-			},
-			/*
-				Table store raw data
-			*/
-			Table: RAW_ISSUE_TABLE,
-		},
+	err = collectorWithState.InitCollector(helper.ApiCollectorArgs{
 		ApiClient:   data.ApiClient,
 		PageSize:    100,
 		Incremental: incremental,
@@ -109,8 +101,9 @@ func CollectApiIssues(taskCtx core.SubTaskContext) errors.Error {
 		Query: func(reqData *helper.RequestData) (url.Values, errors.Error) {
 			query := url.Values{}
 			query.Set("state", "all")
-			if since != nil {
-				query.Set("since", since.String())
+			// data.CreatedDateAfter need to be used to filter data, but now no params supported
+			if latestUpdatedTime != nil {
+				query.Set("since", latestUpdatedTime.String())
 			}
 			query.Set("direction", "asc")
 			query.Set("page", fmt.Sprintf("%v", reqData.Pager.Page))
@@ -149,5 +142,5 @@ func CollectApiIssues(taskCtx core.SubTaskContext) errors.Error {
 		return err
 	}
 
-	return collector.Execute()
+	return collectorWithState.Execute()
 }

--- a/plugins/github/tasks/issue_extractor.go
+++ b/plugins/github/tasks/issue_extractor.go
@@ -225,6 +225,9 @@ func convertGithubLabels(issueRegexes *IssueRegexes, issue *IssuesResponse, gith
 
 func NewIssueRegexes(config *models.GithubTransformationRule) (*IssueRegexes, errors.Error) {
 	var issueRegexes IssueRegexes
+	if config == nil {
+		return &issueRegexes, nil
+	}
 	var issueSeverity = config.IssueSeverity
 	var err error
 	if len(issueSeverity) > 0 {

--- a/plugins/github/tasks/pr_collector.go
+++ b/plugins/github/tasks/pr_collector.go
@@ -53,20 +53,16 @@ func CollectApiPullRequests(taskCtx core.SubTaskContext) errors.Error {
 		return err
 	}
 
-	incremental := collectorWithState.CanIncrementCollect()
 	err = collectorWithState.InitCollector(helper.ApiCollectorArgs{
 		ApiClient:   data.ApiClient,
 		PageSize:    100,
-		Incremental: incremental,
+		Incremental: false,
 
 		UrlTemplate: "repos/{{ .Params.Owner }}/{{ .Params.Repo }}/pulls",
 
 		Query: func(reqData *helper.RequestData) (url.Values, errors.Error) {
 			query := url.Values{}
 			query.Set("state", "all")
-			if incremental {
-				query.Set("since", collectorWithState.LatestState.LatestSuccessStart.String())
-			}
 			query.Set("page", fmt.Sprintf("%v", reqData.Pager.Page))
 			query.Set("direction", "asc")
 			query.Set("per_page", fmt.Sprintf("%v", reqData.Pager.Size))

--- a/plugins/github/tasks/pr_collector.go
+++ b/plugins/github/tasks/pr_collector.go
@@ -20,12 +20,12 @@ package tasks
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/apache/incubator-devlake/errors"
-	"github.com/apache/incubator-devlake/plugins/helper"
 	"net/http"
 	"net/url"
 
+	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/plugins/core"
+	"github.com/apache/incubator-devlake/plugins/helper"
 )
 
 const RAW_PULL_REQUEST_TABLE = "github_api_pull_requests"

--- a/plugins/github/tasks/pr_collector.go
+++ b/plugins/github/tasks/pr_collector.go
@@ -23,6 +23,7 @@ import (
 	"github.com/apache/incubator-devlake/errors"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/apache/incubator-devlake/plugins/core/dal"
 
@@ -33,8 +34,6 @@ import (
 )
 
 const RAW_PULL_REQUEST_TABLE = "github_api_pull_requests"
-
-// this struct should be moved to `gitub_api_common.go`
 
 var CollectApiPullRequestsMeta = core.SubTaskMeta{
 	Name:             "collectApiPullRequests",
@@ -48,11 +47,24 @@ func CollectApiPullRequests(taskCtx core.SubTaskContext) errors.Error {
 	db := taskCtx.GetDal()
 	data := taskCtx.GetData().(*GithubTaskData)
 
-	since := data.Since
-	incremental := false
+	collectorWithState, err := helper.NewApiCollectorWithState(helper.RawDataSubTaskArgs{
+		Ctx: taskCtx,
+		Params: GithubApiParams{
+			ConnectionId: data.Options.ConnectionId,
+			Owner:        data.Options.Owner,
+			Repo:         data.Options.Repo,
+		},
+		Table: RAW_PULL_REQUEST_TABLE,
+	}, data.CreatedDateAfter)
+	if err != nil {
+		return err
+	}
+
+	var latestUpdatedTime *time.Time
+	incremental := collectorWithState.CanIncrementCollect()
 	// user didn't specify a time range to sync, try load from database
 	// actually, for github pull, since doesn't make any sense, github pull api doesn't support it
-	if since == nil {
+	if incremental {
 		var latestUpdated models.GithubPullRequest
 		err := db.All(
 			&latestUpdated,
@@ -64,24 +76,13 @@ func CollectApiPullRequests(taskCtx core.SubTaskContext) errors.Error {
 			return errors.Default.Wrap(err, "failed to get latest github issue record")
 		}
 		if latestUpdated.GithubId > 0 {
-			since = &latestUpdated.GithubUpdatedAt
-			incremental = true
+			latestUpdatedTime = &latestUpdated.GithubUpdatedAt
+		} else {
+			incremental = false
 		}
 	}
 
-	collector, err := helper.NewApiCollector(helper.ApiCollectorArgs{
-		RawDataSubTaskArgs: helper.RawDataSubTaskArgs{
-			Ctx: taskCtx,
-			Params: GithubApiParams{
-				ConnectionId: data.Options.ConnectionId,
-				Owner:        data.Options.Owner,
-				Repo:         data.Options.Repo,
-			},
-			/*
-				Table store raw data
-			*/
-			Table: RAW_PULL_REQUEST_TABLE,
-		},
+	err = collectorWithState.InitCollector(helper.ApiCollectorArgs{
 		ApiClient:   data.ApiClient,
 		PageSize:    100,
 		Incremental: incremental,
@@ -91,8 +92,8 @@ func CollectApiPullRequests(taskCtx core.SubTaskContext) errors.Error {
 		Query: func(reqData *helper.RequestData) (url.Values, errors.Error) {
 			query := url.Values{}
 			query.Set("state", "all")
-			if since != nil {
-				query.Set("since", since.String())
+			if latestUpdatedTime != nil {
+				query.Set("since", latestUpdatedTime.String())
 			}
 			query.Set("page", fmt.Sprintf("%v", reqData.Pager.Page))
 			query.Set("direction", "asc")
@@ -111,10 +112,9 @@ func CollectApiPullRequests(taskCtx core.SubTaskContext) errors.Error {
 			return items, nil
 		},
 	})
-
 	if err != nil {
 		return err
 	}
 
-	return collector.Execute()
+	return collectorWithState.Execute()
 }

--- a/plugins/github/tasks/pr_commit_collector.go
+++ b/plugins/github/tasks/pr_commit_collector.go
@@ -54,12 +54,29 @@ func CollectApiPullRequestCommits(taskCtx core.SubTaskContext) errors.Error {
 	db := taskCtx.GetDal()
 	data := taskCtx.GetData().(*GithubTaskData)
 
-	incremental := false
+	collectorWithState, err := helper.NewApiCollectorWithState(helper.RawDataSubTaskArgs{
+		Ctx: taskCtx,
+		Params: GithubApiParams{
+			ConnectionId: data.Options.ConnectionId,
+			Owner:        data.Options.Owner,
+			Repo:         data.Options.Repo,
+		},
+		Table: RAW_PR_COMMIT_TABLE,
+	}, data.CreatedDateAfter)
+	if err != nil {
+		return err
+	}
 
-	cursor, err := db.Cursor(
+	clauses := []dal.Clause{
 		dal.Select("number, github_id"),
 		dal.From(models.GithubPullRequest{}.TableName()),
 		dal.Where("repo_id = ? and connection_id=?", data.Repo.GithubId, data.Options.ConnectionId),
+	}
+	if collectorWithState.CreatedDateAfter != nil {
+		clauses = append(clauses, dal.Where("github_created_at > ?", *collectorWithState.CreatedDateAfter))
+	}
+	cursor, err := db.Cursor(
+		clauses...,
 	)
 	if err != nil {
 		return err
@@ -68,27 +85,10 @@ func CollectApiPullRequestCommits(taskCtx core.SubTaskContext) errors.Error {
 	if err != nil {
 		return err
 	}
-	collector, err := helper.NewApiCollector(helper.ApiCollectorArgs{
-		RawDataSubTaskArgs: helper.RawDataSubTaskArgs{
-			Ctx: taskCtx,
-			/*
-				This struct will be JSONEncoded and stored into database along with raw data itself, to identity minimal
-				set of data to be process, for example, we process JiraIssues by Board
-			*/
-			Params: GithubApiParams{
-				ConnectionId: data.Options.ConnectionId,
-				Owner:        data.Options.Owner,
-				Repo:         data.Options.Repo,
-			},
-
-			/*
-				Table store raw data
-			*/
-			Table: RAW_PR_COMMIT_TABLE,
-		},
+	err = collectorWithState.InitCollector(helper.ApiCollectorArgs{
 		ApiClient:   data.ApiClient,
 		PageSize:    100,
-		Incremental: incremental,
+		Incremental: false,
 		Input:       iterator,
 
 		UrlTemplate: "repos/{{ .Params.Owner }}/{{ .Params.Repo }}/pulls/{{ .Input.Number }}/commits",
@@ -128,9 +128,9 @@ func CollectApiPullRequestCommits(taskCtx core.SubTaskContext) errors.Error {
 			return items, nil
 		},
 	})
-
 	if err != nil {
 		return err
 	}
-	return collector.Execute()
+
+	return collectorWithState.Execute()
 }

--- a/plugins/github/tasks/pr_review_collector.go
+++ b/plugins/github/tasks/pr_review_collector.go
@@ -20,15 +20,15 @@ package tasks
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/apache/incubator-devlake/errors"
-	"github.com/apache/incubator-devlake/plugins/core/dal"
-	"github.com/apache/incubator-devlake/plugins/github/models"
-	"github.com/apache/incubator-devlake/plugins/helper"
 	"net/http"
 	"net/url"
 	"reflect"
 
+	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/plugins/core"
+	"github.com/apache/incubator-devlake/plugins/core/dal"
+	"github.com/apache/incubator-devlake/plugins/github/models"
+	"github.com/apache/incubator-devlake/plugins/helper"
 )
 
 const RAW_PR_REVIEW_TABLE = "github_api_pull_request_reviews"

--- a/plugins/github/tasks/pr_review_comment_collector.go
+++ b/plugins/github/tasks/pr_review_comment_collector.go
@@ -20,11 +20,12 @@ package tasks
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
+
 	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/plugins/core"
 	"github.com/apache/incubator-devlake/plugins/helper"
-	"net/http"
-	"net/url"
 )
 
 const RAW_PR_REVIEW_COMMENTS_TABLE = "github_api_pull_request_review_comments"

--- a/plugins/github/tasks/task_data.go
+++ b/plugins/github/tasks/task_data.go
@@ -31,18 +31,24 @@ type GithubOptions struct {
 	TransformationRuleId             uint64   `json:"transformationRuleId" mapstructure:"transformationRuleId,omitempty"`
 	ScopeId                          string   `json:"scopeId" mapstructure:"scopeId,omitempty"`
 	Tasks                            []string `json:"tasks,omitempty" mapstructure:",omitempty"`
-	Since                            string   `json:"since" mapstructure:"since,omitempty"`
+	CreatedDateAfter                 string   `json:"createdDateAfter" mapstructure:"createdDateAfter,omitempty"`
 	Owner                            string   `json:"owner" mapstructure:"owner,omitempty"`
 	Repo                             string   `json:"repo"  mapstructure:"repo,omitempty"`
 	*models.GithubTransformationRule `mapstructure:"transformationRules,omitempty" json:"transformationRules"`
 }
 
 type GithubTaskData struct {
-	Options       *GithubOptions
-	ApiClient     *helper.ApiAsyncClient
-	GraphqlClient *helper.GraphqlAsyncClient
-	Since         *time.Time
-	Repo          *models.GithubRepo
+	Options          *GithubOptions
+	ApiClient        *helper.ApiAsyncClient
+	GraphqlClient    *helper.GraphqlAsyncClient
+	CreatedDateAfter *time.Time
+	Repo             *models.GithubRepo
+}
+
+type GithubApiParams struct {
+	ConnectionId uint64
+	Owner        string
+	Repo         string
 }
 
 func DecodeAndValidateTaskOptions(options map[string]interface{}) (*GithubOptions, errors.Error) {

--- a/plugins/github_graphql/impl/impl.go
+++ b/plugins/github_graphql/impl/impl.go
@@ -197,6 +197,7 @@ func (plugin GithubGraphql) PrepareTaskData(taskCtx core.TaskContext, options ma
 		Options:       &op,
 		ApiClient:     apiClient,
 		GraphqlClient: graphqlClient,
+		Repo:          &repo,
 	}
 	if !createdDateAfter.IsZero() {
 		taskData.CreatedDateAfter = &createdDateAfter

--- a/plugins/github_graphql/impl/impl.go
+++ b/plugins/github_graphql/impl/impl.go
@@ -147,7 +147,7 @@ func (plugin GithubGraphql) PrepareTaskData(taskCtx core.TaskContext, options ma
 		return nil, errors.Default.Wrap(err, "unable to get github connection by the given connection ID: %v")
 	}
 
-	_, err = EnrichOptions(taskCtx, &op, connection)
+	githubRepo, err := EnrichOptions(taskCtx, &op, connection)
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +197,7 @@ func (plugin GithubGraphql) PrepareTaskData(taskCtx core.TaskContext, options ma
 		Options:       &op,
 		ApiClient:     apiClient,
 		GraphqlClient: graphqlClient,
-		Repo:          &repo,
+		Repo:          githubRepo,
 	}
 	if !createdDateAfter.IsZero() {
 		taskData.CreatedDateAfter = &createdDateAfter

--- a/plugins/github_graphql/impl/impl.go
+++ b/plugins/github_graphql/impl/impl.go
@@ -75,7 +75,7 @@ func (plugin GithubGraphql) GetTablesInfo() []core.Tabler {
 
 func (plugin GithubGraphql) SubTaskMetas() []core.SubTaskMeta {
 	return []core.SubTaskMeta{
-		tasks.CollectRepoMeta,
+		//tasks.CollectRepoMeta,
 
 		// collect millstones
 		githubTasks.CollectMilestonesMeta,

--- a/plugins/github_graphql/plugin_main.go
+++ b/plugins/github_graphql/plugin_main.go
@@ -32,15 +32,17 @@ func main() {
 	connectionId := cmd.Flags().Uint64P("connectionId", "c", 0, "github connection id")
 	owner := cmd.Flags().StringP("owner", "o", "", "github owner")
 	repo := cmd.Flags().StringP("repo", "r", "", "github repo")
+	CreatedDateAfter := cmd.Flags().StringP("createdDateAfter", "a", "", "collect data that are created after specified time, ie 2006-05-06T07:08:09Z")
 	_ = cmd.MarkFlagRequired("connectionId")
 	_ = cmd.MarkFlagRequired("owner")
 	_ = cmd.MarkFlagRequired("repo")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		runner.DirectRun(cmd, args, PluginEntry, map[string]interface{}{
-			"connectionId": *connectionId,
-			"owner":        *owner,
-			"repo":         *repo,
+			"connectionId":     *connectionId,
+			"owner":            *owner,
+			"repo":             *repo,
+			"createdDateAfter": *CreatedDateAfter,
 		})
 	}
 	runner.RunCmd(cmd)

--- a/plugins/github_graphql/tasks/repo_collector.go
+++ b/plugins/github_graphql/tasks/repo_collector.go
@@ -58,7 +58,7 @@ type GraphqlQueryRepo struct {
 var CollectRepoMeta = core.SubTaskMeta{
 	Name:             "CollectRepo",
 	EntryPoint:       CollectRepo,
-	EnabledByDefault: true,
+	EnabledByDefault: false,
 	Description:      "Collect Repo data from GithubGraphql api",
 	DomainTypes:      []string{core.DOMAIN_TYPE_CODE, core.DOMAIN_TYPE_TICKET, core.DOMAIN_TYPE_CICD, core.DOMAIN_TYPE_CODE_REVIEW, core.DOMAIN_TYPE_CROSS},
 }

--- a/plugins/helper/api_collector_with_state.go
+++ b/plugins/helper/api_collector_with_state.go
@@ -62,16 +62,6 @@ func NewApiCollectorWithState(args RawDataSubTaskArgs, createdDateAfter *time.Ti
 	}, nil
 }
 
-// NewAndInitCollectorWithState create a new ApiCollectorStateManager and init it
-//func NewAndInitCollectorWithState(args ApiCollectorArgs, createdDateAfter *time.Time) (*ApiCollectorStateManager, errors.Error) {
-//	collectorWithState, err := NewApiCollectorWithState(args.RawDataSubTaskArgs, createdDateAfter)
-//	if err != nil {
-//		return nil, err
-//	}
-//	collectorWithState.ApiCollector, err = NewApiCollector(args)
-//	return collectorWithState, err
-//}
-
 // CanIncrementCollect return if the old data can support collect incrementally.
 // only when latest collection is success &&
 // (m.LatestState.CreatedDateAfter == nil means all data have been collected ||

--- a/plugins/helper/api_collector_with_state.go
+++ b/plugins/helper/api_collector_with_state.go
@@ -62,6 +62,16 @@ func NewApiCollectorWithState(args RawDataSubTaskArgs, createdDateAfter *time.Ti
 	}, nil
 }
 
+// NewAndInitCollectorWithState create a new ApiCollectorStateManager and init it
+//func NewAndInitCollectorWithState(args ApiCollectorArgs, createdDateAfter *time.Time) (*ApiCollectorStateManager, errors.Error) {
+//	collectorWithState, err := NewApiCollectorWithState(args.RawDataSubTaskArgs, createdDateAfter)
+//	if err != nil {
+//		return nil, err
+//	}
+//	collectorWithState.ApiCollector, err = NewApiCollector(args)
+//	return collectorWithState, err
+//}
+
 // CanIncrementCollect return if the old data can support collect incrementally.
 // only when latest collection is success &&
 // (m.LatestState.CreatedDateAfter == nil means all data have been collected ||

--- a/plugins/helper/api_collector_with_state.go
+++ b/plugins/helper/api_collector_with_state.go
@@ -65,11 +65,11 @@ func NewApiCollectorWithState(args RawDataSubTaskArgs, createdDateAfter *time.Ti
 // CanIncrementCollect return if the old data can support collect incrementally.
 // only when latest collection is success &&
 // (m.LatestState.CreatedDateAfter == nil means all data have been collected ||
-// CreatedDateAfter at this time exists and later than in the LatestState)
+// CreatedDateAfter at this time exists and no before than in the LatestState)
 // if CreatedDateAfter at this time not exists, collect incrementally only when "m.LatestState.CreatedDateAfter == nil"
 func (m ApiCollectorStateManager) CanIncrementCollect() bool {
 	return m.LatestState.LatestSuccessStart != nil &&
-		(m.LatestState.CreatedDateAfter == nil || m.CreatedDateAfter != nil && m.CreatedDateAfter.After(*m.LatestState.CreatedDateAfter))
+		(m.LatestState.CreatedDateAfter == nil || m.CreatedDateAfter != nil && !m.CreatedDateAfter.Before(*m.LatestState.CreatedDateAfter))
 }
 
 // InitCollector init the embedded collector

--- a/plugins/helper/worker_scheduler.go
+++ b/plugins/helper/worker_scheduler.go
@@ -74,7 +74,7 @@ func NewWorkerScheduler(
 // SubmitBlocking enqueues a async task to ants, the task will be executed in future when timing is right.
 // It doesn't return error because it wouldn't be any when with a Blocking semantic, returned error does nothing but
 // causing confusion, more often, people thought it is returned by the task.
-// Since it is async task, the callframes would not be available for production mode, you can export Environment
+// CreatedDateAfter it is async task, the callframes would not be available for production mode, you can export Environment
 // Varaible ASYNC_CF=true to enable callframes capturing when debugging.
 // IMPORTANT: do NOT call SubmitBlocking inside the async task, it is likely to cause a deadlock, call
 // SubmitNonBlocking instead when number of tasks is relatively small.

--- a/plugins/helper/worker_scheduler.go
+++ b/plugins/helper/worker_scheduler.go
@@ -74,7 +74,7 @@ func NewWorkerScheduler(
 // SubmitBlocking enqueues a async task to ants, the task will be executed in future when timing is right.
 // It doesn't return error because it wouldn't be any when with a Blocking semantic, returned error does nothing but
 // causing confusion, more often, people thought it is returned by the task.
-// CreatedDateAfter it is async task, the callframes would not be available for production mode, you can export Environment
+// Since it is async task, the callframes would not be available for production mode, you can export Environment
 // Varaible ASYNC_CF=true to enable callframes capturing when debugging.
 // IMPORTANT: do NOT call SubmitBlocking inside the async task, it is likely to cause a deadlock, call
 // SubmitNonBlocking instead when number of tasks is relatively small.

--- a/plugins/jenkins/jenkins.go
+++ b/plugins/jenkins/jenkins.go
@@ -30,7 +30,7 @@ func main() {
 	connectionId := jenkinsCmd.Flags().Uint64P("connection", "c", 1, "jenkins connection id")
 	jobFullName := jenkinsCmd.Flags().StringP("jobFullName", "j", "", "jenkins job full name")
 	deployTagPattern := jenkinsCmd.Flags().String("deployTagPattern", "(?i)deploy", "deploy tag name")
-	CreatedDateAfter := jenkinsCmd.Flags().StringP("createdDateAfter", "a", "", "collect data that are updated after specified time, ie 2006-05-06T07:08:09Z")
+	CreatedDateAfter := jenkinsCmd.Flags().StringP("createdDateAfter", "a", "", "collect data that are created after specified time, ie 2006-05-06T07:08:09Z")
 
 	jenkinsCmd.Run = func(cmd *cobra.Command, args []string) {
 		runner.DirectRun(cmd, args, PluginEntry, map[string]interface{}{

--- a/plugins/jira/jira.go
+++ b/plugins/jira/jira.go
@@ -32,12 +32,12 @@ func main() {
 	boardId := cmd.Flags().Uint64P("board", "b", 0, "jira board id")
 	_ = cmd.MarkFlagRequired("connection")
 	_ = cmd.MarkFlagRequired("board")
-	CreatedDateAfter := cmd.Flags().StringP("createdDateAfter", "a", "", "collect data that are updated after specified time, ie 2006-05-06T07:08:09Z")
+	CreatedDateAfter := cmd.Flags().StringP("createdDateAfter", "a", "", "collect data that are created after specified time, ie 2006-05-06T07:08:09Z")
 	cmd.Run = func(c *cobra.Command, args []string) {
 		runner.DirectRun(c, args, PluginEntry, map[string]interface{}{
 			"connectionId":     *connectionId,
 			"boardId":          *boardId,
-			"CreatedDateAfter": *CreatedDateAfter,
+			"createdDateAfter": *CreatedDateAfter,
 		})
 	}
 	runner.RunCmd(cmd)


### PR DESCRIPTION
### Summary
1. add options CreatedDateAfter for github & github_graphql
2. fix some bugs when github running.
3. let `cicd_run` only request data created after `CreatedDateAfter`(for restful & graphql). Notice: cicd_run do not support incremental
4. update `comment/commit/event/issue/pr/plugins/pr_review_comment`'s incremental collector(for restful & graphql)
5. let `pr_commit` only request data created after `CreatedDateAfter`(for restful).
6. let `pr_review` only request data created after `CreatedDateAfter`(for restful & graphql).
7. let `issue/pr` and related model only request data created after `CreatedDateAfter`(for graphql). Notice: graphql do not support incremental.
8. delete wrong incremental in event&pr (for restful); !!there is no `since` in these 2 api.

Because Graphql uses cursor to request next page, so I sort it by created DESC, and collect until created before than `CreatedDateAfter`.

### Does this close any open issues?
Related to #3688 
