### PR TITLE
fix: jenkins scope api error

### DIFF
--- a/plugins/jenkins/api/scope.go
+++ b/plugins/jenkins/api/scope.go
@@ -142,7 +142,7 @@ func GetScopeList(input *core.ApiResourceInput) (*core.ApiResourceOutput, errors
 	}
 	var rules []models.JenkinsTransformationRule
 	if len(ruleIds) > 0 {
-		err = basicRes.GetDal().All(&rules, dal.Where("id IN (?)", ruleIds))
+		err = basicRes.GetDal().All(&rules, dal.Where("transformation_rule_id IN (?)", ruleIds))
 		if err != nil {
 			return nil, err
 		}
@@ -184,7 +184,7 @@ func GetScope(input *core.ApiResourceInput) (*core.ApiResourceOutput, errors.Err
 	}
 	var rule models.JenkinsJob
 	if job.TransformationRuleId > 0 {
-		err = basicRes.GetDal().First(&rule, dal.Where("id = ?", job.TransformationRuleId))
+		err = basicRes.GetDal().First(&rule, dal.Where("transformation_rule_id = ?", job.TransformationRuleId))
 		if err != nil {
 			return nil, err
 		}

--- a/plugins/jenkins/api/scope.go
+++ b/plugins/jenkins/api/scope.go
@@ -142,7 +142,7 @@ func GetScopeList(input *core.ApiResourceInput) (*core.ApiResourceOutput, errors
 	}
 	var rules []models.JenkinsTransformationRule
 	if len(ruleIds) > 0 {
-		err = basicRes.GetDal().All(&rules, dal.Where("transformation_rule_id IN (?)", ruleIds))
+		err = basicRes.GetDal().All(&rules, dal.Where("id IN (?)", ruleIds))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### Summary
the table  lake._tool_jenkins_jobs has not 'id' column, should be 'transformation_rule_id'

### Does this close any open issues?
Closes #4038

### Screenshots

### Other Information
Any other information that is important to this PR.
