### PR TITLE
fix: commit_files of initial commits were not collected

### DIFF
--- a/plugins/gitextractor/impl/impl.go
+++ b/plugins/gitextractor/impl/impl.go
@@ -18,6 +18,7 @@ limitations under the License.
 package impl
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/apache/incubator-devlake/errors"
@@ -94,6 +95,8 @@ func NewGitRepo(logger core.Logger, storage models.Store, op tasks.GitExtractorO
 		repo, err = p.CloneOverSSH(op.RepoId, url, op.PrivateKey, op.Passphrase)
 	} else if strings.HasPrefix(op.Url, "/") {
 		repo, err = p.LocalRepo(op.Url, op.RepoId)
+	} else {
+		return nil, errors.BadInput.New(fmt.Sprintf("unsupported url [%s]", op.Url))
 	}
 	return repo, err
 }

--- a/plugins/gitextractor/parser/repo.go
+++ b/plugins/gitextractor/parser/repo.go
@@ -270,17 +270,16 @@ func (r *GitRepo) CollectCommits(subtaskCtx core.SubTaskContext) errors.Error {
 		if err != nil {
 			return err
 		}
+		var parent *git.Commit
 		if commit.ParentCount() > 0 {
-			parent := commit.Parent(0)
-			if parent != nil {
-				var stats *git.DiffStats
-				if stats, err = r.getDiffComparedToParent(c.Sha, commit, parent, opts, componentMap); err != nil {
-					return err
-				}
-				c.Additions += stats.Insertions()
-				c.Deletions += stats.Deletions()
-			}
+			parent = commit.Parent(0)
 		}
+		var stats *git.DiffStats
+		if stats, err = r.getDiffComparedToParent(c.Sha, commit, parent, opts, componentMap); err != nil {
+			return err
+		}
+		c.Additions += stats.Insertions()
+		c.Deletions += stats.Deletions()
 		err = r.store.Commits(c)
 		if err != nil {
 			return err
@@ -317,7 +316,9 @@ func (r *GitRepo) storeParentCommits(commitSha string, commit *git.Commit) error
 func (r *GitRepo) getDiffComparedToParent(commitSha string, commit *git.Commit, parent *git.Commit, opts *git.DiffOptions, componentMap map[string]*regexp.Regexp) (*git.DiffStats, errors.Error) {
 	var err error
 	var parentTree, tree *git.Tree
-	parentTree, err = parent.Tree()
+	if parent != nil {
+		parentTree, err = parent.Tree()
+	}
 	if err != nil {
 		return nil, errors.Convert(err)
 	}


### PR DESCRIPTION
### Summary
Existing code would collect `commit_files` information IFF the commit has a **Parent**, which is not good for **Initial Commits**

This PR fixes the problem by including the **Initial Commits**

### Does this close any open issues?
Closes #4001

### Screenshots
Tested on https://github.com/merico-dev/build-frontend
![image](https://user-images.githubusercontent.com/61080/209311930-eb835e99-b3fe-436b-92fe-c0e801945b5c.png)

