### PR TITLE
fix: Bitbucket git-extractor repo cloning fix

### DIFF
--- a/plugins/bitbucket/api/blueprint.go
+++ b/plugins/bitbucket/api/blueprint.go
@@ -142,7 +142,7 @@ func makePipelinePlan(subtaskMetas []core.SubTaskMeta, scope []*core.BlueprintSc
 			if err != nil {
 				return nil, err
 			}
-			cloneUrl.User = url.UserPassword(op.Owner, connection.Password)
+			cloneUrl.User = url.UserPassword(connection.Username, connection.Password)
 			stage = append(stage, &core.PipelineTask{
 				Plugin: "gitextractor",
 				Options: map[string]interface{}{

--- a/plugins/bitbucket/api/blueprint_test.go
+++ b/plugins/bitbucket/api/blueprint_test.go
@@ -123,7 +123,7 @@ func TestMakePipelinePlan(t *testing.T) {
 				Plugin: "gitextractor",
 				Options: map[string]interface{}{
 					"repoId": "bitbucket:BitbucketRepo:1:thenicetgp/lake",
-					"url":    "https://thenicetgp:Password@bitbucket.org/thenicetgp/lake.git",
+					"url":    "https://Username:Password@bitbucket.org/thenicetgp/lake.git",
 				},
 			},
 		},


### PR DESCRIPTION
Fixes an issue reported by a Slack user regarding using the git-extractor plugin on Bitbucket. The credential logic for the extractor was incorrect, leading to failed repo clones. This PR fixes that. It'll be ported back to v0.14.8 as well.

Closes #4138 