### PR TITLE
feat(grafana): change default theme

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,7 @@ services:
       - grafana-storage:/var/lib/grafana
     environment:
       GF_SERVER_ROOT_URL: "http://localhost:4000/grafana"
+      GF_USERS_DEFAULT_THEME: "light"
       MYSQL_URL: mysql:3306
       MYSQL_DATABASE: lake
       MYSQL_USER: merico

--- a/releases/lake-v0.14.0/docker-compose.yml
+++ b/releases/lake-v0.14.0/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       - grafana-storage:/var/lib/grafana
     environment:
       GF_SERVER_ROOT_URL: "http://localhost:4000/grafana"
+      GF_USERS_DEFAULT_THEME: "light"
       MYSQL_URL: mysql:3306
       MYSQL_DATABASE: lake
       MYSQL_USER: merico


### PR DESCRIPTION
### Summary
Set grafana default theme to `light` when deploying grafana by docker-compose

