### PR TITLE
fix: typo of rerun-pipeline url

### DIFF
--- a/api/pipelines/pipelines.go
+++ b/api/pipelines/pipelines.go
@@ -170,13 +170,13 @@ func DownloadLogs(c *gin.Context) {
 
 // RerunPipeline rerun all failed tasks of the specified pipeline
 // @Summary rerun tasks
-// @Tags framework/pipeline
+// @Tags framework/pipelines
 // @Accept application/json
 // @Param pipelineId path int true "pipelineId"
 // @Success 200  {object} []models.Task
 // @Failure 400  {object} shared.ApiBody "Bad Request"
 // @Failure 500  {object} shared.ApiBody "Internal Error"
-// @Router /pipeline/{pipelineId}/rerun [post]
+// @Router /pipelines/{pipelineId}/rerun [post]
 func PostRerun(c *gin.Context) {
 	pipelineId := c.Param("pipelineId")
 	id, err := strconv.ParseUint(pipelineId, 10, 64)

--- a/api/task/task.go
+++ b/api/task/task.go
@@ -50,7 +50,7 @@ type getTaskResponse struct {
 
 // GetTaskByPipeline return most recent tasks
 // @Summary Get tasks, only the most recent tasks will be returned
-// @Tags framework/task
+// @Tags framework/tasks
 // @Accept application/json
 // @Param pipelineId path int true "pipelineId"
 // @Success 200  {object} getTaskResponse
@@ -73,7 +73,7 @@ func GetTaskByPipeline(c *gin.Context) {
 
 // RerunTask rerun the specified task.
 // @Summary rerun task
-// @Tags framework/task
+// @Tags framework/tasks
 // @Accept application/json
 // @Success 200  {object} models.Task
 // @Failure 400  {object} shared.ApiBody "Bad Request"


### PR DESCRIPTION
### Summary

`/pipeline/{pipelineId}/rerun` should be `/pipelines/{pipelineId}/rerun`

![image](https://user-images.githubusercontent.com/61080/210323233-a56d390f-d883-42b7-865d-eaa11d539f99.png)
