### PR TITLE
fix: dbt log show failure, but it succeeded

### DIFF
--- a/plugins/dbt/tasks/convertor.go
+++ b/plugins/dbt/tasks/convertor.go
@@ -184,7 +184,7 @@ func DbtConverter(taskCtx core.SubTaskContext) errors.Error {
 	if err != nil {
 		return err
 	}
-
+	// ProcessState contains information about an exited process, available after a call to Wait.
 	defer func() {
 		if !cmd.ProcessState.Success() {
 			log.Error(nil, "dbt run task error, please check!!!")

--- a/plugins/dbt/tasks/convertor.go
+++ b/plugins/dbt/tasks/convertor.go
@@ -184,6 +184,13 @@ func DbtConverter(taskCtx core.SubTaskContext) errors.Error {
 	if err != nil {
 		return err
 	}
+
+	defer func() {
+		if !cmd.ProcessState.Success() {
+			log.Error(nil, "dbt run task error, please check!!!")
+		}
+	}()
+
 	// prevent zombie process
 	defer cmd.Wait() //nolint
 
@@ -201,10 +208,6 @@ func DbtConverter(taskCtx core.SubTaskContext) errors.Error {
 	}
 	if err := errors.Convert(scanner.Err()); err != nil {
 		return err
-	}
-
-	if !cmd.ProcessState.Success() {
-		log.Error(nil, "dbt run task error, please check!!!")
 	}
 
 	return nil


### PR DESCRIPTION
### Summary

ProcessState contains information about an exited process, available **after** a call to Wait or Run.

### Does this close any open issues?
Closes #3968 

### Screenshots
Network problem, the screenshot cannot be submitted, please make it up later.

### Other Information
Any other information that is important to this PR.
