### PR TITLE
refactor: add ConfigReader to BasicRes interface

### DIFF
--- a/impl/default_basic_res.go
+++ b/impl/default_basic_res.go
@@ -20,24 +20,23 @@ package impl
 import (
 	"github.com/apache/incubator-devlake/plugins/core"
 	"github.com/apache/incubator-devlake/plugins/core/dal"
-	"github.com/spf13/viper"
 )
 
 // DefaultBasicRes offers a common implementation for the  BasisRes interface
 type DefaultBasicRes struct {
-	cfg    *viper.Viper
+	cfg    core.ConfigReader
 	logger core.Logger
 	db     dal.Dal
+}
+
+// GetConfigReader returns the ConfigReader instance
+func (c *DefaultBasicRes) GetConfigReader() core.ConfigReader {
+	return c.cfg
 }
 
 // GetConfig returns the value of the specificed name
 func (c *DefaultBasicRes) GetConfig(name string) string {
 	return c.cfg.GetString(name)
-}
-
-// GetDal returns the Dal instance
-func (c *DefaultBasicRes) GetDal() dal.Dal {
-	return c.db
 }
 
 // GetLogger returns the Logger instance
@@ -63,9 +62,14 @@ func (c *DefaultBasicRes) ReplaceLogger(logger core.Logger) core.BasicRes {
 	}
 }
 
