### PR TITLE
fix(gitlab): update job convertor

### DIFF
--- a/plugins/gitlab/e2e/job_test.go
+++ b/plugins/gitlab/e2e/job_test.go
@@ -36,9 +36,12 @@ func TestGitlabJobDataFlow(t *testing.T) {
 
 	taskData := &tasks.GitlabTaskData{
 		Options: &tasks.GitlabOptions{
-			ConnectionId:             1,
-			ProjectId:                44,
-			GitlabTransformationRule: new(models.GitlabTransformationRule),
+			ConnectionId: 1,
+			ProjectId:    44,
+			GitlabTransformationRule: &models.GitlabTransformationRule{
+				DeploymentPattern: "(?i)compile",
+				ProductionPattern: "(?i)compile",
+			},
 		},
 	}
 	// import raw data table

--- a/plugins/gitlab/e2e/snapshot_tables/cicd_tasks.csv
+++ b/plugins/gitlab/e2e/snapshot_tables/cicd_tasks.csv
@@ -1,14 +1,14 @@
 id,name,pipeline_id,result,status,type,environment,duration_sec,started_date,finished_date,cicd_scope_id
-gitlab:GitlabJob:1:100,compile,gitlab:GitlabPipeline:1:24,SUCCESS,DONE,,,2,2022-07-25T15:06:57.051+00:00,2022-07-25T15:06:59.885+00:00,gitlab:GitlabProject:1:44
+gitlab:GitlabJob:1:100,compile,gitlab:GitlabPipeline:1:24,SUCCESS,DONE,DEPLOYMENT,PRODUCTION,2,2022-07-25T15:06:57.051+00:00,2022-07-25T15:06:59.885+00:00,gitlab:GitlabProject:1:44
 gitlab:GitlabJob:1:101,format,gitlab:GitlabPipeline:1:25,SUCCESS,DONE,,,3,2022-07-25T15:13:37.206+00:00,2022-07-25T15:13:40.246+00:00,gitlab:GitlabProject:1:44
 gitlab:GitlabJob:1:102,format,gitlab:GitlabPipeline:1:26,SUCCESS,DONE,,,2,2022-07-25T15:30:22.560+00:00,2022-07-25T15:30:25.315+00:00,gitlab:GitlabProject:1:44
 gitlab:GitlabJob:1:103,format,gitlab:GitlabPipeline:1:27,SUCCESS,DONE,,,2,2022-07-25T15:30:55.671+00:00,2022-07-25T15:30:58.650+00:00,gitlab:GitlabProject:1:44
 gitlab:GitlabJob:1:104,format,gitlab:GitlabPipeline:1:28,SUCCESS,DONE,,,2,2022-07-25T15:32:04.954+00:00,2022-07-25T15:32:07.726+00:00,gitlab:GitlabProject:1:44
-gitlab:GitlabJob:1:105,compile,gitlab:GitlabPipeline:1:28,FAILURE,DONE,,,3,2022-07-25T15:32:07.953+00:00,2022-07-25T15:32:11.077+00:00,gitlab:GitlabProject:1:44
+gitlab:GitlabJob:1:105,compile,gitlab:GitlabPipeline:1:28,FAILURE,DONE,DEPLOYMENT,PRODUCTION,3,2022-07-25T15:32:07.953+00:00,2022-07-25T15:32:11.077+00:00,gitlab:GitlabProject:1:44
 gitlab:GitlabJob:1:106,format,gitlab:GitlabPipeline:1:29,SUCCESS,DONE,,,2,2022-07-25T15:33:26.382+00:00,2022-07-25T15:33:29.356+00:00,gitlab:GitlabProject:1:44
 gitlab:GitlabJob:1:107,format,gitlab:GitlabPipeline:1:30,SUCCESS,DONE,,,2,2022-07-25T15:34:23.665+00:00,2022-07-25T15:34:26.392+00:00,gitlab:GitlabProject:1:44
 gitlab:GitlabJob:1:108,format,gitlab:GitlabPipeline:1:31,SUCCESS,DONE,,,2,2022-07-25T15:35:11.707+00:00,2022-07-25T15:35:14.224+00:00,gitlab:GitlabProject:1:44
-gitlab:GitlabJob:1:109,compile,gitlab:GitlabPipeline:1:31,SUCCESS,DONE,,,3,2022-07-25T15:35:14.724+00:00,2022-07-25T15:35:17.828+00:00,gitlab:GitlabProject:1:44
+gitlab:GitlabJob:1:109,compile,gitlab:GitlabPipeline:1:31,SUCCESS,DONE,DEPLOYMENT,PRODUCTION,3,2022-07-25T15:35:14.724+00:00,2022-07-25T15:35:17.828+00:00,gitlab:GitlabProject:1:44
 gitlab:GitlabJob:1:110,format,gitlab:GitlabPipeline:1:32,SUCCESS,DONE,,,2,2022-07-25T15:36:18.097+00:00,2022-07-25T15:36:20.954+00:00,gitlab:GitlabProject:1:44
 gitlab:GitlabJob:1:111,format,gitlab:GitlabPipeline:1:33,SUCCESS,DONE,,,3,2022-07-25T15:38:03.463+00:00,2022-07-25T15:38:06.467+00:00,gitlab:GitlabProject:1:44
 gitlab:GitlabJob:1:112,format,gitlab:GitlabPipeline:1:34,SUCCESS,DONE,,,3,2022-07-25T21:19:14.509+00:00,2022-07-25T21:19:17.811+00:00,gitlab:GitlabProject:1:44


### PR DESCRIPTION
### Summary
modify gitlab to adapt the new way to convert TYPE/ENVIRONMENT for cicd_tasks

### Does this close any open issues?
Relate to pr #3850 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
