### PR TITLE
gitextractor should delete old data

### DIFF
--- a/plugins/gitextractor/impl/impl.go
+++ b/plugins/gitextractor/impl/impl.go
@@ -64,7 +64,7 @@ func (plugin GitExtractor) PrepareTaskData(taskCtx core.TaskContext, options map
 	if err := op.Valid(); err != nil {
 		return nil, err
 	}
-	storage := store.NewDatabase(taskCtx, op.Url)
+	storage := store.NewDatabase(taskCtx, op.RepoId)
 	repo, err := NewGitRepo(taskCtx.GetLogger(), storage, op)
 	if err != nil {
 		return nil, err

--- a/plugins/gitextractor/main.go
+++ b/plugins/gitextractor/main.go
@@ -72,7 +72,7 @@ func main() {
 	}
 	// If we didn't specify output or dburl, we will use db by default
 	if storage == nil {
-		storage = store.NewDatabase(basicRes, *url)
+		storage = store.NewDatabase(basicRes, *id)
 	}
 	defer storage.Close()
 	ctx := context.Background()

--- a/services/pipeline.go
+++ b/services/pipeline.go
@@ -82,6 +82,14 @@ func pipelineServiceInit() {
 		if err != nil {
 			panic(err)
 		}
+		err = db.UpdateColumn(
+			&models.Task{},
+			"status", models.TASK_FAILED,
+			dal.Where("status = ?", models.TASK_RUNNING),
+		)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	err := ReloadBlueprints(cronManager)


### PR DESCRIPTION
### Summary

The phenomenon described in #4024 was caused by the fact that `gitextractor` failed to delete previously collected data, it was due to the fact `_raw_data_*` fields were never populated so they would never be deleted.

This PR fixes the problem


### Does this close any open issues?
Closes #4024 
