### PR TITLE
fix(github): modify bp v200

### DIFF
--- a/models/domainlayer/code/repo.go
+++ b/models/domainlayer/code/repo.go
@@ -34,7 +34,7 @@ type Repo struct {
 	OwnerId     string     `json:"ownerId" gorm:"type:varchar(255)"`
 	Language    string     `json:"language" gorm:"type:varchar(255)"`
 	ForkedFrom  string     `json:"forkedFrom"`
-	CreatedDate time.Time  `json:"createdDate"`
+	CreatedDate *time.Time `json:"createdDate"`
 	UpdatedDate *time.Time `json:"updatedDate"`
 	Deleted     bool       `json:"deleted"`
 }

--- a/plugins/bitbucket/tasks/repo_convertor.go
+++ b/plugins/bitbucket/tasks/repo_convertor.go
@@ -79,7 +79,7 @@ func ConvertRepo(taskCtx core.SubTaskContext) errors.Error {
 				Url:         repository.HTMLUrl,
 				Description: repository.Description,
 				Language:    repository.Language,
-				CreatedDate: repository.CreatedDate,
+				CreatedDate: &repository.CreatedDate,
 				UpdatedDate: repository.UpdatedDate,
 			}
 

--- a/plugins/gitee/tasks/repo_convertor.go
+++ b/plugins/gitee/tasks/repo_convertor.go
@@ -73,7 +73,7 @@ func ConvertRepo(taskCtx core.SubTaskContext) errors.Error {
 				Description: repository.Description,
 				ForkedFrom:  repository.ParentHTMLUrl,
 				Language:    repository.Language,
-				CreatedDate: repository.CreatedDate,
+				CreatedDate: &repository.CreatedDate,
 				UpdatedDate: repository.UpdatedDate,
 			}
 

