### PR TITLE
refactor: rename project metrics

### DIFF
--- a/models/migrationscripts/20221109_rename_project_metrics.go
+++ b/models/migrationscripts/20221109_rename_project_metrics.go
@@ -1,0 +1,48 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"github.com/apache/incubator-devlake/errors"
+	"github.com/apache/incubator-devlake/plugins/core"
+)
+
+var _ core.MigrationScript = (*renameProjectMetrics)(nil)
+
+type renameProjectMetrics struct{}
+
+type ProjectMetricSetting struct {
+}
+
+func (ProjectMetricSetting) TableName() string {
+	return "project_metric_settings"
+}
+
+func (script *renameProjectMetrics) Up(basicRes core.BasicRes) errors.Error {
+	db := basicRes.GetDal()
+	// To create multiple tables with migrationhelper
+	return db.RenameTable(ProjectMetric{}.TableName(), ProjectMetricSetting{}.TableName())
+}
+
+func (*renameProjectMetrics) Version() uint64 {
+	return 20222123191424
+}
+
+func (*renameProjectMetrics) Name() string {
+	return "rename project metrics"
+}

--- a/models/migrationscripts/register.go
+++ b/models/migrationscripts/register.go
@@ -67,5 +67,6 @@ func All() []core.MigrationScript {
 		new(addOriginalProject),
 		new(addErrorName),
 		new(encryptTask221221),
+		new(renameProjectMetrics),
 	}
 }

--- a/models/project.go
+++ b/models/project.go
@@ -39,18 +39,18 @@ type BaseMetric struct {
 	Enable       bool   `json:"enable" mapstructure:"enable" gorm:"type:boolean"`
 }
 
-type BaseProjectMetric struct {
+type BaseProjectMetricSetting struct {
 	ProjectName string `json:"projectName" mapstructure:"projectName" gorm:"primaryKey;type:varchar(255)"`
 	BaseMetric  `mapstructure:",squash"`
 }
 
-type ProjectMetric struct {
-	BaseProjectMetric `mapstructure:",squash"`
+type ProjectMetricSetting struct {
+	BaseProjectMetricSetting `mapstructure:",squash"`
 	common.NoPKModel
 }
 
-func (ProjectMetric) TableName() string {
-	return "project_metrics"
+func (ProjectMetricSetting) TableName() string {
+	return "project_metric_settings"
 }
 
 type ApiInputProject struct {

--- a/services/blueprint.go
+++ b/services/blueprint.go
@@ -319,7 +319,7 @@ func MakePlanForBlueprint(blueprint *models.Blueprint) (core.PipelinePlan, error
 	case "2.0.0":
 		// load project metric plugins and convert it to a map
 		metrics := make(map[string]json.RawMessage)
-		projectMetrics := make([]models.ProjectMetric, 0)
+		projectMetrics := make([]models.ProjectMetricSetting, 0)
 		if blueprint.ProjectName != "" {
 			err = db.All(&projectMetrics, dal.Where("project_name = ? AND enable = ?", blueprint.ProjectName, true))
 			if err != nil {

--- a/services/project.go
+++ b/services/project.go
@@ -166,7 +166,7 @@ func PatchProject(name string, body map[string]interface{}) (*models.ApiOutputPr
 	if name != project.Name {
 		// ProjectMetric
 		err = tx.UpdateColumn(
-			&models.ProjectMetric{},
+			&models.ProjectMetricSetting{},
 			"project_name", project.Name,
 			dal.Where("project_name = ?", name),
 		)
@@ -250,14 +250,14 @@ func PatchProject(name string, body map[string]interface{}) (*models.ApiOutputPr
 }
 
 func refreshProjectMetrics(tx dal.Transaction, projectInput *models.ApiInputProject) errors.Error {
-	err := tx.Delete(&models.ProjectMetric{}, dal.Where("project_name = ?", projectInput.Name))
+	err := tx.Delete(&models.ProjectMetricSetting{}, dal.Where("project_name = ?", projectInput.Name))
 	if err != nil {
 		return err
 	}
 
 	for _, baseMetric := range *projectInput.Metrics {
-		err = tx.Create(&models.ProjectMetric{
-			BaseProjectMetric: models.BaseProjectMetric{
+		err = tx.Create(&models.ProjectMetricSetting{
+			BaseProjectMetricSetting: models.BaseProjectMetricSetting{
 				ProjectName: projectInput.Name,
 				BaseMetric:  baseMetric,
 			},
@@ -273,7 +273,7 @@ func makeProjectOutput(baseProject *models.BaseProject) (*models.ApiOutputProjec
 	projectOutput := &models.ApiOutputProject{}
 	projectOutput.BaseProject = *baseProject
 	// load project metrics
-	projectMetrics := make([]models.ProjectMetric, 0)
+	projectMetrics := make([]models.ProjectMetricSetting, 0)
 	err := db.All(&projectMetrics, dal.Where("project_name = ?", projectOutput.Name))
 	if err != nil {
 		return nil, errors.Default.Wrap(err, "failed to load project metrics")


### PR DESCRIPTION
### Summary

To make the name of the table easier to read.
So rename project_metrics to project_metric_settings.

![image](https://user-images.githubusercontent.com/2921251/209329964-9c9cfe3e-687c-4105-a424-27493a5c2370.png)


