### PR TITLE
fix: jenkins transformation rules have not in effect by blueprint

### DIFF
--- a/plugins/jenkins/impl/impl.go
+++ b/plugins/jenkins/impl/impl.go
@@ -255,7 +255,7 @@ func EnrichOptions(taskCtx core.TaskContext,
 		op.JobPath = fmt.Sprintf("%s/", op.JobPath)
 	}
 	// We only set op.JenkinsTransformationRule when it's nil and we have op.TransformationRuleId != 0
-	if op.JenkinsTransformationRule == nil && op.TransformationRuleId != 0 {
+	if op.JenkinsTransformationRule.DeploymentPattern == "" && op.JenkinsTransformationRule.ProductionPattern == "" && op.TransformationRuleId != 0 {
 		var transformationRule models.JenkinsTransformationRule
 		err = taskCtx.GetDal().First(&transformationRule, dal.Where("id = ?", op.TransformationRuleId))
 		if err != nil {
@@ -264,7 +264,7 @@ func EnrichOptions(taskCtx core.TaskContext,
 		op.JenkinsTransformationRule = &transformationRule
 	}
 
-	if op.JenkinsTransformationRule == nil && op.TransformationRuleId == 0 {
+	if op.JenkinsTransformationRule.DeploymentPattern == "" && op.JenkinsTransformationRule.ProductionPattern == "" && op.TransformationRuleId == 0 {
 		op.JenkinsTransformationRule = new(models.JenkinsTransformationRule)
 	}
 


### PR DESCRIPTION
### Summary
fix: jenkins transformation rules have not in effect by blueprint.
the JenkinsTransformationRule never equel nil.

### Does this close any open issues?
Closes #4057 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
