### PR TITLE
fix: add unique index for the name of transformation rule

### DIFF
--- a/impl/dalgorm/dalgorm.go
+++ b/impl/dalgorm/dalgorm.go
@@ -362,7 +362,7 @@ func (d *Dalgorm) IsErrorNotFound(err errors.Error) bool {
 
 // IsDuplicationError checking if the sql error is not found.
 func (d *Dalgorm) IsDuplicationError(err errors.Error) bool {
-	return strings.Contains(err.Error(), "duplicate")
+	return strings.Contains(strings.ToLower(err.Error()), "duplicate")
 }
 
 // NewDalgorm creates a *Dalgorm

--- a/plugins/github/api/transformation_rule.go
+++ b/plugins/github/api/transformation_rule.go
@@ -26,7 +26,6 @@ import (
 	"github.com/apache/incubator-devlake/plugins/core/dal"
 	"github.com/apache/incubator-devlake/plugins/github/models"
 	"github.com/apache/incubator-devlake/plugins/helper"
-	"github.com/mitchellh/mapstructure"
 )
 
 // CreateTransformationRule create transformation rule for Github
@@ -41,13 +40,13 @@ import (
 // @Router /plugins/github/transformation_rules [POST]
 func CreateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOutput, errors.Error) {
 	var rule models.GithubTransformationRule
-	err := mapstructure.Decode(input.Body, &rule)
+	err := helper.Decode(input.Body, &rule, vld)
 	if err != nil {
-		return nil, errors.Default.Wrap(err, "error in decoding transformation rule")
+		return nil, errors.BadInput.Wrap(err, "error in decoding transformation rule")
 	}
 	err = basicRes.GetDal().Create(&rule)
 	if err != nil {
-		return nil, errors.Default.Wrap(err, "error on saving TransformationRule")
+		return nil, errors.BadInput.Wrap(err, "error on saving TransformationRule")
 	}
 	return &core.ApiResourceOutput{Body: rule, Status: http.StatusOK}, nil
 }
@@ -80,7 +79,7 @@ func UpdateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOu
 	old.ID = transformationRuleId
 	err = basicRes.GetDal().Update(&old, dal.Where("id = ?", transformationRuleId))
 	if err != nil {
-		return nil, errors.Default.Wrap(err, "error on saving TransformationRule")
+		return nil, errors.BadInput.Wrap(err, "error on saving TransformationRule")
 	}
 	return &core.ApiResourceOutput{Body: old, Status: http.StatusOK}, nil
 }

--- a/plugins/github/api/transformation_rule.go
+++ b/plugins/github/api/transformation_rule.go
@@ -46,6 +46,9 @@ func CreateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOu
 	}
 	err = basicRes.GetDal().Create(&rule)
 	if err != nil {
+		if basicRes.GetDal().IsDuplicationError(err) {
+			return nil, errors.BadInput.New("there was a transformation rule with the same name, please choose another name")
+		}
 		return nil, errors.BadInput.Wrap(err, "error on saving TransformationRule")
 	}
 	return &core.ApiResourceOutput{Body: rule, Status: http.StatusOK}, nil
