### PR TITLE
refactor: improve slice size check for gitlab

### DIFF
--- a/plugins/gitlab/tasks/issue_extractor.go
+++ b/plugins/gitlab/tasks/issue_extractor.go
@@ -206,21 +206,21 @@ func ExtractApiIssues(taskCtx core.SubTaskContext) errors.Error {
 				})
 				if issueSeverityRegex != nil {
 					groups := issueSeverityRegex.FindStringSubmatch(label)
-					if len(groups) > 0 {
+					if len(groups) > 1 {
 						gitlabIssue.Severity = groups[1]
 					}
 				}
 
 				if issueComponentRegex != nil {
 					groups := issueComponentRegex.FindStringSubmatch(label)
-					if len(groups) > 0 {
+					if len(groups) > 1 {
 						gitlabIssue.Component = groups[1]
 					}
 				}
 
 				if issuePriorityRegex != nil {
 					groups := issuePriorityRegex.FindStringSubmatch(label)
-					if len(groups) > 0 {
+					if len(groups) > 1 {
 						gitlabIssue.Priority = groups[1]
 					}
 				}

--- a/plugins/gitlab/tasks/mr_extractor.go
+++ b/plugins/gitlab/tasks/mr_extractor.go
@@ -119,7 +119,7 @@ func ExtractApiMergeRequests(taskCtx core.SubTaskContext) errors.Error {
 				// if pr.Type has not been set and prType is set in .env, process the below
 				if labelTypeRegex != nil {
 					groups := labelTypeRegex.FindStringSubmatch(label)
-					if len(groups) > 0 {
+					if len(groups) > 1 {
 						gitlabMergeRequest.Type = groups[1]
 					}
 				}
@@ -127,7 +127,7 @@ func ExtractApiMergeRequests(taskCtx core.SubTaskContext) errors.Error {
 				// if pr.Component has not been set and prComponent is set in .env, process
 				if labelComponentRegex != nil {
 					groups := labelComponentRegex.FindStringSubmatch(label)
-					if len(groups) > 0 {
+					if len(groups) > 1 {
 						gitlabMergeRequest.Component = groups[1]
 					}
 				}


### PR DESCRIPTION
### Summary
The following snippet is taken from the codebase. It looks like it would result in the `index out of range error`, but the function `FindStringSubmatch` ensures this will not happen. In this PR, we improved the readability by changing the expression inside the `if` statement from `len(groups) > 0` to `len(groups) > 1`
```go
groups := labelTypeRegex.FindStringSubmatch(label)
	if len(groups) > 0 {
		gitlabMergeRequest.Type = groups[1]
	}
```

