### PR TITLE
fix: pending task status

### DIFF
--- a/models/task.go
+++ b/models/task.go
@@ -34,6 +34,8 @@ const (
 	TASK_CANCELLED = "TASK_CANCELLED"
 )
 
+var PendingTaskStatus = []string{TASK_CREATED, TASK_RERUN, TASK_RUNNING}
+
 type TaskProgressDetail struct {
 	TotalSubTasks    int    `json:"totalSubTasks"`
 	FinishedSubTasks int    `json:"finishedSubTasks"`

--- a/services/pipeline_helper.go
+++ b/services/pipeline_helper.go
@@ -37,8 +37,7 @@ func CreateDbPipeline(newPipeline *models.NewPipeline) (*models.DbPipeline, erro
 	defer cronLocker.Unlock()
 	if newPipeline.BlueprintId > 0 {
 		var count int64
-		status := []string{models.TASK_CREATED, models.TASK_RUNNING, models.TASK_RERUN}
-		err := db.Model(&models.DbPipeline{}).Where("blueprint_id = ? AND status IN ?", newPipeline.BlueprintId, status).Count(&count).Error
+		err := db.Model(&models.DbPipeline{}).Where("blueprint_id = ? AND status IN ?", newPipeline.BlueprintId, models.PendingTaskStatus).Count(&count).Error
 		if err != nil {
 			return nil, errors.Default.Wrap(err, "query pipelines error")
 		}
@@ -136,7 +135,7 @@ func GetDbPipelines(query *PipelineQuery) ([]*models.DbPipeline, int64, errors.E
 		dbQuery = dbQuery.Where("status = ?", query.Status)
 	}
 	if query.Pending > 0 {
-		dbQuery = dbQuery.Where("finished_at is null and status != ?", "TASK_FAILED")
+		dbQuery = dbQuery.Where("finished_at is null and status IN ?", models.PendingTaskStatus)
 	}
 	if query.Label != "" {
 		dbQuery = dbQuery.


### PR DESCRIPTION
### Summary
Redefine pending task status, and apply it to api `get pipelines`.

### Does this close any open issues?
fix #3893

### Screenshots
Create a cancelled pipeline for bp 2.  
![image](https://user-images.githubusercontent.com/11383928/206642062-b2b159d1-2f62-4695-9ed2-ae882d59a1d8.png).  
Get bp's pipelines with pending filter.  
![image](https://user-images.githubusercontent.com/11383928/206642638-4fb4fbda-0112-4ea9-857b-a088a19fadee.png).  
Create a new pipeline and get bp's pipeline again.  
![image](https://user-images.githubusercontent.com/11383928/206642543-4ba45e15-a8ce-4310-ba79-d1be215db1a3.png)




### Other Information
Any other information that is important to this PR.
