### PR TITLE
feat(jenkins): update bp v200

### DIFF
--- a/plugins/azure/api/blueprint.go
+++ b/plugins/azure/api/blueprint.go
@@ -37,7 +37,11 @@ func MakePipelinePlan(subtaskMetas []core.SubTaskMeta, connectionId uint64, scop
 			return nil, errors.Default.Wrap(err, "unable to deserialize pipeline task options")
 		}
 		taskOptions["connectionId"] = connectionId
-		_, err := tasks.DecodeAndValidateTaskOptions(taskOptions)
+		op, err := tasks.DecodeTaskOptions(taskOptions)
+		if err != nil {
+			return nil, err
+		}
+		_, err = tasks.ValidateTaskOptions(op)
 		if err != nil {
 			return nil, err
 		}

--- a/plugins/jenkins/api/blueprint_v100.go
+++ b/plugins/jenkins/api/blueprint_v100.go
@@ -60,7 +60,11 @@ func makePipelinePlanV100(subtaskMetas []core.SubTaskMeta, scope []*core.Bluepri
 		}
 		taskOptions["connectionId"] = connection.ID
 		taskOptions["transformationRules"] = transformationRules
-		_, err := tasks.DecodeAndValidateTaskOptions(taskOptions)
+		op, err := tasks.DecodeTaskOptions(taskOptions)
+		if err != nil {
+			return nil, err
+		}
+		_, err = tasks.ValidateTaskOptions(op)
 		if err != nil {
 			return nil, err
 		}

