### PR TITLE
PoC Jira Server PAT support

### DIFF
--- a/plugins/jira/api/connection.go
+++ b/plugins/jira/api/connection.go
@@ -48,13 +48,17 @@ func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, erro
 	if err != nil {
 		return nil, err
 	}
+	headers := map[string]string{
+		"Authorization": fmt.Sprintf("Basic %v", connection.GetEncodedToken()),
+	}
+	if connection.Username == "_BEARER_TOKEN_" {
+		headers["Authorization"] = fmt.Sprintf("Bearer %v", connection.Password)
+	}
 	// test connection
 	apiClient, err := helper.NewApiClient(
 		context.TODO(),
 		connection.Endpoint,
-		map[string]string{
-			"Authorization": fmt.Sprintf("Basic %v", connection.GetEncodedToken()),
-		},
+		headers,
 		3*time.Second,
 		connection.Proxy,
 		basicRes,

--- a/plugins/jira/api/proxy.go
+++ b/plugins/jira/api/proxy.go
@@ -35,12 +35,16 @@ func Proxy(input *core.ApiResourceInput) (*core.ApiResourceOutput, errors.Error)
 	if err != nil {
 		return nil, err
 	}
+	headers := map[string]string{
+		"Authorization": fmt.Sprintf("Basic %v", connection.GetEncodedToken()),
+	}
+	if connection.Username == "_BEARER_TOKEN_" {
+		headers["Authorization"] = fmt.Sprintf("Bearer %v", connection.Password)
+	}
 	apiClient, err := helper.NewApiClient(
 		context.TODO(),
 		connection.Endpoint,
-		map[string]string{
-			"Authorization": fmt.Sprintf("Basic %v", connection.GetEncodedToken()),
-		},
+		headers,
 		30*time.Second,
 		connection.Proxy,
 		basicRes,

--- a/plugins/jira/tasks/api_client.go
+++ b/plugins/jira/tasks/api_client.go
@@ -19,8 +19,9 @@ package tasks
 
 import (
 	"fmt"
-	"github.com/apache/incubator-devlake/errors"
 	"net/http"
+
+	"github.com/apache/incubator-devlake/errors"
 
 	"github.com/apache/incubator-devlake/plugins/core"
 	"github.com/apache/incubator-devlake/plugins/helper"
@@ -31,6 +32,9 @@ func NewJiraApiClient(taskCtx core.TaskContext, connection *models.JiraConnectio
 	// create synchronize api client so we can calculate api rate limit dynamically
 	headers := map[string]string{
 		"Authorization": fmt.Sprintf("Basic %v", connection.GetEncodedToken()),
+	}
+	if connection.Username == "_BEARER_TOKEN_" {
+		headers["Authorization"] = fmt.Sprintf("Bearer %v", connection.Password)
 	}
 
 	apiClient, err := helper.NewApiClient(taskCtx.GetContext(), connection.Endpoint, headers, 0, connection.Proxy, taskCtx)


### PR DESCRIPTION
### Summary
Currently, we support only `Basic Authentication` for Jira Cloud/Server, it worked fine for most of our users.
However, some might run into a situation the their Jira Server support PAT only for security reason which makes it impossible for devlake to collect data.

### Does this close any open issues?
This is a PoC to verify if it is possible to collect data by using Jira PAT in a hacky way.
