### PR TITLE
fix: limit the max rate limit = 200 for gitlab

### DIFF
--- a/plugins/gitlab/tasks/api_client.go
+++ b/plugins/gitlab/tasks/api_client.go
@@ -19,14 +19,13 @@ package tasks
 
 import (
 	"fmt"
-	"github.com/apache/incubator-devlake/errors"
 	"net/http"
 	"strconv"
 	"time"
 
-	"github.com/apache/incubator-devlake/plugins/gitlab/models"
-
+	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/plugins/core"
+	"github.com/apache/incubator-devlake/plugins/gitlab/models"
 	"github.com/apache/incubator-devlake/plugins/helper"
 )
 
@@ -54,7 +53,11 @@ func NewGitlabApiClient(taskCtx core.TaskContext, connection *models.GitlabConne
 				return 0, 0, errors.Default.Wrap(err, "failed to parse RateLimit-Limit header")
 			}
 			// seems like gitlab rate limit is on minute basis
-			return rateLimit, 1 * time.Minute, nil
+			if rateLimit > 200 {
+				return 200, 1 * time.Minute, nil
+			} else {
+				return rateLimit, 1 * time.Minute, nil
+			}
 		},
 	}
 	asyncApiClient, err := helper.CreateAsyncApiClient(

--- a/plugins/gitlab/tasks/pipeline_collector.go
+++ b/plugins/gitlab/tasks/pipeline_collector.go
@@ -46,7 +46,6 @@ func CollectApiPipelines(taskCtx core.SubTaskContext) errors.Error {
 	err = collectorWithState.InitCollector(helper.ApiCollectorArgs{
 		RawDataSubTaskArgs: *rawDataSubTaskArgs,
 		ApiClient:          data.ApiClient,
-		Concurrency:        5,
 		PageSize:           100,
 		Incremental:        incremental,
 		UrlTemplate:        "projects/{{ .Params.ProjectId }}/pipelines",


### PR DESCRIPTION
### Summary
limit the max rate limit = 200 for GitLab. Because the pipeline seems to have can only support about 250 requests per minute. Although Gitlab allow 2000 pre minute, I find that Devlake now can only use about 300 per minute by rateLimit header for GitLab. So I think we can set it to 200 at the most.

Closes #3192