### PR TITLE
feat: add enrich options for jenkins prepare

### DIFF
--- a/plugins/jenkins/jenkins.go
+++ b/plugins/jenkins/jenkins.go
@@ -35,7 +35,7 @@ func main() {
 	jenkinsCmd.Run = func(cmd *cobra.Command, args []string) {
 		runner.DirectRun(cmd, args, PluginEntry, map[string]interface{}{
 			"connectionId":     *connectionId,
-			"jobFullName":      jobFullName,
+			"jobFullName":      *jobFullName,
 			"deployTagPattern": *deployTagPattern,
 			"createdDateAfter": *CreatedDateAfter,
 		})


### PR DESCRIPTION
### Summary
To ensure the smooth execution of v100-related businesses, V100-related processing is added to PrepareTaskData.
Including EnrichOptions ConvertJobToJenkinsJob, and GetJob with corresponding unit tests

### Does this close any open issues?
Closes xx

### Screenshots
![image](https://user-images.githubusercontent.com/2921251/208087815-f4add48a-84ec-4bb7-ba09-38ae5857e9ad.png)

### Other Information
Any other information that is important to this PR.
