### PR TITLE
feat: add time filter for gitlab jobs

### DIFF
--- a/plugins/gitlab/tasks/job_collector.go
+++ b/plugins/gitlab/tasks/job_collector.go
@@ -43,7 +43,7 @@ func CollectApiJobs(taskCtx core.SubTaskContext) errors.Error {
 		Incremental:        false,
 		UrlTemplate:        "projects/{{ .Params.ProjectId }}/jobs",
 		Query:              GetQuery,
-		ResponseParser:     GetRawMessageFromResponse,
+		ResponseParser:     GetRawMessageCreatedAtAfter(data.CreatedDateAfter),
 		AfterResponse:      ignoreHTTPStatus403, // ignore 403 for CI/CD disable
 	})
 

--- a/plugins/gitlab/tasks/shared.go
+++ b/plugins/gitlab/tasks/shared.go
@@ -94,7 +94,7 @@ func GetRawMessageCreatedAtAfter(createDateAfter *time.Time) func(res *http.Resp
 				return nil, err
 			}
 			if createDateAfter == nil || createDateAfter.Before(apiModel.CreatedAt.ToTime()) {
-				// only finish when all item before `createDateAfter`
+				// only finish when all items created before `createDateAfter`
 				// because gitlab's order may not strict enough
 				isFinish = false
 				filterRawMessages = append(filterRawMessages, rawMessage)

--- a/plugins/gitlab/tasks/shared.go
+++ b/plugins/gitlab/tasks/shared.go
@@ -94,7 +94,7 @@ func GetRawMessageCreatedAtAfter(createDateAfter *time.Time) func(res *http.Resp
 				return nil, err
 			}
 			if createDateAfter == nil || createDateAfter.Before(apiModel.CreatedAt.ToTime()) {
-				// only finish when all items created before `createDateAfter`
+				// only finish when all items are created before `createDateAfter`
 				// because gitlab's order may not strict enough
 				isFinish = false
 				filterRawMessages = append(filterRawMessages, rawMessage)

--- a/plugins/gitlab/tasks/shared.go
+++ b/plugins/gitlab/tasks/shared.go
@@ -27,6 +27,7 @@ import (
 	"net/url"
 	"reflect"
 	"strconv"
+	"time"
 
 	"github.com/apache/incubator-devlake/plugins/core"
 	"github.com/apache/incubator-devlake/plugins/helper"
@@ -72,6 +73,38 @@ func GetRawMessageFromResponse(res *http.Response) ([]json.RawMessage, errors.Er
 	}
 
 	return rawMessages, nil
+}
+
+func GetRawMessageCreatedAtAfter(createDateAfter *time.Time) func(res *http.Response) ([]json.RawMessage, errors.Error) {
+	type ApiModel struct {
+		CreatedAt *helper.Iso8601Time `json:"created_at"`
+	}
+
+	return func(res *http.Response) ([]json.RawMessage, errors.Error) {
+		rawMessages, err := GetRawMessageFromResponse(res)
+		if err != nil {
+			return nil, errors.Default.Wrap(err, fmt.Sprintf("error reading response from %s", res.Request.URL.String()))
+		}
+		isFinish := true
+		filterRawMessages := []json.RawMessage{}
+		for _, rawMessage := range rawMessages {
+			apiModel := &ApiModel{}
+			err = errors.Convert(json.Unmarshal(rawMessage, apiModel))
+			if err != nil {
+				return nil, err
+			}
+			if createDateAfter == nil || createDateAfter.Before(apiModel.CreatedAt.ToTime()) {
+				// only finish when all item before `createDateAfter`
+				// because gitlab's order may not strict enough
+				isFinish = false
+				filterRawMessages = append(filterRawMessages, rawMessage)
+			}
+		}
+		if isFinish {
+			return filterRawMessages, helper.ErrFinishCollect
+		}
+		return filterRawMessages, nil
+	}
 }
 
 func GetQuery(reqData *helper.RequestData) (url.Values, errors.Error) {


### PR DESCRIPTION
### Summary
add time filter for gitlab jobs.

GitLab jobs do not support the time filter and time sorting. It can only sort by id desc (not strictly). https://docs.gitlab.com/ee/api/pipelines.html#list-project-pipelines

So filter by stopping when job's create time before than options.

gitlab's pipeline can sort by time asc, so I haven't add this. Sort asc can avoid new rows qustions.

### snapshots
The result for only collect the rows created after `2022-12-01T00:00:00Z`
![image](https://user-images.githubusercontent.com/3294100/208966882-ee9d6d5b-eaee-448f-a6dd-608c364b4de7.png)
