### PR TITLE
fix(dora): change refdiff subtask name

### DIFF
--- a/plugins/dora/impl/impl.go
+++ b/plugins/dora/impl/impl.go
@@ -117,7 +117,7 @@ func (plugin Dora) MakeMetricPluginPipelinePlanV200(projectName string, options 
 	stageDeploymentCommitdiff := core.PipelineStage{
 		{
 			Plugin:   "refdiff",
-			Subtasks: []string{"calculateDeploymentDiffs"},
+			Subtasks: []string{"calculateProjectDeploymentCommitsDiff"},
 			Options: map[string]interface{}{
 				"projectName": projectName,
 			},

--- a/plugins/dora/impl/impl_test.go
+++ b/plugins/dora/impl/impl_test.go
@@ -39,7 +39,7 @@ func TestMakeMetricPluginPipelinePlanV200(t *testing.T) {
 		core.PipelineStage{
 			{
 				Plugin:   "refdiff",
-				Subtasks: []string{"calculateDeploymentDiffs"},
+				Subtasks: []string{"calculateProjectDeploymentCommitsDiff"},
 				Options:  map[string]interface{}{"projectName": projectName},
 			},
 		},

--- a/plugins/gitlab/models/project.go
+++ b/plugins/gitlab/models/project.go
@@ -38,7 +38,7 @@ type GitlabProject struct {
 	StarCount               int    `json:"starCount" mapstructure:"StarCount"`
 	ForkedFromProjectId     int    `json:"forkedFromProjectId" mapstructure:"forkedFromProjectId"`
 	ForkedFromProjectWebUrl string `json:"forkedFromProjectWebUrl" mapstructure:"forkedFromProjectWebUrl" gorm:"type:varchar(255)"`
-	HttpUrlToRepo           string `json:"http_url_to_repo" gorm:"varchar(255)"`
+	HttpUrlToRepo           string `json:"httpUrlToRepo" gorm:"varchar(255)"`
 
 	CreatedDate      time.Time  `json:"createdDate" mapstructure:"-"`
 	UpdatedDate      *time.Time `json:"updatedDate" mapstructure:"-"`

--- a/services/blueprint_makeplan_v200_test.go
+++ b/services/blueprint_makeplan_v200_test.go
@@ -61,7 +61,7 @@ func TestMakePlanV200(t *testing.T) {
 	doraName := "TestMakePlanV200-dora"
 	doraOutputPlan := core.PipelinePlan{
 		{
-			{Plugin: "refdiff", Subtasks: []string{"calculateDeploymentDiffs"}, Options: map[string]interface{}{"projectName": projectName}},
+			{Plugin: "refdiff", Subtasks: []string{"calculateProjectDeploymentCommitsDiff"}, Options: map[string]interface{}{"projectName": projectName}},
 			{Plugin: doraName},
 		},
 	}


### PR DESCRIPTION
### Summary
Change refdiff subtask name that was created by dora when making plan.

By the way, this pr also changed the json tag of a field(HttpUrlToRepo) of GitlabProject

### Does this close any open issues?
Closes #3940 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
