### PR TITLE
fix: fix jenkins upgrade

### DIFF
--- a/config-ui/src/error/components/bp-upgrade/use-bp-upgrade.ts
+++ b/config-ui/src/error/components/bp-upgrade/use-bp-upgrade.ts
@@ -118,6 +118,13 @@ export const useBPUpgrade = ({ id, onResetError }: UseBPUpgradeProps) => {
   const upgradeConnection = async (connection: any) => {
     const { plugin, connectionId } = connection;
 
+    if (plugin == 'jenkins') {
+      return {
+        plugin,
+        connectionId,
+        scopes: [],
+      };
+    }
     const scope = await Promise.all((connection.scope ?? []).map((sc: any) => upgradeScope(plugin, connectionId, sc)));
 
     return {

--- a/config-ui/src/pages/blueprint/detail/panel/configuration.tsx
+++ b/config-ui/src/pages/blueprint/detail/panel/configuration.tsx
@@ -64,7 +64,7 @@ export const Configuration = ({ blueprint, operating, onUpdate, onRefresh }: Pro
             name: plugin.name,
             connectionId: cs.connectionId,
             entities: plugin.entities,
-            selectedEntites: cs.scopes?.[0].entities ?? [],
+            selectedEntites: cs.scopes.length > 0 ? cs.scopes[0].entities : [],
             plugin: cs.plugin,
             scope: cs.scopes,
             scopeIds: cs.scopes.map((sc: any) => sc.id),

--- a/config-ui/src/pages/blueprint/detail/panel/configuration.tsx
+++ b/config-ui/src/pages/blueprint/detail/panel/configuration.tsx
@@ -64,7 +64,7 @@ export const Configuration = ({ blueprint, operating, onUpdate, onRefresh }: Pro
             name: plugin.name,
             connectionId: cs.connectionId,
             entities: plugin.entities,
-            selectedEntites: cs.scopes.length > 0 ? cs.scopes[0].entities : [],
+            selectedEntites: cs.scopes?.[0]?.entities ?? [],
             plugin: cs.plugin,
             scope: cs.scopes,
             scopeIds: cs.scopes.map((sc: any) => sc.id),


### PR DESCRIPTION
### Summary
fix jenkins upgrade.

V100 bp with transformation may like this:
```
{
  "name": "TEST_PROJECT_2-BLUEPRINT",
  "mode": "NORMAL",
  "enable": true,
  "cronConfig": "0 0 * * *",
  "isManual": false,
  "skipOnFail": false,
  "labels": [],
  "settings": {"connections":[{"connectionId":1,"plugin":"jenkins","scope":[{"entities":["CICD"],"options":{},"transformation":{"deploymentPattern":"","productionPattern":""}}]}],"version":"1.0.0"},
  "createdAt": "2022-12-12T08:36:38.079Z",
  "updatedAt": "2022-12-13T08:31:51.696Z"
}
```

So add some fix for upgrade