### PR TITLE
fix: dbt zombie processes

### DIFF
--- a/plugins/dbt/tasks/convertor.go
+++ b/plugins/dbt/tasks/convertor.go
@@ -185,7 +185,7 @@ func DbtConverter(taskCtx core.SubTaskContext) errors.Error {
 		return err
 	}
 	// prevent zombie process
-	defer cmd.Wait()
+	defer cmd.Wait() //nolint
 
 	scanner := bufio.NewScanner(stdout)
 	var errStr string

--- a/plugins/dbt/tasks/convertor.go
+++ b/plugins/dbt/tasks/convertor.go
@@ -184,6 +184,9 @@ func DbtConverter(taskCtx core.SubTaskContext) errors.Error {
 	if err != nil {
 		return err
 	}
+	// prevent zombie process
+	defer cmd.Wait()
+
 	scanner := bufio.NewScanner(stdout)
 	var errStr string
 	for scanner.Scan() {
@@ -199,10 +202,7 @@ func DbtConverter(taskCtx core.SubTaskContext) errors.Error {
 	if err := errors.Convert(scanner.Err()); err != nil {
 		return err
 	}
-	err = errors.Convert(cmd.Wait())
-	if err != nil {
-		return errors.Internal.New(errStr)
-	}
+
 	if !cmd.ProcessState.Success() {
 		log.Error(nil, "dbt run task error, please check!!!")
 	}


### PR DESCRIPTION
### Summary
make sure the cmd.Wait() can be executed.

### Does this close any open issues?
Closes #3919 

### Screenshots
before:
Execute three times in a row, process screenshot：

![image](https://user-images.githubusercontent.com/101256042/207279272-418d3b99-2c51-4da3-818a-911046585132.png)

after:
Execute three times in a row, process screenshot：
![image](https://user-images.githubusercontent.com/101256042/207279833-eda94377-ef4a-45bf-8547-bf8112af65ac.png)


### Other Information
Any other information that is important to this PR.
