### PR TITLE
fix: fix advance bp cannot edit again

### DIFF
--- a/models/blueprint.go
+++ b/models/blueprint.go
@@ -36,14 +36,14 @@ type Blueprint struct {
 	Name        string          `json:"name" validate:"required"`
 	ProjectName string          `json:"projectName" gorm:"type:varchar(255)"`
 	Mode        string          `json:"mode" gorm:"varchar(20)" validate:"required,oneof=NORMAL ADVANCED"`
-	Plan        json.RawMessage `json:"plan"`
+	Plan        json.RawMessage `json:"plan,omitempty"`
 	Enable      bool            `json:"enable"`
 	//please check this https://crontab.guru/ for detail
 	CronConfig   string          `json:"cronConfig" format:"* * * * *" example:"0 0 * * 1"`
 	IsManual     bool            `json:"isManual"`
 	SkipOnFail   bool            `json:"skipOnFail"`
 	Labels       []string        `json:"labels"`
-	Settings     json.RawMessage `json:"settings" swaggertype:"array,string" example:"please check api: /blueprints/<PLUGIN_NAME>/blueprint-setting"`
+	Settings     json.RawMessage `json:"settings,omitempty" swaggertype:"array,string" example:"please check api: /blueprints/<PLUGIN_NAME>/blueprint-setting"`
 	common.Model `swaggerignore:"true"`
 }
 


### PR DESCRIPTION
### Summary
fix advance bp cannot edit again.

Create request:
![image](https://user-images.githubusercontent.com/3294100/211528400-6f3c54b4-5df3-4264-a61a-8ccc7f534cf1.png)

Edit request:
![image](https://user-images.githubusercontent.com/3294100/211528538-b26361c4-2b6e-4ea7-96cc-0b2d2256c827.png)

If `setting` haven't been post, the bp display API will got error.

Now I fix it.