### PR TITLE
fix(config-ui): connection store not injected into the context

### DIFF
--- a/config-ui/src/pages/blueprint/create/hooks/use-blueprint-value.ts
+++ b/config-ui/src/pages/blueprint/create/hooks/use-blueprint-value.ts
@@ -19,6 +19,7 @@
 import { useState, useMemo } from 'react'
 import { useHistory } from 'react-router-dom'
 
+import { useStore, ConnectionStatusEnum } from '@/store'
 import { operator } from '@/utils'
 
 import type { BPConnectionItemType, BPScopeItemType } from '../types'
@@ -49,6 +50,8 @@ export const useBlueprintValue = ({ from, projectName }: Props) => {
 
   const history = useHistory()
 
+  const store = useStore()
+
   const validRawPlan = (rp: string) => {
     try {
       const p = JSON.parse(rp)
@@ -71,12 +74,19 @@ export const useBlueprintValue = ({ from, projectName }: Props) => {
         return 'Advanced Mode: Invalid/Empty Configuration'
       case mode === ModeEnum.normal && !connections.length:
         return 'Normal Mode: No Data Connections selected.'
+      case mode === ModeEnum.normal &&
+        !store.connections
+          .filter((cs) =>
+            connections.map((it) => it.unique).includes(cs.unique)
+          )
+          .every((cs) => cs.status === ConnectionStatusEnum.ONLINE):
+        return 'Normal Mode: Has some offline connections'
       case step === 2 && !connections.every((cs) => cs.scope.length):
         return 'No Data Scope is Selected'
       default:
         return ''
     }
-  }, [name, mode, rawPlan, connections, step])
+  }, [name, mode, rawPlan, connections, step, store])
 
   const payload = useMemo(() => {
     const params: any = {

--- a/config-ui/src/pages/blueprint/create/step-one/index.tsx
+++ b/config-ui/src/pages/blueprint/create/step-one/index.tsx
@@ -28,7 +28,7 @@ import {
 } from '@blueprintjs/core'
 import { Popover2 } from '@blueprintjs/popover2'
 
-import { useConnections, ConnectionStatusEnum } from '@/store'
+import { useStore } from '@/store/store'
 import { Divider, MultiSelector, Loading } from '@/components'
 
 import { ModeEnum } from '../types'
@@ -40,7 +40,7 @@ import * as S from './styled'
 export const StepOne = () => {
   const [isOpen, setIsOpen] = useState(false)
 
-  const connectionsStore = useConnections()
+  const connectionsStore = useStore()
 
   const {
     mode,
@@ -92,7 +92,7 @@ export const StepOne = () => {
               getIcon={(it) => it.icon}
               selectedItems={selectedConnections}
               onChangeItems={(selectedItems) => {
-                connectionsStore.onTest(selectedItems)
+                connectionsStore.onTestConnections(selectedItems)
                 onChangeConnections(
                   selectedItems.map((it) => ({
                     ...it,

--- a/config-ui/src/store/index.ts
+++ b/config-ui/src/store/index.ts
@@ -16,4 +16,5 @@
  *
  */
 
+export * from './store'
 export * from './connections'

--- a/config-ui/src/store/store.tsx
+++ b/config-ui/src/store/store.tsx
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import React, { useContext } from 'react'
+
+import { PageLoading } from '@/components'
+
+import type { ConnectionItemType } from './connections'
+import { useConnections } from './connections'
+
+export const StoreContext = React.createContext<{
+  connections: ConnectionItemType[]
+  onRefreshConnections: () => void
+  onTestConnections: (selectedConnections: ConnectionItemType[]) => void
+}>({
+  connections: [],
+  onRefreshConnections: () => {},
+  onTestConnections: () => {}
+})
+
+interface Props {
+  children?: React.ReactNode
+}
+
+export const StoreContextProvider = ({ children }: Props) => {
+  const { loading, connections, onRefresh, onTest } = useConnections()
+
+  if (loading) {
+    return <PageLoading />
+  }
+
+  return (
+    <StoreContext.Provider
+      value={{
+        connections,
+        onRefreshConnections: onRefresh,
+        onTestConnections: onTest
+      }}
+    >
+      {children}
+    </StoreContext.Provider>
+  )
+}
+
+export const useStore = () => {
+  return useContext(StoreContext)
+}


### PR DESCRIPTION
### Summary
The connections store is not injected into the context, and it will trigger a lot of extra requests.