### PR TITLE
fix: fix jira issue jql; fix afterFunction's effort in other collectors

### DIFF
--- a/plugins/azure/tasks/api_client.go
+++ b/plugins/azure/tasks/api_client.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/plugins/azure/models"
-	"net/http"
-
 	"github.com/apache/incubator-devlake/plugins/core"
 	"github.com/apache/incubator-devlake/plugins/helper"
 )
@@ -37,13 +35,6 @@ func CreateApiClient(taskCtx core.TaskContext, connection *models.AzureConnectio
 	if err != nil {
 		return nil, err
 	}
-
-	apiClient.SetAfterFunction(func(res *http.Response) errors.Error {
-		if res.StatusCode == http.StatusUnauthorized {
-			return errors.Unauthorized.New("authentication failed, please check your Username/Password")
-		}
-		return nil
-	})
 
 	// TODO add some check after request if necessary
 	// create rate limit calculator

--- a/plugins/bitbucket/tasks/api_client.go
+++ b/plugins/bitbucket/tasks/api_client.go
@@ -39,12 +39,6 @@ func CreateApiClient(taskCtx core.TaskContext, connection *models.BitbucketConne
 		req.Header.Set("Authorization", fmt.Sprintf("Basic %v", token))
 		return nil
 	})
-	apiClient.SetAfterFunction(func(res *http.Response) errors.Error {
-		if res.StatusCode == http.StatusUnauthorized {
-			return errors.Unauthorized.New("authentication failed, please check your Basic Auth configuration")
-		}
-		return nil
-	})
 
 	// create rate limit calculator
 	rateLimiter := &helper.ApiRateLimitCalculator{

--- a/plugins/helper/api_client.go
+++ b/plugins/helper/api_client.go
@@ -185,6 +185,7 @@ func (apiClient *ApiClient) GetAfterFunction() common.ApiClientAfterResponse {
 }
 
 // SetAfterFunction will set afterResponseFunction
+// don't call this function directly in collector, use Collector.AfterResponse instead.
 func (apiClient *ApiClient) SetAfterFunction(callback common.ApiClientAfterResponse) {
 	apiClient.afterResponse = callback
 }

--- a/plugins/helper/api_collector.go
+++ b/plugins/helper/api_collector.go
@@ -119,9 +119,9 @@ func NewApiCollector(args ApiCollectorArgs) (*ApiCollector, errors.Error) {
 	}
 	if args.AfterResponse != nil {
 		apiCollector.SetAfterResponse(args.AfterResponse)
-	} else if apiCollector.GetAfterResponse() == nil {
+	} else {
 		apiCollector.SetAfterResponse(func(res *http.Response) errors.Error {
-			if res.StatusCode == http.StatusUnauthorized {
+			if res.StatusCode == http.StatusUnauthorized || res.StatusCode == http.StatusUnprocessableEntity {
 				return errors.Unauthorized.New("authentication failed, please check your AccessToken")
 			}
 			return nil

--- a/plugins/jira/tasks/issue_collector.go
+++ b/plugins/jira/tasks/issue_collector.go
@@ -70,10 +70,10 @@ func CollectIssues(taskCtx core.SubTaskContext) errors.Error {
 	// IMPORTANT: we have to keep paginated data in a consistence order to avoid data-missing, if we sort issues by
 	//  `updated`, issue will be jumping between pages if it got updated during the collection process
 	createdDateAfter := data.CreatedDateAfter
-	jql := "ORDER BY created ASC"
+	jql := "created is not null ORDER BY created ASC"
 	if createdDateAfter != nil {
 		// prepend a time range criteria if `since` was specified, either by user or from database
-		jql = fmt.Sprintf("created >= '%v' %v", createdDateAfter.Format("2006/01/02 15:04"), jql)
+		jql = fmt.Sprintf("created >= '%v' AND %v", createdDateAfter.Format("2006/01/02 15:04"), jql)
 	}
 
 	incremental := collectorWithState.IsIncremental()
@@ -92,7 +92,7 @@ func CollectIssues(taskCtx core.SubTaskContext) errors.Error {
 			return errors.NotFound.Wrap(err, "failed to get latest jira issue record")
 		}
 		if latestUpdated.IssueId > 0 {
-			jql = fmt.Sprintf("updated >= '%v' %v", latestUpdated.Updated.Format("2006/01/02 15:04"), jql)
+			jql = fmt.Sprintf("updated >= '%v' AND %v", latestUpdated.Updated.Format("2006/01/02 15:04"), jql)
 		} else {
 			incremental = false
 		}

--- a/plugins/tapd/tasks/api_client.go
+++ b/plugins/tapd/tasks/api_client.go
@@ -21,8 +21,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"github.com/apache/incubator-devlake/errors"
-	"net/http"
-
 	"github.com/apache/incubator-devlake/plugins/core"
 	"github.com/apache/incubator-devlake/plugins/helper"
 	"github.com/apache/incubator-devlake/plugins/tapd/models"
@@ -39,12 +37,6 @@ func NewTapdApiClient(taskCtx core.TaskContext, connection *models.TapdConnectio
 	if err != nil {
 		return nil, err
 	}
-	apiClient.SetAfterFunction(func(res *http.Response) errors.Error {
-		if res.StatusCode == http.StatusUnprocessableEntity {
-			return errors.HttpStatus(res.StatusCode).New("authentication failed, please check your AccessToken")
-		}
-		return nil
-	})
 
 	// create rate limit calculator
 	rateLimiter := &helper.ApiRateLimitCalculator{


### PR DESCRIPTION
### Summary
1. fix jira issue jql;
2. fix afterFunction's effort in other collectors. The old logic afterFunction will affect other collector because it change ApiClient.
3. use recorded last updated.

![image](https://user-images.githubusercontent.com/3294100/210378553-feeabefc-6742-4b97-92f7-e3cbd94da477.png)