@@ -63,12 +66,12 @@ func CreateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOu
 // @Failure 500  {object} shared.ApiBody "Internal Error"
 // @Router /plugins/github/transformation_rules/{id} [PATCH]
 func UpdateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOutput, errors.Error) {
-	transformationRuleId, err := strconv.ParseUint(input.Params["id"], 10, 64)
-	if err != nil {
-		return nil, errors.Default.Wrap(err, "the transformation rule ID should be an integer")
+	transformationRuleId, e := strconv.ParseUint(input.Params["id"], 10, 64)
+	if e != nil {
+		return nil, errors.Default.Wrap(e, "the transformation rule ID should be an integer")
 	}
 	var old models.GithubTransformationRule
-	err = basicRes.GetDal().First(&old, dal.Where("id = ?", transformationRuleId))
+	err := basicRes.GetDal().First(&old, dal.Where("id = ?", transformationRuleId))
 	if err != nil {
 		return nil, errors.Default.Wrap(err, "error on saving TransformationRule")
 	}
@@ -79,6 +82,9 @@ func UpdateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOu
 	old.ID = transformationRuleId
 	err = basicRes.GetDal().Update(&old, dal.Where("id = ?", transformationRuleId))
 	if err != nil {
+		if basicRes.GetDal().IsDuplicationError(err) {
+			return nil, errors.BadInput.New("there was a transformation rule with the same name, please choose another name")
+		}
 		return nil, errors.BadInput.Wrap(err, "error on saving TransformationRule")
 	}
 	return &core.ApiResourceOutput{Body: old, Status: http.StatusOK}, nil

--- a/plugins/github/models/migrationscripts/20221214_add_trasformation_rule_table.go
+++ b/plugins/github/models/migrationscripts/20221214_add_trasformation_rule_table.go
@@ -40,7 +40,7 @@ func (script *addTransformationRule20221124) Up(basicRes core.BasicRes) errors.E
 }
 
 func (*addTransformationRule20221124) Version() uint64 {
-	return 20221214095900
+	return 20221214095902
 }
 
 func (*addTransformationRule20221124) Name() string {

--- a/plugins/github/models/migrationscripts/archived/transformation_rules.go
+++ b/plugins/github/models/migrationscripts/archived/transformation_rules.go
@@ -25,7 +25,7 @@ import (
 
 type GithubTransformationRule struct {
 	archived.Model
-	Name                 string `mapstructure:"name" json:"name" gorm:"type:varchar(255)"`
+	Name                 string `mapstructure:"name" json:"name" gorm:"type:varchar(255);index:idx_name,unique" validate:"required"`
 	PrType               string `mapstructure:"prType" json:"prType" gorm:"type:varchar(255)"`
 	PrComponent          string `mapstructure:"prComponent" json:"prComponent" gorm:"type:varchar(255)"`
 	PrBodyClosePattern   string `mapstructure:"prBodyClosePattern" json:"prBodyClosePattern" gorm:"type:varchar(255)"`

--- a/plugins/github/models/transformation_rule.go
+++ b/plugins/github/models/transformation_rule.go
@@ -24,7 +24,7 @@ import (
 
 type GithubTransformationRule struct {
 	common.Model         `mapstructure:"-"`
-	Name                 string            `mapstructure:"name" json:"name" gorm:"type:varchar(255)"`
+	Name                 string            `mapstructure:"name" json:"name" gorm:"type:varchar(255);index:idx_name,unique" validate:"required"`
 	PrType               string            `mapstructure:"prType,omitempty" json:"prType" gorm:"type:varchar(255)"`
 	PrComponent          string            `mapstructure:"prComponent,omitempty" json:"prComponent" gorm:"type:varchar(255)"`
 	PrBodyClosePattern   string            `mapstructure:"prBodyClosePattern,omitempty" json:"prBodyClosePattern" gorm:"type:varchar(255)"`

--- a/plugins/gitlab/api/transformation_rule.go
+++ b/plugins/gitlab/api/transformation_rule.go
@@ -46,6 +46,9 @@ func CreateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOu
 	}
 	err = basicRes.GetDal().Create(&rule)
 	if err != nil {
+		if basicRes.GetDal().IsDuplicationError(err) {
+			return nil, errors.BadInput.New("there was a transformation rule with the same name, please choose another name")
+		}
 		return nil, errors.BadInput.Wrap(err, "error on saving TransformationRule")
 	}
 	return &core.ApiResourceOutput{Body: rule, Status: http.StatusOK}, nil
@@ -63,12 +66,12 @@ func CreateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOu
 // @Failure 500  {object} shared.ApiBody "Internal Error"
 // @Router /plugins/gitlab/transformation_rules/{id} [PATCH]
 func UpdateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOutput, errors.Error) {
-	transformationRuleId, err := strconv.ParseUint(input.Params["id"], 10, 64)
-	if err != nil {
-		return nil, errors.Default.Wrap(err, "the transformation rule ID should be an integer")
+	transformationRuleId, e := strconv.ParseUint(input.Params["id"], 10, 64)
+	if e != nil {
+		return nil, errors.Default.Wrap(e, "the transformation rule ID should be an integer")
 	}
 	var old models.GitlabTransformationRule
-	err = basicRes.GetDal().First(&old, dal.Where("id = ?", transformationRuleId))
+	err := basicRes.GetDal().First(&old, dal.Where("id = ?", transformationRuleId))
 	if err != nil {
 		return nil, errors.Default.Wrap(err, "error on saving TransformationRule")
 	}
@@ -79,6 +82,9 @@ func UpdateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOu
 	old.ID = transformationRuleId
 	err = basicRes.GetDal().Update(&old, dal.Where("id = ?", transformationRuleId))
 	if err != nil {
+		if basicRes.GetDal().IsDuplicationError(err) {
+			return nil, errors.BadInput.New("there was a transformation rule with the same name, please choose another name")
+		}
 		return nil, errors.BadInput.Wrap(err, "error on saving TransformationRule")
 	}
 	return &core.ApiResourceOutput{Body: old, Status: http.StatusOK}, nil

--- a/plugins/gitlab/api/transformation_rule.go
+++ b/plugins/gitlab/api/transformation_rule.go
@@ -26,7 +26,6 @@ import (
 	"github.com/apache/incubator-devlake/plugins/core/dal"
 	"github.com/apache/incubator-devlake/plugins/gitlab/models"
 	"github.com/apache/incubator-devlake/plugins/helper"
-	"github.com/mitchellh/mapstructure"
 )
 
 // CreateTransformationRule create transformation rule for Gitlab
@@ -41,13 +40,13 @@ import (
 // @Router /plugins/gitlab/transformation_rules [POST]
 func CreateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOutput, errors.Error) {
 	var rule models.GitlabTransformationRule
-	err := mapstructure.Decode(input.Body, &rule)
+	err := helper.Decode(input.Body, &rule, vld)
 	if err != nil {
-		return nil, errors.Default.Wrap(err, "error in decoding transformation rule")
+		return nil, errors.BadInput.Wrap(err, "error in decoding transformation rule")
 	}
 	err = basicRes.GetDal().Create(&rule)
 	if err != nil {
-		return nil, errors.Default.Wrap(err, "error on saving TransformationRule")
+		return nil, errors.BadInput.Wrap(err, "error on saving TransformationRule")
 	}
 	return &core.ApiResourceOutput{Body: rule, Status: http.StatusOK}, nil
 }
@@ -80,7 +79,7 @@ func UpdateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOu
 	old.ID = transformationRuleId
 	err = basicRes.GetDal().Update(&old, dal.Where("id = ?", transformationRuleId))
 	if err != nil {
-		return nil, errors.Default.Wrap(err, "error on saving TransformationRule")
+		return nil, errors.BadInput.Wrap(err, "error on saving TransformationRule")
 	}
 	return &core.ApiResourceOutput{Body: old, Status: http.StatusOK}, nil
 }

--- a/plugins/gitlab/models/migrationscripts/20221125_add_html_url_to_project.go
+++ b/plugins/gitlab/models/migrationscripts/20221125_add_html_url_to_project.go
@@ -40,7 +40,7 @@ func (*addTransformationRule20221125) Up(basicRes core.BasicRes) errors.Error {
 }
 
 func (*addTransformationRule20221125) Version() uint64 {
-	return 20221125102500
+	return 20221125102502
 }
 
 func (*addTransformationRule20221125) Name() string {

--- a/plugins/gitlab/models/migrationscripts/archived/transformation_rules.go
+++ b/plugins/gitlab/models/migrationscripts/archived/transformation_rules.go
@@ -24,7 +24,7 @@ import (
 
 type GitlabTransformationRule struct {
 	archived.Model
-	Name                 string `gorm:"type:varchar(255)"`
+	Name                 string `gorm:"type:varchar(255);index:idx_name,unique" validate:"required"`
 	PrType               string `mapstructure:"prType" json:"prType" gorm:"type:varchar(255)"`
 	PrComponent          string `mapstructure:"prComponent" json:"prComponent" gorm:"type:varchar(255)"`
 	PrBodyClosePattern   string `mapstructure:"prBodyClosePattern" json:"prBodyClosePattern" gorm:"type:varchar(255)"`

--- a/plugins/gitlab/models/transformation_rule.go
+++ b/plugins/gitlab/models/transformation_rule.go
@@ -24,7 +24,7 @@ import (
 
 type GitlabTransformationRule struct {
 	common.Model
-	Name                 string            `gorm:"type:varchar(255)" mapstructure:"name" json:"name"`
+	Name                 string            `gorm:"type:varchar(255);index:idx_name,unique" validate:"required" mapstructure:"name" json:"name"`
 	PrType               string            `mapstructure:"prType" json:"prType"`
 	PrComponent          string            `mapstructure:"prComponent" json:"prComponent"`
 	PrBodyClosePattern   string            `mapstructure:"prBodyClosePattern" json:"prBodyClosePattern"`

--- a/plugins/jenkins/api/transformation_rule.go
+++ b/plugins/jenkins/api/transformation_rule.go
@@ -46,6 +46,9 @@ func CreateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOu
 	}
 	err = basicRes.GetDal().Create(&rule)
 	if err != nil {
+		if basicRes.GetDal().IsDuplicationError(err) {
+			return nil, errors.BadInput.New("there was a transformation rule with the same name, please choose another name")
+		}
 		return nil, errors.BadInput.Wrap(err, "error on saving TransformationRule")
 	}
 	return &core.ApiResourceOutput{Body: rule, Status: http.StatusOK}, nil
@@ -63,12 +66,12 @@ func CreateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOu
 // @Failure 500  {object} shared.ApiBody "Internal Error"
 // @Router /plugins/jenkins/transformation_rules/{id} [PATCH]
 func UpdateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOutput, errors.Error) {
-	transformationRuleId, err := strconv.ParseUint(input.Params["id"], 10, 64)
-	if err != nil {
-		return nil, errors.Default.Wrap(err, "the transformation rule ID should be an integer")
+	transformationRuleId, e := strconv.ParseUint(input.Params["id"], 10, 64)
+	if e != nil {
+		return nil, errors.Default.Wrap(e, "the transformation rule ID should be an integer")
 	}
 	var old models.JenkinsTransformationRule
-	err = basicRes.GetDal().First(&old, dal.Where("id = ?", transformationRuleId))
+	err := basicRes.GetDal().First(&old, dal.Where("id = ?", transformationRuleId))
 	if err != nil {
 		return nil, errors.Default.Wrap(err, "error on saving TransformationRule")
 	}
@@ -79,6 +82,9 @@ func UpdateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOu
 	old.ID = transformationRuleId
 	err = basicRes.GetDal().Update(&old, dal.Where("id = ?", transformationRuleId))
 	if err != nil {
+		if basicRes.GetDal().IsDuplicationError(err) {
+			return nil, errors.BadInput.New("there was a transformation rule with the same name, please choose another name")
+		}
 		return nil, errors.BadInput.Wrap(err, "error on saving TransformationRule")
 	}
 	return &core.ApiResourceOutput{Body: old, Status: http.StatusOK}, nil

--- a/plugins/jenkins/api/transformation_rule.go
+++ b/plugins/jenkins/api/transformation_rule.go
@@ -26,7 +26,6 @@ import (
 	"github.com/apache/incubator-devlake/plugins/core/dal"
 	"github.com/apache/incubator-devlake/plugins/helper"
 	"github.com/apache/incubator-devlake/plugins/jenkins/models"
-	"github.com/mitchellh/mapstructure"
 )
 
 // CreateTransformationRule create transformation rule for Jenkins
@@ -41,13 +40,13 @@ import (
 // @Router /plugins/jenkins/transformation_rules [POST]
 func CreateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOutput, errors.Error) {
 	var rule models.JenkinsTransformationRule
-	err := mapstructure.Decode(input.Body, &rule)
+	err := helper.Decode(input.Body, &rule, vld)
 	if err != nil {
-		return nil, errors.Default.Wrap(err, "error in decoding transformation rule")
+		return nil, errors.BadInput.Wrap(err, "error in decoding transformation rule")
 	}
 	err = basicRes.GetDal().Create(&rule)
 	if err != nil {
-		return nil, errors.Default.Wrap(err, "error on saving TransformationRule")
+		return nil, errors.BadInput.Wrap(err, "error on saving TransformationRule")
 	}
 	return &core.ApiResourceOutput{Body: rule, Status: http.StatusOK}, nil
 }
@@ -80,7 +79,7 @@ func UpdateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOu
 	old.ID = transformationRuleId
 	err = basicRes.GetDal().Update(&old, dal.Where("id = ?", transformationRuleId))
 	if err != nil {
-		return nil, errors.Default.Wrap(err, "error on saving TransformationRule")
+		return nil, errors.BadInput.Wrap(err, "error on saving TransformationRule")
 	}
 	return &core.ApiResourceOutput{Body: old, Status: http.StatusOK}, nil
 }

--- a/plugins/jenkins/models/migrationscripts/20221205_add_trasformation_rule_table.go
+++ b/plugins/jenkins/models/migrationscripts/20221205_add_trasformation_rule_table.go
@@ -39,7 +39,7 @@ func (*addTransformationRule20221128) Up(basicRes core.BasicRes) errors.Error {
 }
 
 func (*addTransformationRule20221128) Version() uint64 {
-	return 20221205113500
+	return 20221205113502
 }
 
 func (*addTransformationRule20221128) Name() string {

--- a/plugins/jenkins/models/migrationscripts/archived/transformation_rules.go
+++ b/plugins/jenkins/models/migrationscripts/archived/transformation_rules.go
@@ -23,7 +23,7 @@ import (
 
 type JenkinsTransformationRule struct {
 	archived.Model
-	Name              string `gorm:"type:varchar(255)"`
+	Name              string `gorm:"type:varchar(255);index:idx_name,unique" validate:"required"`
 	DeploymentPattern string `gorm:"type:varchar(255)" mapstructure:"deploymentPattern" json:"deploymentPattern"`
 	ProductionPattern string `gorm:"type:varchar(255)" mapstructure:"deploymentPattern,omitempty" json:"productionPattern"`
 }

--- a/plugins/jenkins/models/transformation_rule.go
+++ b/plugins/jenkins/models/transformation_rule.go
@@ -21,7 +21,7 @@ import "github.com/apache/incubator-devlake/models/common"
 
 type JenkinsTransformationRule struct {
 	common.Model      `mapstructure:"-"`
-	Name              string `gorm:"type:varchar(255)" mapstructure:"name" json:"name"`
+	Name              string `gorm:"type:varchar(255);index:idx_name,unique" validate:"required" mapstructure:"name" json:"name"`
 	DeploymentPattern string `gorm:"type:varchar(255)" mapstructure:"deploymentPattern,omitempty" json:"deploymentPattern"`
 	ProductionPattern string `gorm:"type:varchar(255)" mapstructure:"productionPattern,omitempty" json:"productionPattern"`
 }

--- a/plugins/jira/api/transformation_rule.go
+++ b/plugins/jira/api/transformation_rule.go
@@ -27,7 +27,6 @@ import (
 	"github.com/apache/incubator-devlake/plugins/helper"
 	"github.com/apache/incubator-devlake/plugins/jira/models"
 	"github.com/apache/incubator-devlake/plugins/jira/tasks"
-	"github.com/mitchellh/mapstructure"
 )
 
 // CreateTransformationRule create transformation rule for Jira
@@ -43,11 +42,11 @@ import (
 func CreateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOutput, errors.Error) {
 	rule, err := makeDbTransformationRuleFromInput(input)
 	if err != nil {
-		return nil, errors.Default.Wrap(err, "error in makeJiraTransformationRule")
+		return nil, errors.BadInput.Wrap(err, "error in makeJiraTransformationRule")
 	}
 	err = basicRes.GetDal().Create(&rule)
 	if err != nil {
-		return nil, errors.Default.Wrap(err, "error on saving TransformationRule")
+		return nil, errors.BadInput.Wrap(err, "error on saving TransformationRule")
 	}
 	return &core.ApiResourceOutput{Body: rule, Status: http.StatusOK}, nil
 }
@@ -80,16 +79,16 @@ func UpdateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOu
 	old.ID = transformationRuleId
 	err = basicRes.GetDal().Update(&old, dal.Where("id = ?", transformationRuleId))
 	if err != nil {
-		return nil, errors.Default.Wrap(err, "error on saving TransformationRule")
+		return nil, errors.BadInput.Wrap(err, "error on saving TransformationRule")
 	}
 	return &core.ApiResourceOutput{Body: old, Status: http.StatusOK}, nil
 }
 
 func makeDbTransformationRuleFromInput(input *core.ApiResourceInput) (*models.JiraTransformationRule, errors.Error) {
 	var req tasks.JiraTransformationRule
-	err := mapstructure.Decode(input.Body, &req)
+	err := helper.Decode(input.Body, &req, vld)
 	if err != nil {
-		return nil, errors.Default.Wrap(err, "error decoding map into transformationRule")
+		return nil, err
 	}
 	return req.ToDb()
 }

--- a/plugins/jira/api/transformation_rule.go
+++ b/plugins/jira/api/transformation_rule.go
@@ -46,6 +46,9 @@ func CreateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOu
 	}
 	err = basicRes.GetDal().Create(&rule)
 	if err != nil {
+		if basicRes.GetDal().IsDuplicationError(err) {
+			return nil, errors.BadInput.New("there was a transformation rule with the same name, please choose another name")
+		}
 		return nil, errors.BadInput.Wrap(err, "error on saving TransformationRule")
 	}
 	return &core.ApiResourceOutput{Body: rule, Status: http.StatusOK}, nil
@@ -63,12 +66,12 @@ func CreateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOu
 // @Failure 500  {object} shared.ApiBody "Internal Error"
 // @Router /plugins/jira/transformation_rules/{id} [PATCH]
 func UpdateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOutput, errors.Error) {
-	transformationRuleId, err := strconv.ParseUint(input.Params["id"], 10, 64)
-	if err != nil {
-		return nil, errors.Default.Wrap(err, "the transformation rule ID should be an integer")
+	transformationRuleId, e := strconv.ParseUint(input.Params["id"], 10, 64)
+	if e != nil {
+		return nil, errors.Default.Wrap(e, "the transformation rule ID should be an integer")
 	}
 	var old models.JiraTransformationRule
-	err = basicRes.GetDal().First(&old, dal.Where("id = ?", transformationRuleId))
+	err := basicRes.GetDal().First(&old, dal.Where("id = ?", transformationRuleId))
 	if err != nil {
 		return nil, errors.Default.Wrap(err, "error on saving TransformationRule")
 	}
@@ -79,6 +82,9 @@ func UpdateTransformationRule(input *core.ApiResourceInput) (*core.ApiResourceOu
 	old.ID = transformationRuleId
 	err = basicRes.GetDal().Update(&old, dal.Where("id = ?", transformationRuleId))
 	if err != nil {
+		if basicRes.GetDal().IsDuplicationError(err) {
+			return nil, errors.BadInput.New("there was a transformation rule with the same name, please choose another name")
+		}
 		return nil, errors.BadInput.Wrap(err, "error on saving TransformationRule")
 	}
 	return &core.ApiResourceOutput{Body: old, Status: http.StatusOK}, nil

--- a/plugins/jira/models/migrationscripts/20221116_add_trasformation_rule_table.go
+++ b/plugins/jira/models/migrationscripts/20221116_add_trasformation_rule_table.go
@@ -39,7 +39,7 @@ func (script *addTransformationRule20221116) Up(basicRes core.BasicRes) errors.E
 }
 
 func (*addTransformationRule20221116) Version() uint64 {
-	return 20221117122532
+	return 20221117122534
 }
 
 func (*addTransformationRule20221116) Name() string {

--- a/plugins/jira/models/migrationscripts/archived/transformation_rule.go
+++ b/plugins/jira/models/migrationscripts/archived/transformation_rule.go
@@ -25,7 +25,7 @@ import (
 
 type JiraTransformationRule struct {
 	archived.Model
-	Name                       string          `gorm:"type:varchar(255)"`
+	Name                       string          `gorm:"type:varchar(255);index:idx_name,unique" validate:"required"`
 	EpicKeyField               string          `json:"epicKeyField" gorm:"type:varchar(255)"`
 	StoryPointField            string          `json:"storyPointField" gorm:"type:varchar(255)"`
 	RemotelinkCommitShaPattern string          `json:"remotelinkCommitShaPattern" gorm:"type:varchar(255)"`

--- a/plugins/jira/models/transformation_rules.go
+++ b/plugins/jira/models/transformation_rules.go
@@ -25,7 +25,7 @@ import (
 
 type JiraTransformationRule struct {
 	common.Model               `mapstructure:"-"`
-	Name                       string          `mapstructure:"name" json:"name" gorm:"type:varchar(255)"`
+	Name                       string          `mapstructure:"name" json:"name" gorm:"type:varchar(255);index:idx_name,unique" validate:"required"`
 	EpicKeyField               string          `mapstructure:"epicKeyField,omitempty" json:"epicKeyField" gorm:"type:varchar(255)"`
 	StoryPointField            string          `mapstructure:"storyPointField,omitempty" json:"storyPointField" gorm:"type:varchar(255)"`
 	RemotelinkCommitShaPattern string          `mapstructure:"remotelinkCommitShaPattern,omitempty" json:"remotelinkCommitShaPattern" gorm:"type:varchar(255)"`

--- a/plugins/jira/tasks/task_data.go
+++ b/plugins/jira/tasks/task_data.go
@@ -41,7 +41,7 @@ type TypeMapping struct {
 type TypeMappings map[string]TypeMapping
 
 type JiraTransformationRule struct {
-	Name                       string       `gorm:"type:varchar(255)"`
+	Name                       string       `gorm:"type:varchar(255)" validate:"required"`
 	EpicKeyField               string       `json:"epicKeyField"`
 	StoryPointField            string       `json:"storyPointField"`
 	RemotelinkCommitShaPattern string       `json:"remotelinkCommitShaPattern"`


### PR DESCRIPTION
### Summary
## Database
add a unique index for the column `name` of the following tables:
- `_tool_github_transformation_rules`
- `_tool_gitlab_transformation_rules`
- `_tool_jenkins_transformation_rules`
- `_tool_jira_transformation_rules`

## API
empty or duplicate `name` value will return an error of `400 bad request` for the following API
- POST /plugins/github/transformation_rules
- POST /plugins/gitlab/transformation_rules
- POST /plugins/jenkins/transformation_rules
- POST /plugins/jira/transformation_rules
- PATCH /plugins/github/transformation_rules/{id}
- PATCH /plugins/gitlab/transformation_rules/{id}
- PATCH /plugins/jenkins/transformation_rules/{id}
- PATCH /plugins/jira/transformation_rules/{id}

### Screenshots
![31264ab0-0901-4370-9fff-1fe923dfd376](https://user-images.githubusercontent.com/8455907/211493037-657fc741-d55c-4ffc-b94a-a695f841ecc1.jpeg)
![image](https://user-images.githubusercontent.com/8455907/211503888-79d34fae-9468-4d56-908c-873cf5cecca0.png)


### Other Information
Any other information that is important to this PR.
