### PR TITLE
fix: the jenkins plugin can not scope name in transformation rules

### DIFF
--- a/plugins/jenkins/api/scope.go
+++ b/plugins/jenkins/api/scope.go
@@ -182,9 +182,10 @@ func GetScope(input *core.ApiResourceInput) (*core.ApiResourceOutput, errors.Err
 	if err != nil {
 		return nil, err
 	}
-	var rule models.JenkinsJob
+
+	var rule models.JenkinsTransformationRule
 	if job.TransformationRuleId > 0 {
-		err = basicRes.GetDal().First(&rule, dal.Where("transformation_rule_id = ?", job.TransformationRuleId))
+		err = basicRes.GetDal().First(&rule, dal.Where("id = ?", job.TransformationRuleId))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### Summary
fix: the jenkins plugin can not scope name in transformation rules.
the model is error.

### Does this close any open issues?
Closes #4038 

### Screenshots
old:
![image](https://user-images.githubusercontent.com/101256042/209753486-6541eefc-c15c-4f12-9945-e7a0111d2b24.png)
![image](https://user-images.githubusercontent.com/101256042/209753510-1df9e997-1789-4983-b25c-fd8233689558.png)
new:
![image](https://user-images.githubusercontent.com/101256042/209753578-d40efd44-0f90-45f4-9f08-f8ade01164ac.png)


### Other Information
Any other information that is important to this PR.
