### PR TITLE
fix: pipeline stucks after first execution

### DIFF
--- a/services/pipeline.go
+++ b/services/pipeline.go
@@ -166,7 +166,6 @@ func RunPipelineInQueue(pipelineMaxParallel int64) {
 	sema := semaphore.NewWeighted(pipelineMaxParallel)
 	runningParallelLabels := []string{}
 	var runningParallelLabelLock sync.Mutex
-	dbPipeline := &models.DbPipeline{}
 	for {
 		globalPipelineLog.Info("acquire lock")
 		// start goroutine when sema lock ready and pipeline exist.
@@ -176,6 +175,7 @@ func RunPipelineInQueue(pipelineMaxParallel int64) {
 			panic(err)
 		}
 		globalPipelineLog.Info("get lock and wait next pipeline")
+		dbPipeline := &models.DbPipeline{}
 		for {
 			cronLocker.Lock()
 			// prepare query to find an appropriate pipeline to execute


### PR DESCRIPTION
### Summary
Fix pipeline execution stucks

When the `dbPipeline` variable gets put outside the `for` loop, the `dbPipeline.id` gets passed to the next `dequeue` query (line#182), hence no pipeline would ever get dequeued anymore.

### Does this close any open issues?
Closes #4014 

### Screenshots
![Snipaste_2022-12-22_15-52-23](https://user-images.githubusercontent.com/61080/209085108-ad8e5c5d-a5ef-49d4-8232-15d11729fd23.png)


