### PR TITLE
fix: dbt zombie process, set dbt default threads=1

### DIFF
--- a/plugins/dbt/dbt.go
+++ b/plugins/dbt/dbt.go
@@ -38,7 +38,6 @@ func main() {
 	failFast := dbtCmd.Flags().BoolP("failFast", "", false, "dbt fail fast")
 	profilesPath := dbtCmd.Flags().StringP("profilesPath", "", "/Users/abeizn/.dbt", "dbt profiles path")
 	profile := dbtCmd.Flags().StringP("profile", "", "default", "dbt profile")
-	threads := dbtCmd.Flags().IntP("threads", "", 1, "dbt threads")
 	noVersionCheck := dbtCmd.Flags().BoolP("noVersionCheck", "", false, "dbt no version check")
 	excludeModels := dbtCmd.Flags().StringSliceP("excludeModels", "", []string{}, "dbt exclude models")
 	selector := dbtCmd.Flags().StringP("selector", "", "", "dbt selector")
@@ -68,7 +67,6 @@ func main() {
 			"failFast":       *failFast,
 			"profilesPath":   *profilesPath,
 			"profile":        *profile,
-			"threads":        *threads,
 			"noVersionCheck": *noVersionCheck,
 			"excludeModels":  *excludeModels,
 			"selector":       *selector,


### PR DESCRIPTION
### Summary
The dbt threads default value changed to 4, but it can not release when the project run ended,
so we need set dbt default threads=1.

https://docs.getdbt.com/docs/dbt-versions/release-notes/dec-2022/default-thread-value

### Does this close any open issues?
related to #3921

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
