### PR TITLE
fix: support create bp without project

### DIFF
--- a/services/blueprint_makeplan_v200.go
+++ b/services/blueprint_makeplan_v200.go
@@ -41,12 +41,14 @@ func GeneratePlanJsonV200(
 	}
 	// refresh project_mapping table to reflect project/scopes relationship
 	if len(scopes) > 0 {
-		e := db.Where("project_name = ?", projectName).Delete(&crossdomain.ProjectMapping{}).Error
-		if e != nil {
-			return nil, errors.Default.Wrap(e, fmt.Sprintf("projectName:[%s]", projectName))
+		if projectName != "" {
+			e := db.Where("project_name = ?", projectName).Delete(&crossdomain.ProjectMapping{}).Error
+			if e != nil {
+				return nil, errors.Default.Wrap(e, fmt.Sprintf("projectName:[%s]", projectName))
+			}
 		}
 		for _, scope := range scopes {
-			e = basicRes.GetDal().CreateOrUpdate(scope)
+			e := basicRes.GetDal().CreateOrUpdate(scope)
 			if e != nil {
 				scopeInfo := fmt.Sprintf("[Id:%s][Name:%s][TableName:%s]", scope.ScopeId(), scope.ScopeName(), scope.TableName())
 				return nil, errors.Default.Wrap(e, fmt.Sprintf("failed to create scopes:[%s]", scopeInfo))


### PR DESCRIPTION
### Summary
support creating a blueprint without any project.
Check the blueprint's project name if it was used by another blueprint.

bp_post2.0.0.sh
```bash
#!/bin/sh
curl --location --request POST 'devlake:8080/blueprints' \
--header 'Content-Type: application/json' \
--data-raw '
{
    "name":"test-gitlab-nddtf-v200",
    "projectName":"TestProject",
    "cronConfig":"0 0 * * *",
    "plan":{},
    "settings":
    {
        "version":"2.0.0",
        "connections":
        [
            {
                "plugin":"gitlab",
                "connectionId":1,
                "scopes":[
                    {
                        "id": "37",
                        "name": "思码逸 / Lake",
                        "entities":["CODE","TICKET","CODEREVIEW","CROSS","CICD"]
                    }
                ]
            }
        ]
    },
    "enable":true,
    "mode":"NORMAL",
    "isManual":true
}'


echo "\r\n"
```

bp_patch2.0.0.sh
```bash
#!/bin/sh
curl --location --request PATCH 'devlake:8080/blueprints/25' \
--header 'Content-Type: application/json' \
--data-raw '
{
    "name":"test-gitlab-nddtf-v200-no-project-name",
    "projectName":"TestProject",
    "cronConfig":"0 0 * * *",
    "plan":{},
    "settings":
    {
        "version":"2.0.0",
        "connections":
        [
            {
                "plugin":"gitlab",
                "connectionId":1,
                "scopes":[
                    {
                        "id": "37",
                        "name": "思码逸 / Lake",
                        "entities":["CODE","TICKET","CODEREVIEW","CROSS","CICD"]
                    }
                ]
            }
        ]
    },
    "enable":true,
    "mode":"NORMAL",
    "isManual":true
}'


echo "\r\n"
```

bp_patch2.0.0_np.sh
```bash
#!/bin/sh
curl --location --request PATCH 'devlake:8080/blueprints/25' \
--header 'Content-Type: application/json' \
--data-raw '
{
    "name":"test-gitlab-nddtf-v200-no-project-name",
    "cronConfig":"0 0 * * *",
    "plan":{},
    "settings":
    {
        "version":"2.0.0",
        "connections":
        [
            {
                "plugin":"gitlab",
                "connectionId":1,
                "scopes":[
                    {
                        "id": "37",
                        "name": "思码逸 / Lake",
                        "entities":["CODE","TICKET","CODEREVIEW","CROSS","CICD"]
                    }
                ]
            }
        ]
    },
    "enable":true,
    "mode":"NORMAL",
    "isManual":true
}'


echo "\r\n"
```

### Does this close any open issues?
Closes #3944 

### Screenshots
![1671442520537](https://user-images.githubusercontent.com/2921251/208398558-5ed514b8-c638-4495-9067-0163afca02cc.jpg)
![1671443448648](https://user-images.githubusercontent.com/2921251/208398577-64ccdb7a-04ca-449f-acb9-4bbc103c4b1a.jpg)
![image](https://user-images.githubusercontent.com/2921251/208409010-0790bc0f-8a59-4a0b-bcdb-6b819d2c24be.png)


