### PR TITLE
refactor: improve the error message for pipeline and task

### DIFF
--- a/runner/run_task.go
+++ b/runner/run_task.go
@@ -85,7 +85,7 @@ func RunTask(
 			}
 			dbe := db.UpdateColumns(task, []dal.DalSet{
 				{ColumnName: "status", Value: models.TASK_FAILED},
-				{ColumnName: "message", Value: lakeErr.Messages().Format()},
+				{ColumnName: "message", Value: lakeErr.Error()},
 				{ColumnName: "finished_at", Value: finishedAt},
 				{ColumnName: "spent_seconds", Value: spentSeconds},
 				{ColumnName: "failed_sub_task", Value: subTaskName},

--- a/services/pipeline_runner.go
+++ b/services/pipeline_runner.go
@@ -127,11 +127,7 @@ func runPipeline(pipelineId uint64) errors.Error {
 	}
 	if err != nil {
 		dbPipeline.Status = models.TASK_FAILED
-		if lakeErr := errors.AsLakeErrorType(err); lakeErr != nil {
-			dbPipeline.Message = lakeErr.Messages().Format()
-		} else {
-			dbPipeline.Message = err.Error()
-		}
+		dbPipeline.Message = err.Error()
 	} else {
 		dbPipeline.Status = models.TASK_COMPLETED
 		dbPipeline.Message = ""

--- a/services/task.go
+++ b/services/task.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/apache/incubator-devlake/errors"
@@ -301,7 +302,12 @@ func RunTasksStandalone(parentLogger core.Logger, taskIds []uint64) errors.Error
 		}
 	}
 	if len(errs) > 0 {
-		err = errors.Default.Combine(errs)
+		var sb strings.Builder
+		for _, e := range errs {
+			_, _ = sb.WriteString(e.Error())
+			_, _ = sb.WriteString("\n")
+		}
+		err = errors.Default.New(sb.String())
 	}
 	return errors.Convert(err)
 }


### PR DESCRIPTION
### Summary
Improve the error message. Save more detailed information in the database when an error occurs.
The `_devlake_pipelines.message` and `_devlake_tasks.message` is filled with a detailed error message.

### Does this close any open issues?
Closes #3974 

### Screenshots
_devlake_pipelines.message
![image](https://user-images.githubusercontent.com/8455907/208633652-a5556204-ce07-4eeb-9beb-2ff2e94b1802.png)

_devlake_tasks.message
![image](https://user-images.githubusercontent.com/8455907/208633839-7093395c-0d1e-4267-975e-e11ae3ff81ba.png)


