### PR TITLE
fix(config-ui): the jira connection scope not exist

### DIFF
--- a/config-ui/src/pages/blueprints/blueprint-settings.jsx
+++ b/config-ui/src/pages/blueprints/blueprint-settings.jsx
@@ -679,7 +679,7 @@ const BlueprintSettings = (props) => {
                       c.scope?.map((s) => s.options?.boardId),
                       [
                         ...allJiraResources?.boards,
-                        ...c.scope.map((s) => s.options)
+                        ...(c.scope?.map((s) => s.options) ?? [])
                       ]
                     )
                   : []
@@ -707,7 +707,7 @@ const BlueprintSettings = (props) => {
                       c.scope?.map((s) => s.options?.boardId),
                       [
                         ...allJiraResources?.boards,
-                        ...c.scope.map((s) => s.options)
+                        ...(c.scope?.map((s) => s.options) ?? [])
                       ]
                     )
                   : []
@@ -918,7 +918,7 @@ const BlueprintSettings = (props) => {
                 ...c,
                 boardsList: getJiraMappedBoards(c.boardIds, [
                   ...(boards ?? []),
-                  ...c.scope.map((s) => s.options)
+                  ...(c.scope?.map((s) => s.options) ?? [])
                 ])
               })
           )
@@ -951,7 +951,7 @@ const BlueprintSettings = (props) => {
                 ...c,
                 boardsList: getJiraMappedBoards(c.boardIds, [
                   ...(boards ?? []),
-                  ...c.scope.map((s) => s.options)
+                  ...(c.scope?.map((s) => s.options) ?? [])
                 ])
               })
           )


### PR DESCRIPTION
### Summary
fixed the jira connection scope not exist.

When the user uses the advanced mode to create the bp of jira scope, there is no connectionId of jira, so there is no board information, so this error will be caused.

### Does this close any open issues?
Closes #4077