--- a/plugins/github/api/blueprint.go
+++ b/plugins/github/api/blueprint.go
@@ -226,7 +226,7 @@ func addGithub(subtaskMetas []core.SubTaskMeta, connection *models.GithubConnect
 }
 
 func getApiRepo(op *tasks.GithubOptions, apiClient helper.ApiClientGetter) (*tasks.GithubApiRepo, errors.Error) {
-	apiRepo := &tasks.GithubApiRepo{}
+	repoRes := &tasks.GithubApiRepo{}
 	res, err := apiClient.Get(fmt.Sprintf("repos/%s/%s", op.Owner, op.Repo), nil, nil)
 	if err != nil {
 		return nil, err
@@ -239,11 +239,11 @@ func getApiRepo(op *tasks.GithubOptions, apiClient helper.ApiClientGetter) (*tas
 	if err != nil {
 		return nil, err
 	}
-	err = errors.Convert(json.Unmarshal(body, apiRepo))
+	err = errors.Convert(json.Unmarshal(body, repoRes))
 	if err != nil {
 		return nil, err
 	}
-	return apiRepo, nil
+	return repoRes, nil
 }
 
 func memorizedGetApiRepo(repo *tasks.GithubApiRepo, op *tasks.GithubOptions, apiClient helper.ApiClientGetter) (*tasks.GithubApiRepo, errors.Error) {

--- a/plugins/github/api/blueprint_V200_test.go
+++ b/plugins/github/api/blueprint_V200_test.go
@@ -93,14 +93,8 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 				Subtasks:   []string{},
 				SkipOnFail: false,
 				Options: map[string]interface{}{
-					"connectionId":         uint64(1),
-					"transformationRuleId": uint64(1),
-					"owner":                "test",
-					"repo":                 "testRepo",
-					"transformationRules": map[string]interface{}{
-						"name":   "github transformation rule",
-						"prType": "hey,man,wasup",
-					},
+					"connectionId": uint64(1),
+					"scopeId":      "1",
 				},
 			},
 			{
@@ -154,8 +148,7 @@ func NewMockBasicRes() *mocks.BasicRes {
 	testGithubRepo := &models.GithubRepo{
 		ConnectionId:         1,
 		GithubId:             12345,
-		Name:                 "testRepo",
-		OwnerLogin:           "test",
+		Name:                 "test/testRepo",
 		TransformationRuleId: 1,
 		CreatedDate:          time.Time{},
 	}

--- a/plugins/github/api/blueprint_test.go
+++ b/plugins/github/api/blueprint_test.go
@@ -34,13 +34,20 @@ import (
 	"testing"
 )
 
-var bs = &core.BlueprintScopeV100{
-	Entities: []string{"CODE"},
-	Options: json.RawMessage(`{
+var repo = &tasks.GithubApiRepo{
+	GithubId:  12345,
+	CloneUrl:  "https://this_is_cloneUrl",
+	CreatedAt: helper.Iso8601Time{},
+}
+
+func TestMakePipelinePlan(t *testing.T) {
+	var bs = &core.BlueprintScopeV100{
+		Entities: []string{"CODE"},
+		Options: json.RawMessage(`{
               "owner": "test",
               "repo": "testRepo"
             }`),
-	Transformation: json.RawMessage(`{
+		Transformation: json.RawMessage(`{
               "prType": "hey,man,wasup",
               "refdiff": {
                 "tagsPattern": "pattern",
@@ -49,15 +56,7 @@ var bs = &core.BlueprintScopeV100{
               },
               "productionPattern": "xxxx"
             }`),
-}
-
-var repo = &tasks.GithubApiRepo{
-	GithubId:  12345,
-	CloneUrl:  "https://this_is_cloneUrl",
-	CreatedAt: helper.Iso8601Time{},
-}
-
-func TestMakePipelinePlan(t *testing.T) {
+	}
 	prepareMockMeta(t)
 	mockApiClient := prepareMockClient(t, repo)
 	connection := &models.GithubConnection{
@@ -131,7 +130,7 @@ func TestMakePipelinePlan(t *testing.T) {
 }
 
 func TestMemorizedGetApiRepo(t *testing.T) {
-	op := prepareOptions(t, bs)
+	op := prepareOptions(t)
 	expect := repo
 	repo1, err := memorizedGetApiRepo(repo, op, nil)
 	assert.Nil(t, err)
@@ -143,7 +142,7 @@ func TestMemorizedGetApiRepo(t *testing.T) {
 }
 
 func TestGetApiRepo(t *testing.T) {
-	op := prepareOptions(t, bs)
+	op := prepareOptions(t)
 	mockClient := prepareMockClient(t, repo)
 	repo1, err := getApiRepo(op, mockClient)
 	assert.Nil(t, err)
@@ -168,7 +167,23 @@ func prepareMockClient(t *testing.T, repo *tasks.GithubApiRepo) *mocks.ApiClient
 	return mockApiCLient
 }
 
-func prepareOptions(t *testing.T, bs *core.BlueprintScopeV100) *tasks.GithubOptions {
+func prepareOptions(t *testing.T) *tasks.GithubOptions {
+	var bs = &core.BlueprintScopeV100{
+		Entities: []string{"CODE"},
+		Options: json.RawMessage(`{
+              "owner": "test",
+              "repo": "testRepo"
+            }`),
+		Transformation: json.RawMessage(`{
+              "prType": "hey,man,wasup",
+              "refdiff": {
+                "tagsPattern": "pattern",
+                "tagsLimit": 10,
+                "tagsOrder": "reverse semver"
+              },
+              "productionPattern": "xxxx"
+            }`),
+	}
 	options := make(map[string]interface{})
 	err := errors.Convert(json.Unmarshal(bs.Options, &options))
 	assert.Nil(t, err)

--- a/plugins/github/tasks/repo_convertor.go
+++ b/plugins/github/tasks/repo_convertor.go
@@ -82,7 +82,7 @@ func ConvertRepo(taskCtx core.SubTaskContext) errors.Error {
 				Description: repository.Description,
 				ForkedFrom:  repository.ParentHTMLUrl,
 				Language:    repository.Language,
-				CreatedDate: repository.CreatedDate,
+				CreatedDate: &repository.CreatedDate,
 				UpdatedDate: repository.UpdatedDate,
 			}
 

--- a/plugins/github/tasks/task_data.go
+++ b/plugins/github/tasks/task_data.go
@@ -29,10 +29,11 @@ import (
 type GithubOptions struct {
 	ConnectionId                     uint64   `json:"connectionId" mapstructure:"connectionId,omitempty"`
 	TransformationRuleId             uint64   `json:"transformationRuleId" mapstructure:"transformationRuleId,omitempty"`
+	ScopeId                          string   `json:"scopeId" mapstructure:"scopeId,omitempty"`
 	Tasks                            []string `json:"tasks,omitempty" mapstructure:",omitempty"`
 	Since                            string   `json:"since" mapstructure:"since,omitempty"`
-	Owner                            string   `json:"owner" mapstructure:"owner"`
-	Repo                             string   `json:"repo"  mapstructure:"repo"`
+	Owner                            string   `json:"owner" mapstructure:"owner,omitempty"`
+	Repo                             string   `json:"repo"  mapstructure:"repo,omitempty"`
 	*models.GithubTransformationRule `mapstructure:"transformationRules,omitempty" json:"transformationRules"`
 }
 
@@ -45,25 +46,29 @@ type GithubTaskData struct {
 }
 
 func DecodeAndValidateTaskOptions(options map[string]interface{}) (*GithubOptions, errors.Error) {
-	var op GithubOptions
-	err := helper.Decode(options, &op, nil)
+	op, err := DecodeTaskOptions(options)
 	if err != nil {
 		return nil, err
 	}
-	err = ValidateTaskOptions(&op)
+	err = ValidateTaskOptions(op)
+	if err != nil {
+		return nil, err
+	}
+	return op, nil
+}
+
+func DecodeTaskOptions(options map[string]interface{}) (*GithubOptions, errors.Error) {
+	var op GithubOptions
+	err := helper.Decode(options, &op, nil)
 	if err != nil {
 		return nil, err
 	}
 	return &op, nil
 }
 
-func ValidateAndEncodeTaskOptions(op *GithubOptions) (map[string]interface{}, errors.Error) {
-	err := ValidateTaskOptions(op)
-	if err != nil {
-		return nil, err
-	}
+func EncodeTaskOptions(op *GithubOptions) (map[string]interface{}, errors.Error) {
 	var result map[string]interface{}
-	err = helper.Decode(op, &result, nil)
+	err := helper.Decode(op, &result, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/github_graphql/impl/impl.go
+++ b/plugins/github_graphql/impl/impl.go
@@ -19,7 +19,9 @@ package impl
 
 import (
 	"context"
+	goerror "errors"
 	"fmt"
+	"github.com/apache/incubator-devlake/plugins/core/dal"
 	"reflect"
 	"strings"
 	"time"
@@ -120,13 +122,6 @@ func (plugin GithubGraphql) PrepareTaskData(taskCtx core.TaskContext, options ma
 	if err != nil {
 		return nil, err
 	}
-	if op.Owner == "" {
-		return nil, errors.Default.New("owner is required for GitHub execution")
-	}
-	if op.Repo == "" {
-		return nil, errors.Default.New("repo is required for GitHub execution")
-	}
-
 	connectionHelper := helper.NewConnectionHelper(
 		taskCtx,
 		nil,
@@ -135,6 +130,11 @@ func (plugin GithubGraphql) PrepareTaskData(taskCtx core.TaskContext, options ma
 	err = connectionHelper.FirstById(connection, op.ConnectionId)
 	if err != nil {
 		return nil, errors.Default.Wrap(err, "unable to get github connection by the given connection ID: %v")
+	}
+
+	_, err = EnrichOptions(taskCtx, &op, connection)
+	if err != nil {
+		return nil, err
 	}
 
 	tokens := strings.Split(connection.Token, ",")
@@ -176,6 +176,49 @@ func (plugin GithubGraphql) PrepareTaskData(taskCtx core.TaskContext, options ma
 		ApiClient:     apiClient,
 		GraphqlClient: graphqlClient,
 	}, nil
+}
+
+func EnrichOptions(taskCtx core.TaskContext,
+	op *githubTasks.GithubOptions,
+	connection *models.GithubConnection) (*models.GithubRepo, errors.Error) {
+	var githubRepo models.GithubRepo
+	var err errors.Error
+	log := taskCtx.GetLogger()
+	// for advanced mode or others which we already set value to onwer/repo
+	if op.Owner != "" && op.Repo != "" {
+		err := taskCtx.GetDal().First(&githubRepo, dal.Where(
+			"connection_id = ? AND name = ? AND owner_login = ?",
+			op.ConnectionId, op.Repo, op.Owner))
+		if err != nil {
+			return nil, errors.Default.Wrap(err, fmt.Sprintf("fail to find repo %s/%s", op.Owner, op.Repo))
+		}
+		op.TransformationRuleId = githubRepo.TransformationRuleId
+	}
+	// for bp v200 which we only set ScopeId for options
+	if githubRepo.GithubId == 0 && op.ScopeId != "" {
+		log.Debug(fmt.Sprintf("Getting githubRepo by op.ScopeId: %s", op.ScopeId))
+		err = taskCtx.GetDal().First(&githubRepo, dal.Where(`connection_id = ? AND github_id = ?`, connection.ID, op.ScopeId))
+		if err != nil {
+			return nil, errors.Default.Wrap(err, fmt.Sprintf("fail to find repo %s", op.ScopeId))
+		}
+		ownerName := strings.Split(githubRepo.Name, "/")
+		if len(ownerName) != 2 {
+			return nil, errors.Default.New("Fail to set owner/repo for github options.")
+		}
+		op.Owner = ownerName[0]
+		op.Repo = ownerName[1]
+		op.TransformationRuleId = githubRepo.TransformationRuleId
+	}
+	// Set GithubTransformationRule if it's nil, this has lower priority
+	if op.GithubTransformationRule == nil && op.TransformationRuleId != 0 {
+		var transformationRule models.GithubTransformationRule
+		err = taskCtx.GetDal().First(&transformationRule, dal.Where("id = ?", githubRepo.TransformationRuleId))
+		if err != nil && !goerror.Is(err, gorm.ErrRecordNotFound) {
+			return nil, errors.BadInput.Wrap(err, "fail to get transformationRule")
+		}
+		op.GithubTransformationRule = &transformationRule
+	}
+	return &githubRepo, nil
 }
 
 // PkgPath information lost when compiled as plugin(.so)

--- a/plugins/gitlab/tasks/project_convertor.go
+++ b/plugins/gitlab/tasks/project_convertor.go
@@ -91,7 +91,7 @@ func convertToRepositoryModel(project *models.GitlabProject) *code.Repo {
 		Url:         project.WebUrl,
 		Description: project.Description,
 		ForkedFrom:  project.ForkedFromProjectWebUrl,
-		CreatedDate: project.CreatedDate,
+		CreatedDate: &project.CreatedDate,
 		UpdatedDate: project.UpdatedDate,
 	}
 	return domainRepository

--- a/plugins/jenkins/api/blueprint_v200.go
+++ b/plugins/jenkins/api/blueprint_v200.go
@@ -64,8 +64,11 @@ func makeDataSourcePipelinePlanV200(
 	connection *models.JenkinsConnection,
 ) (core.PipelinePlan, errors.Error) {
 	var err errors.Error
-	var stage core.PipelineStage
 	for i, bpScope := range bpScopes {
+		stage := plan[i]
+		if stage == nil {
+			stage = core.PipelineStage{}
+		}
 		jenkinsJob := &models.JenkinsJob{}
 		// get repo from db
 		err = basicRes.GetDal().First(jenkinsJob,

--- a/plugins/jira/api/blueprint_v200.go
+++ b/plugins/jira/api/blueprint_v200.go
@@ -64,8 +64,11 @@ func makeDataSourcePipelinePlanV200(
 ) (core.PipelinePlan, errors.Error) {
 	db := basicRes.GetDal()
 	var err errors.Error
-	var stage core.PipelineStage
 	for i, bpScope := range bpScopes {
+		stage := plan[i]
+		if stage == nil {
+			stage = core.PipelineStage{}
+		}
 		jiraBoard := &models.JiraBoard{}
 		// get repo from db
 		err = db.First(jiraBoard, dal.Where(`connection_id = ? and board_id = ?`, connection.ID, bpScope.Id))

--- a/services/blueprint_makeplan_v200.go
+++ b/services/blueprint_makeplan_v200.go
@@ -44,9 +44,11 @@ func GeneratePlanJsonV200(
 		if e != nil {
 			return nil, errors.Convert(err)
 		}
-		e = db.Create(scopes).Error
-		if e != nil {
-			return nil, errors.Convert(err)
+		for _, scope := range scopes {
+			e = basicRes.GetDal().CreateOrUpdate(scope)
+			if e != nil {
+				return nil, errors.Convert(err)
+			}
 		}
 	}
 	return plan, err

--- a/services/pipeline_helper.go
+++ b/services/pipeline_helper.go
@@ -20,6 +20,7 @@ package services
 import (
 	"encoding/json"
 	goerror "errors"
+	"fmt"
 
 	"github.com/apache/incubator-devlake/config"
 	"github.com/apache/incubator-devlake/errors"
@@ -90,6 +91,7 @@ func CreateDbPipeline(newPipeline *models.NewPipeline) (*models.DbPipeline, erro
 	// create tasks accordingly
 	for i := range newPipeline.Plan {
 		for j := range newPipeline.Plan[i] {
+			log.Debug(fmt.Sprintf("plan[%d][%d] is %+v\n", i, j, newPipeline.Plan[i][j]))
 			pipelineTask := newPipeline.Plan[i][j]
 			newTask := &models.NewTask{
 				PipelineTask: pipelineTask,


### PR DESCRIPTION
### Summary
Change the way to set options in plugin GitHub.
Before, we set all values to tasks.GithubOptions when making plan, right now, we just pass scopeId to options, and set other values when preparing plugin data

### Does this close any open issues?
relate to #3468 

### Screenshots
we can see that the blueprint can be triggered successfully
<img width="716" alt="image" src="https://user-images.githubusercontent.com/39366025/206635790-ce65f9e3-dbda-4a3b-bfdd-57e187a44f53.png">

bp V100:
<img width="939" alt="image" src="https://user-images.githubusercontent.com/39366025/206651649-b93944a8-2294-49d7-9803-7954612bcb25.png">


### Other Information
Any other information that is important to this PR.