--- a/plugins/jenkins/tasks/task_data.go
+++ b/plugins/jenkins/tasks/task_data.go
@@ -33,6 +33,7 @@ type JenkinsApiParams struct {
 
 type JenkinsOptions struct {
 	ConnectionId                      uint64 `json:"connectionId"`
+	ScopeId                           string
 	TransformationRuleId              uint64 `json:"transformationRuleId"`
 	JobFullName                       string `json:"jobFullName"` // "path1/path2/job name"
 	JobName                           string `json:"jobName"`     // "job name"
@@ -49,12 +50,16 @@ type JenkinsTaskData struct {
 	CreatedDateAfter *time.Time
 }
 
-func DecodeAndValidateTaskOptions(options map[string]interface{}) (*JenkinsOptions, errors.Error) {
+func DecodeTaskOptions(options map[string]interface{}) (*JenkinsOptions, errors.Error) {
 	var op JenkinsOptions
 	err := helper.Decode(options, &op, nil)
 	if err != nil {
 		return nil, errors.BadInput.Wrap(err, "could not decode request parameters")
 	}
+	return &op, nil
+}
+
+func ValidateTaskOptions(op *JenkinsOptions) (*JenkinsOptions, errors.Error) {
 	if op.ConnectionId == 0 {
 		return nil, errors.BadInput.New("connectionId is invalid")
 	}
@@ -71,5 +76,5 @@ func DecodeAndValidateTaskOptions(options map[string]interface{}) (*JenkinsOptio
 	if op.JenkinsTransformationRule == nil && op.TransformationRuleId == 0 {
 		op.JenkinsTransformationRule = new(models.JenkinsTransformationRule)
 	}
-	return &op, nil
+	return op, nil
 }

--- a/plugins/jira/impl/impl.go
+++ b/plugins/jira/impl/impl.go
@@ -177,7 +177,9 @@ func (plugin Jira) PrepareTaskData(taskCtx core.TaskContext, options map[string]
 			return nil, errors.Default.Wrap(err, fmt.Sprintf("fail to find board%s", op.ScopeId))
 		}
 		op.BoardId = jiraBoard.BoardId
-		op.TransformationRuleId = jiraBoard.TransformationRuleId
+		if op.TransformationRuleId == 0 {
+			op.TransformationRuleId = jiraBoard.TransformationRuleId
+		}
 	}
 	if op.TransformationRules == nil && op.TransformationRuleId != 0 {
 		var transformationRule models.JiraTransformationRule

--- a/services/blueprint_makeplan_v200.go
+++ b/services/blueprint_makeplan_v200.go
@@ -105,6 +105,10 @@ func genPlanJsonV200(
 			return nil, nil, err
 		}
 		if pluginBp, ok := plugin.(core.MetricPluginBlueprintV200); ok {
+			// If we enable one metric plugin, even if it has nil option, we still process it
+			if len(metricPluginOptJson) == 0 {
+				metricPluginOptJson = json.RawMessage("{}")
+			}
 			metricPlans[i], err = pluginBp.MakeMetricPluginPipelinePlanV200(projectName, metricPluginOptJson)
 			if err != nil {
 				return nil, nil, err

--- a/services/blueprint_makeplan_v200_test.go
+++ b/services/blueprint_makeplan_v200_test.go
@@ -65,7 +65,7 @@ func TestMakePlanV200(t *testing.T) {
 		},
 	}
 	dora := new(mocks.CompositeMetricPluginBlueprintV200)
-	dora.On("MakeMetricPluginPipelinePlanV200", projectName, json.RawMessage(nil)).Return(doraOutputPlan, nil)
+	dora.On("MakeMetricPluginPipelinePlanV200", projectName, json.RawMessage("{}")).Return(doraOutputPlan, nil)
 
 	// expectation, establish expectation before any code being launch to avoid unwanted modification
 	expectedPlan := make(core.PipelinePlan, 0)


### PR DESCRIPTION
### Summary
Change the way to set options in plugin jenkins.
Before, we set all values to tasks.JenkinsOptions when making plan, right now, we just pass scopeId to options, and set other values when preparing plugin data

Also make a little modification for services/blueprint_makeplan_v200.go: if we enable metricPlugin, even if plugin's option is nill, we still need to create that stage

### Does this close any open issues?
relate to #3468 

### Screenshots
create bp for jenkins:
![image](https://user-images.githubusercontent.com/39366025/207017970-a0c25dcf-c23b-4dc8-8e45-f923d554bddf.png)
output:
```json
{
	"name": "TEST_PROJECT_1-BLUEP2RINT",
	"projectName": "TEST_PROJECT_1",
	"mode": "NORMAL",
	"plan": [
		[
			{
				"plugin": "jenkins",
				"skipOnFail": false,
				"subtasks": [],
				"options": {
					"connectionId": 1,
					"scopeId": "a/b/c"
				}
			}
		],
		[
			{
				"plugin": "jenkins",
				"skipOnFail": false,
				"subtasks": [],
				"options": {
					"connectionId": 1,
					"scopeId": "a/b/c/d"
				}
			}
		],
		[
			{
				"plugin": "refdiff",
				"skipOnFail": false,
				"subtasks": [
					"calculateDeploymentDiffs"
				],
				"options": {
					"projectName": "TEST_PROJECT_1"
				}
			}
		],
		[
			{
				"plugin": "dora",
				"skipOnFail": false,
				"subtasks": null,
				"options": {
					"projectName": "TEST_PROJECT_1"
				}
			}
		]
	],
	"enable": true,
	"cronConfig": "0 0 * * *",
	"isManual": true,
	"skipOnFail": false,
	"labels": null,
	"settings": {
		"version": "2.0.0",
		"connections": [
			{
				"plugin": "jenkins",
				"connectionId": 1,
				"scopes": [
					{
						"id": "a/b/c"
					},
					{
						"id": "a/b/c/d"
					}
				]
			}
		]
	},
	"id": 4,
	"createdAt": "2022-12-12T18:02:44.593+08:00",
	"updatedAt": "2022-12-12T18:02:44.593+08:00"
}
```

Trigger the bp:

![image](https://user-images.githubusercontent.com/39366025/207018336-8e72c122-3a4e-4740-bf36-b709e3b7e814.png)


### Other Information
Any other information that is important to this PR.
