### PR TITLE
fix: jenkins production_pattern is same to deployment_pattern

### DIFF
--- a/plugins/jenkins/models/transformation_rule.go
+++ b/plugins/jenkins/models/transformation_rule.go
@@ -23,7 +23,7 @@ type JenkinsTransformationRule struct {
 	common.Model      `mapstructure:"-"`
 	Name              string `gorm:"type:varchar(255)" mapstructure:"name" json:"name"`
 	DeploymentPattern string `gorm:"type:varchar(255)" mapstructure:"deploymentPattern,omitempty" json:"deploymentPattern"`
-	ProductionPattern string `gorm:"type:varchar(255)" mapstructure:"deploymentPattern,omitempty" json:"productionPattern"`
+	ProductionPattern string `gorm:"type:varchar(255)" mapstructure:"productionPattern,omitempty" json:"productionPattern"`
 }
 
 func (t JenkinsTransformationRule) TableName() string {


### PR DESCRIPTION
### Summary
jenkins production_pattern is same to deployment_pattern, ProductionPattern model set error

### Does this close any open issues?
Closes #4049 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
