### PR TITLE
fix(gitex): print all errors that swallowed before

### DIFF
--- a/models/migrationscripts/20220913_fix_commitfile_id_toolong.go
+++ b/models/migrationscripts/20220913_fix_commitfile_id_toolong.go
@@ -36,12 +36,16 @@ type commitFile20220913Before struct {
 	archived.DomainEntity
 	CommitSha string `gorm:"type:varchar(40)"`
 	FilePath  string `gorm:"type:varchar(255)"` // target field
+	Additions int
+	Deletions int
 }
 
 type commitFile20220913After struct {
 	archived.DomainEntity
 	CommitSha string `gorm:"type:varchar(40)"`
 	FilePath  string `gorm:"type:text"` // target field
+	Additions int
+	Deletions int
 }
 
 type commitFileComponent20220913 struct {

--- a/plugins/gitextractor/parser/repo.go
+++ b/plugins/gitextractor/parser/repo.go
@@ -115,7 +115,10 @@ func (r *GitRepo) CountCommits(ctx context.Context) (int, errors.Error) {
 			return ctx.Err()
 		default:
 		}
-		commit, _ := r.repo.LookupCommit(id)
+		commit, e := r.repo.LookupCommit(id)
+		if e != nil {
+			r.logger.Error(e, "")
+		}
 		if commit != nil {
 			count++
 		}
@@ -135,7 +138,12 @@ func (r *GitRepo) CollectTags(subtaskCtx core.SubTaskContext) errors.Error {
 		var err1 error
 		var tag *git.Tag
 		var tagCommit string
-		tag, _ = r.repo.LookupTag(id)
+		tag, err1 = r.repo.LookupTag(id)
+		if err1 != nil {
+			if err1 != nil {
+				r.logger.Error(err1, "")
+			}
+		}
 		if tag != nil {
 			tagCommit = tag.TargetId().String()
 		} else {
@@ -189,7 +197,10 @@ func (r *GitRepo) CollectBranches(subtaskCtx core.SubTaskContext) errors.Error {
 				CommitSha:    sha,
 				RefType:      BRANCH,
 			}
-			ref.IsDefault, _ = branch.IsHead()
+			ref.IsDefault, err1 = branch.IsHead()
+			if err1 != nil {
+				r.logger.Error(err1, "")
+			}
 			err1 = r.store.Refs(ref)
 			if err1 != nil {
 				return err1
@@ -228,7 +239,10 @@ func (r *GitRepo) CollectCommits(subtaskCtx core.SubTaskContext) errors.Error {
 			return subtaskCtx.GetContext().Err()
 		default:
 		}
-		commit, _ := r.repo.LookupCommit(id)
+		commit, err1 := r.repo.LookupCommit(id)
+		if err1 != nil {
+			r.logger.Error(err1, "")
+		}
 		if commit == nil {
 			return nil
 		}
@@ -401,14 +415,23 @@ func (r *GitRepo) CollectDiffLine(subtaskCtx core.SubTaskContext) errors.Error {
 	commitList := make([]git.Commit, 0)
 	//get currently head commitsha, dafault is master branch
 	// check branch, if not master, checkout to branch's head
-	commitOid, _ := repo.Head()
+	commitOid, err1 := repo.Head()
+	if err1 != nil {
+		r.logger.Error(err1, "")
+	}
 	//get head commit object and add into commitList
-	commit, _ := repo.LookupCommit(commitOid.Target())
+	commit, err1 := repo.LookupCommit(commitOid.Target())
+	if err1 != nil {
+		r.logger.Error(err1, "")
+	}
 	commitList = append(commitList, *commit)
 	// if current head has parents, get parent commitsha
 	for commit != nil && commit.ParentCount() > 0 {
 		pid := commit.ParentId(0)
-		commit, _ = repo.LookupCommit(pid)
+		commit, err1 = repo.LookupCommit(pid)
+		if err1 != nil {
+			r.logger.Error(err1, "")
+		}
 		commitList = append(commitList, *commit)
 	}
 	// reverse commitList

--- a/plugins/gitextractor/tasks/git_repo_collector.go
+++ b/plugins/gitextractor/tasks/git_repo_collector.go
@@ -54,6 +54,7 @@ func CollectGitCommits(subTaskCtx core.SubTaskContext) errors.Error {
 	if count, err := repo.CountCommits(subTaskCtx.GetContext()); err != nil {
 		subTaskCtx.GetLogger().Error(err, "unable to get commit count")
 		subTaskCtx.SetProgress(0, -1)
+		return err
 	} else {
 		subTaskCtx.SetProgress(0, count)
 	}
@@ -65,6 +66,7 @@ func CollectGitBranches(subTaskCtx core.SubTaskContext) errors.Error {
 	if count, err := repo.CountBranches(subTaskCtx.GetContext()); err != nil {
 		subTaskCtx.GetLogger().Error(err, "unable to get branch count")
 		subTaskCtx.SetProgress(0, -1)
+		return err
 	} else {
 		subTaskCtx.SetProgress(0, count)
 	}
@@ -76,6 +78,7 @@ func CollectGitTags(subTaskCtx core.SubTaskContext) errors.Error {
 	if count, err := repo.CountTags(); err != nil {
 		subTaskCtx.GetLogger().Error(err, "unable to get tag count")
 		subTaskCtx.SetProgress(0, -1)
+		return err
 	} else {
 		subTaskCtx.SetProgress(0, count)
 	}
@@ -87,6 +90,7 @@ func CollectGitDiffLines(subTaskCtx core.SubTaskContext) errors.Error {
 	if count, err := repo.CountTags(); err != nil {
 		subTaskCtx.GetLogger().Error(err, "unable to get line content")
 		subTaskCtx.SetProgress(0, -1)
+		return err
 	} else {
 		subTaskCtx.SetProgress(0, count)
 	}


### PR DESCRIPTION
### Summary
Before change, we swallowed some errors in order to let the process continue. These errors were produced by libgit2, but would not impact the whole process. So in this pr, we just print them in log files.

In addition, we update 20220913_fix_commitfile_id_toolong.go to let commit_files keep additions and deletions. Otherwise, it will panic.

### Does this close any open issues?
Closes #3864

### Screenshots
![image](https://user-images.githubusercontent.com/39366025/208599470-66f660c9-f8f4-4a5f-a47f-b375a91a4fd6.png)


### Other Information
Any other information that is important to this PR.