+// GetDal returns the Dal instance
+func (c *DefaultBasicRes) GetDal() dal.Dal {
+	return c.db
+}
+
 // NewDefaultBasicRes creates a new DefaultBasicRes instance
 func NewDefaultBasicRes(
-	cfg *viper.Viper,
+	cfg core.ConfigReader,
 	logger core.Logger,
 	db dal.Dal,
 ) *DefaultBasicRes {

--- a/plugins/core/basic_res.go
+++ b/plugins/core/basic_res.go
@@ -23,9 +23,13 @@ import (
 
 // BasicRes defines a set of fundamental resources that needed pretty much everywhere in our system
 type BasicRes interface {
+	// config
+	GetConfigReader() ConfigReader
 	GetConfig(name string) string
+	// logger
 	GetLogger() Logger
-	GetDal() dal.Dal
 	NestedLogger(name string) BasicRes
 	ReplaceLogger(logger Logger) BasicRes
+	// dal
+	GetDal() dal.Dal
 }

--- a/plugins/core/config.go
+++ b/plugins/core/config.go
@@ -17,10 +17,20 @@ limitations under the License.
 
 package core
 
-type ConfigGetter interface {
-	GetString(name string) string
-}
+import "time"
 
-type InjectConfigGetter interface {
-	SetConfigGetter(getter ConfigGetter)
+type ConfigReader interface {
+	Get(key string) interface{}
+	GetBool(name string) bool
+	GetFloat64(key string) float64
+	GetInt(key string) int
+	GetIntSlice(key string) []int
+	GetString(key string) string
+	GetStringMap(key string) map[string]interface{}
+	GetStringMapString(key string) map[string]string
+	GetStringSlice(key string) []string
+	GetTime(key string) time.Time
+	GetDuration(key string) time.Duration
+	IsSet(key string) bool
+	AllSettings() map[string]interface{}
 }

--- a/plugins/core/config.go
+++ b/plugins/core/config.go
@@ -24,6 +24,9 @@ type ConfigReader interface {
 	GetBool(name string) bool
 	GetFloat64(key string) float64
 	GetInt(key string) int
+	GetInt64(key string) int64
+	GetUint(key string) uint
+	GetUint64(key string) uint64
 	GetIntSlice(key string) []int
 	GetString(key string) string
 	GetStringMap(key string) map[string]interface{}

--- a/plugins/core/logger.go
+++ b/plugins/core/logger.go
@@ -18,8 +18,9 @@ limitations under the License.
 package core
 
 import (
-	"github.com/sirupsen/logrus"
 	"io"
+
+	"github.com/sirupsen/logrus"
 )
 
 type LogLevel logrus.Level
@@ -55,10 +56,6 @@ type Logger interface {
 type LoggerStreamConfig struct {
 	Path   string
 	Writer io.Writer
-}
-
-type InjectLogger interface {
-	SetLogger(logger Logger)
 }
 
 // LoggerConfig config related to the Logger. This needs to be serializable, so it can be passed around over the wire.

--- a/plugins/feishu/models/migrationscripts/20220714_add_init_tables.go
+++ b/plugins/feishu/models/migrationscripts/20220714_add_init_tables.go
@@ -27,11 +27,6 @@ import (
 )
 
 type addInitTables struct {
-	config core.ConfigGetter
-}
-
-func (u *addInitTables) SetConfigGetter(config core.ConfigGetter) {
-	u.config = config
 }
 
 func (u *addInitTables) Up(basicRes core.BasicRes) errors.Error {

--- a/plugins/github/models/migrationscripts/20220715_add_init_tables.go
+++ b/plugins/github/models/migrationscripts/20220715_add_init_tables.go
@@ -27,11 +27,6 @@ import (
 )
 
 type addInitTables struct {
-	config core.ConfigGetter
-}
-
-func (u *addInitTables) SetConfigGetter(config core.ConfigGetter) {
-	u.config = config
 }
 
 func (u *addInitTables) Up(basicRes core.BasicRes) errors.Error {

--- a/runner/basic_res.go
+++ b/runner/basic_res.go
@@ -23,7 +23,6 @@ import (
 	"github.com/apache/incubator-devlake/impl/dalgorm"
 	"github.com/apache/incubator-devlake/logger"
 	"github.com/apache/incubator-devlake/plugins/core"
-	"github.com/spf13/viper"
 	"gorm.io/gorm"
 )
 
@@ -40,6 +39,6 @@ func CreateAppBasicRes() core.BasicRes {
 }
 
 // CreateBasicRes returns a BasicRes based on what was given
-func CreateBasicRes(cfg *viper.Viper, log core.Logger, db *gorm.DB) core.BasicRes {
+func CreateBasicRes(cfg core.ConfigReader, log core.Logger, db *gorm.DB) core.BasicRes {
 	return impl.NewDefaultBasicRes(cfg, log, dalgorm.NewDalgorm(db))
 }

--- a/runner/db.go
+++ b/runner/db.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/apache/incubator-devlake/plugins/core"
 	"github.com/apache/incubator-devlake/plugins/core/dal"
-	"github.com/spf13/viper"
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -35,7 +34,7 @@ import (
 )
 
 // NewGormDb creates a new *gorm.DB and set it up properly
-func NewGormDb(config *viper.Viper, logger core.Logger) (*gorm.DB, errors.Error) {
+func NewGormDb(config core.ConfigReader, logger core.Logger) (*gorm.DB, errors.Error) {
 	return NewGormDbEx(config, logger, &dal.SessionConfig{
 		PrepareStmt:            true,
 		SkipDefaultTransaction: true,
@@ -43,7 +42,7 @@ func NewGormDb(config *viper.Viper, logger core.Logger) (*gorm.DB, errors.Error)
 }
 
 // NewGormDbEx acts like NewGormDb but accept extra sessionConfig
-func NewGormDbEx(config *viper.Viper, logger core.Logger, sessionConfig *dal.SessionConfig) (*gorm.DB, errors.Error) {
+func NewGormDbEx(config core.ConfigReader, logger core.Logger, sessionConfig *dal.SessionConfig) (*gorm.DB, errors.Error) {
 	dbLoggingLevel := gormLogger.Error
 	switch strings.ToLower(config.GetString("DB_LOGGING_LEVEL")) {
 	case "silent":

--- a/services/init.go
+++ b/services/init.go
@@ -32,11 +32,10 @@ import (
 	"github.com/apache/incubator-devlake/plugins/core/dal"
 	"github.com/apache/incubator-devlake/runner"
 	"github.com/robfig/cron/v3"
-	"github.com/spf13/viper"
 	"gorm.io/gorm"
 )
 
-var cfg *viper.Viper
+var cfg core.ConfigReader
 var log core.Logger
 var db *gorm.DB
 var basicRes core.BasicRes


### PR DESCRIPTION
### Summary

This is a prerequisite of #3709 

1. Remove the unused/deprecated interfaces: `ConfigGetter` `InjectConfigGetter` and `InjectLogger`
2. Add `GetConfigReader` to `BasicRes` for:
   - Remove `viper` coupling
   - Callers may utilize the typed methods(`GetBool` `GetInt`, etc.) which make our life easier 
   - We can create a new `BasicRes` instance from the existing one with ease
3. Replace `viper` with `ConfigReader` in the `services` module

### Does this close any open issues?

prerequisite of #3709 

### Screenshots

I tested the GitHub pipeline, it looks alright.
![image](https://user-images.githubusercontent.com/61080/208049059-a9d02e4b-83dc-4b8c-bf73-3e898729bd84.png)


