### PR TITLE
docs(github): add comment for collector using since

### DIFF
--- a/plugins/github/tasks/comment_collector.go
+++ b/plugins/github/tasks/comment_collector.go
@@ -56,6 +56,9 @@ func CollectApiComments(taskCtx core.SubTaskContext) errors.Error {
 			query.Set("state", "all")
 			// if data.CreatedDateAfter != nil, we set since once
 			if data.CreatedDateAfter != nil {
+				// Note that `since` is for filtering records by the `updated` time
+				// which is not ideal for semantic reasons and would result in slightly more records than expected.
+				// But we have no choice since it is the only available field we could exploit from the API.
 				query.Set("since", data.CreatedDateAfter.String())
 			}
 			// if incremental == true, we overwrite it

--- a/plugins/github/tasks/pr_review_comment_collector.go
+++ b/plugins/github/tasks/pr_review_comment_collector.go
@@ -57,9 +57,6 @@ func CollectPrReviewComments(taskCtx core.SubTaskContext) errors.Error {
 		Query: func(reqData *helper.RequestData) (url.Values, errors.Error) {
 			query := url.Values{}
 			// if data.CreatedDateAfter != nil, we set since once
-			// Actually we should use create instead of since, but this api only has since as query param
-			// Using since will return data updated(and created) after the given time.
-			// So here we will get more data than what we want
 			if data.CreatedDateAfter != nil {
 				// Note that `since` is for filtering records by the `updated` time
 				// which is not ideal for semantic reasons and would result in slightly more records than expected.

--- a/plugins/github/tasks/pr_review_comment_collector.go
+++ b/plugins/github/tasks/pr_review_comment_collector.go
@@ -57,7 +57,13 @@ func CollectPrReviewComments(taskCtx core.SubTaskContext) errors.Error {
 		Query: func(reqData *helper.RequestData) (url.Values, errors.Error) {
 			query := url.Values{}
 			// if data.CreatedDateAfter != nil, we set since once
+			// Actually we should use create instead of since, but this api only has since as query param
+			// Using since will return data updated(and created) after the given time.
+			// So here we will get more data than what we want
 			if data.CreatedDateAfter != nil {
+				// Note that `since` is for filtering records by the `updated` time
+				// which is not ideal for semantic reasons and would result in slightly more records than expected.
+				// But we have no choice since it is the only available field we could exploit from the API.
 				query.Set("since", data.CreatedDateAfter.String())
 			}
 			// if incremental == true, we overwrite it
@@ -88,7 +94,7 @@ func CollectPrReviewComments(taskCtx core.SubTaskContext) errors.Error {
 }
 
 var CollectApiPrReviewCommentsMeta = core.SubTaskMeta{
-	Name:             "CollectApiPrReviewCommentsMeta",
+	Name:             "collectApiPrReviewCommentsMeta",
 	EntryPoint:       CollectPrReviewComments,
 	EnabledByDefault: true,
 	Description:      "Collect pr review comments data from Github api",


### PR DESCRIPTION
### Summary
In collectApiPrReviewCommentsMeta and collectApiComments, we are using `since` instead of `created` to collect data created after the given time. This might mislead developers, so we add some annotations.
Using `since` will return data updated the given time, so the data contains both that updated and created after the given time.

### Does this close any open issues?
Relate to #4044 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
