### PR TITLE
fix(github): update prBodyClosePattern to adapt new github options

### DIFF
--- a/config-ui/src/pages/blueprint/components/advanced-editor/example/index.ts
+++ b/config-ui/src/pages/blueprint/components/advanced-editor/example/index.ts
@@ -26,6 +26,8 @@ import jenkins from './jenkins'
 import feishu from './feishu'
 import dbt from './dbt'
 import starrocks from './starrocks'
+import tapd from './tapd'
+import zentao from './zentao'
 
 export const EXAMPLE_CONFIG = [
   {
@@ -72,6 +74,16 @@ export const EXAMPLE_CONFIG = [
     id: 'dbt',
     name: 'Load DBT Configuration',
     config: dbt
+  },
+  {
+    id: 'tapd',
+    name: 'Load TAPD Configuration',
+    config: tapd
+  },
+  {
+    id: 'zentao',
+    name: 'Load ZENTAO Configuration',
+    config: zentao
   },
   {
     id: 'starrocks',

--- a/config-ui/src/pages/blueprint/components/advanced-editor/example/tapd.ts
+++ b/config-ui/src/pages/blueprint/components/advanced-editor/example/tapd.ts
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+export default [
+  [
+    {
+      plugin: 'tapd',
+      options: {
+        companyId: 1,
+        workspaceId: 1,
+        connectionId: 1
+      }
+    }
+  ]
+]

--- a/config-ui/src/pages/blueprint/components/advanced-editor/example/zentao.ts
+++ b/config-ui/src/pages/blueprint/components/advanced-editor/example/zentao.ts
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+export default [
+  [
+    {
+      plugin: 'zentao',
+      options: {
+        connectionId: 1,
+        productId: 1,
+        projectId: 1,
+        executionId: 1
+      }
+    }
+  ]
+]

--- a/config-ui/src/pages/configure/settings/github.jsx
+++ b/config-ui/src/pages/configure/settings/github.jsx
@@ -375,7 +375,7 @@ export default function GithubSettings(props) {
                 className='textarea'
                 value={transformation?.prBodyClosePattern}
                 // eslint-disable-next-line max-len
-                placeholder='(?mi)(fix|close|resolve|fixes|closes|resolves|fixed|closed|resolved)[\s]*.*(((and )?(#|https:\/\/github.com\/%s\/%s\/issues\/)\d+[ ]*)+)'
+                placeholder='(?mi)(fix|close|resolve|fixes|closes|resolves|fixed|closed|resolved)[\s]*.*(((and )?(#|https:\/\/github.com\/%s\/issues\/)\d+[ ]*)+)'
                 onChange={(e) =>
                   onSettingsChange({ prBodyClosePattern: e.target.value })
                 }

--- a/config-ui/src/plugins/github/components/code-review/index.tsx
+++ b/config-ui/src/plugins/github/components/code-review/index.tsx
@@ -124,7 +124,7 @@ export const CodeReview = ({
       >
         <TextArea
           value={transformation.prBodyClosePattern}
-          placeholder='(?mi)(fix|close|resolve|fixes|closes|resolves|fixed|closed|resolved)[\s]*.*(((and )?(#|https:\/\/github.com\/%s\/%s\/issues\/)\d+[ ]*)+)'
+          placeholder='(?mi)(fix|close|resolve|fixes|closes|resolves|fixed|closed|resolved)[\s]*.*(((and )?(#|https:\/\/github.com\/%s\/issues\/)\d+[ ]*)+)'
           onChange={(e) =>
             setTransformation({
               ...transformation,

--- a/plugins/github/github.go
+++ b/plugins/github/github.go
@@ -39,7 +39,7 @@ func main() {
 
 	prType := cmd.Flags().String("prType", "type/(.*)$", "pr type")
 	prComponent := cmd.Flags().String("prComponent", "component/(.*)$", "pr component")
-	prBodyClosePattern := cmd.Flags().String("prBodyClosePattern", "(?mi)(fix|close|resolve|fixes|closes|resolves|fixed|closed|resolved)[\\s]*.*(((and )?(#|https:\\/\\/github.com\\/%s\\/%s\\/issues\\/)\\d+[ ]*)+)", "pr body close pattern")
+	prBodyClosePattern := cmd.Flags().String("prBodyClosePattern", "(?mi)(fix|close|resolve|fixes|closes|resolves|fixed|closed|resolved)[\\s]*.*(((and )?(#|https:\\/\\/github.com\\/%s\\/issues\\/)\\d+[ ]*)+)", "pr body close pattern")
 	issueSeverity := cmd.Flags().String("issueSeverity", "severity/(.*)$", "issue severity")
 	issuePriority := cmd.Flags().String("issuePriority", "^(highest|high|medium|low)$", "issue priority")
 	issueComponent := cmd.Flags().String("issueComponent", "component/(.*)$", "issue component")


### PR DESCRIPTION
### Summary
1. According to pr #3927 , we combined owner and repo into name, so we also need to update `prBodyClosePattern`
2. add lodingTemplate of tapd
### Does this close any open issues?
relate to #3468 

### Screenshots
in new pr, we can successfully collect refs_issues_diffs
<img width="1013" alt="image" src="https://user-images.githubusercontent.com/39366025/209554755-93263442-90a8-44e6-ad32-0ea0f2ed8221.png">


### Other Information
Any other information that is important to this PR.
