### PR TITLE
fix: jenkins transformation rules have not in effect and getjobs api error

### DIFF
--- a/plugins/jenkins/api/blueprint_v200.go
+++ b/plugins/jenkins/api/blueprint_v200.go
@@ -58,18 +58,11 @@ func makeDataSourcePipelinePlanV200(
 		if stage == nil {
 			stage = core.PipelineStage{}
 		}
-		jenkinsJob := &models.JenkinsJob{}
-		// get transformation_rule_id from db
-		err := basicRes.GetDal().First(jenkinsJob, dal.Where(`connection_id = ? AND full_name = ?`, connectionId, bpScope.Id))
-		if err != nil {
-			return nil, errors.Default.Wrap(err, fmt.Sprintf("fail to find transformation_rule_id by %s", bpScope.Id))
-		}
 
 		// construct task options for Jenkins
 		options := make(map[string]interface{})
 		options["scopeId"] = bpScope.Id
 		options["connectionId"] = connectionId
-		options["TransformationRuleId"] = jenkinsJob.TransformationRuleId
 
 		if syncPolicy.CreatedDateAfter != nil {
 			options["createdDateAfter"] = syncPolicy.CreatedDateAfter.Format(time.RFC3339)

--- a/plugins/jenkins/api/blueprint_v200.go
+++ b/plugins/jenkins/api/blueprint_v200.go
@@ -58,10 +58,19 @@ func makeDataSourcePipelinePlanV200(
 		if stage == nil {
 			stage = core.PipelineStage{}
 		}
-		// construct task options for Jira
+		jenkinsJob := &models.JenkinsJob{}
+		// get transformation_rule_id from db
+		err := basicRes.GetDal().First(jenkinsJob, dal.Where(`connection_id = ? AND full_name = ?`, connectionId, bpScope.Id))
+		if err != nil {
+			return nil, errors.Default.Wrap(err, fmt.Sprintf("fail to find transformation_rule_id by %s", bpScope.Id))
+		}
+
+		// construct task options for Jenkins
 		options := make(map[string]interface{})
 		options["scopeId"] = bpScope.Id
 		options["connectionId"] = connectionId
+		options["TransformationRuleId"] = jenkinsJob.TransformationRuleId
+
 		if syncPolicy.CreatedDateAfter != nil {
 			options["createdDateAfter"] = syncPolicy.CreatedDateAfter.Format(time.RFC3339)
 		}

--- a/plugins/jenkins/api/jobs.go
+++ b/plugins/jenkins/api/jobs.go
@@ -78,7 +78,7 @@ func GetJobs(apiClient helper.ApiClientGetter, path string, pageSize int, callba
 func GetJob(apiClient helper.ApiClientGetter, path string, name string, fullName string, pageSize int, callback func(job *models.Job, isPath bool) errors.Error) errors.Error {
 	var err errors.Error
 
-	return GetJobs(apiClient, path+name, pageSize, func(job *models.Job) errors.Error {
+	return GetJobs(apiClient, path, pageSize, func(job *models.Job) errors.Error {
 		if job.Name != name {
 			return nil
 		}

--- a/plugins/jenkins/api/jobs.go
+++ b/plugins/jenkins/api/jobs.go
@@ -78,7 +78,7 @@ func GetJobs(apiClient helper.ApiClientGetter, path string, pageSize int, callba
 func GetJob(apiClient helper.ApiClientGetter, path string, name string, fullName string, pageSize int, callback func(job *models.Job, isPath bool) errors.Error) errors.Error {
 	var err errors.Error
 
-	return GetJobs(apiClient, path, pageSize, func(job *models.Job) errors.Error {
+	return GetJobs(apiClient, path+name, pageSize, func(job *models.Job) errors.Error {
 		if job.Name != name {
 			return nil
 		}

--- a/plugins/jenkins/impl/impl.go
+++ b/plugins/jenkins/impl/impl.go
@@ -236,6 +236,9 @@ func EnrichOptions(taskCtx core.TaskContext,
 			lastOne := len(pathSplit)
 
 			path := "job/" + strings.Join(pathSplit[0:lastOne-1], "job/")
+			if path == "job/" {
+				path = ""
+			}
 			name := pathSplit[lastOne-1]
 
 			err = api.GetJob(apiClient, path, name, op.JobFullName, 100, func(job *models.Job, isPath bool) errors.Error {

--- a/plugins/jenkins/impl/impl.go
+++ b/plugins/jenkins/impl/impl.go
@@ -219,21 +219,7 @@ func EnrichOptions(taskCtx core.TaskContext,
 	}
 	log := taskCtx.GetLogger()
 
-	// We only set op.JenkinsTransformationRule when it's nil and we have op.TransformationRuleId != 0
-	if op.JenkinsTransformationRule == nil && op.TransformationRuleId != 0 {
-		var transformationRule models.JenkinsTransformationRule
-		err = taskCtx.GetDal().First(&transformationRule, dal.Where("id = ?", op.TransformationRuleId))
-		if err != nil {
-			return errors.BadInput.Wrap(err, "fail to get transformationRule")
-		}
-		op.JenkinsTransformationRule = &transformationRule
-	}
-
-	if op.JenkinsTransformationRule == nil && op.TransformationRuleId == 0 {
-		op.JenkinsTransformationRule = new(models.JenkinsTransformationRule)
-	}
-
-	// for advanced mode or others which we only have name, for bp v200, we have githubId
+	// for advanced mode or others which we only have name, for bp v200, we have TransformationRuleId
 	err = taskCtx.GetDal().First(jenkinsJob,
 		dal.Where(`connection_id = ? and full_name = ?`,
 			op.ConnectionId, op.JobFullName))
@@ -270,6 +256,20 @@ func EnrichOptions(taskCtx core.TaskContext,
 
 	if !strings.HasSuffix(op.JobPath, "/") {
 		op.JobPath = fmt.Sprintf("%s/", op.JobPath)
+	}
+
+	// bp v200
+	if op.TransformationRuleId != 0 {
+		var transformationRule models.JenkinsTransformationRule
+		err = taskCtx.GetDal().First(&transformationRule, dal.Where("id = ?", op.TransformationRuleId))
+		if err != nil {
+			return errors.BadInput.Wrap(err, "fail to get transformationRule")
+		}
+		op.JenkinsTransformationRule = &transformationRule
+	}
+
+	if op.JenkinsTransformationRule == nil && op.TransformationRuleId == 0 {
+		op.JenkinsTransformationRule = new(models.JenkinsTransformationRule)
 	}
 
 	return nil

--- a/plugins/jenkins/impl/impl.go
+++ b/plugins/jenkins/impl/impl.go
@@ -258,8 +258,8 @@ func EnrichOptions(taskCtx core.TaskContext,
 		op.JobPath = fmt.Sprintf("%s/", op.JobPath)
 	}
 
-	// bp v200
-	if op.TransformationRuleId != 0 {
+	// We only set op.JenkinsTransformationRule when it's nil and we have op.TransformationRuleId != 0
+	if op.JenkinsTransformationRule == nil && op.TransformationRuleId != 0 {
 		var transformationRule models.JenkinsTransformationRule
 		err = taskCtx.GetDal().First(&transformationRule, dal.Where("id = ?", op.TransformationRuleId))
 		if err != nil {


### PR DESCRIPTION
### Summary
1. jenkins v200 add transformation rule id for prepareTaskData usage.
2. fix getjobs api error

### Does this close any open issues?
Closes #4057 

### Screenshots

![image](https://user-images.githubusercontent.com/101256042/209895092-7cc59eaa-a834-4f29-8712-de532eec9610.png)

### Other Information
Any other information that is important to this PR.
