### PR TITLE
fix: fix jenkins example bug

### DIFF
--- a/config-ui/src/pages/blueprint/components/advanced-editor/example/general.ts
+++ b/config-ui/src/pages/blueprint/components/advanced-editor/example/general.ts
@@ -36,7 +36,7 @@ const general = [
       plugin: 'jenkins',
       options: {
         connectionId: 1,
-        jobName: 'unit_test',
+        jobFullName: 'unit_test',
       },
     },
     {

--- a/config-ui/src/pages/blueprint/components/advanced-editor/example/jenkins.ts
+++ b/config-ui/src/pages/blueprint/components/advanced-editor/example/jenkins.ts
@@ -22,7 +22,7 @@ const jenkins = [
       plugin: 'jenkins',
       options: {
         connectionId: 1,
-        jobName: 'unit_test',
+        jobFullName: 'unit_test',
       },
     },
   ],


### PR DESCRIPTION
### Summary
fix jenkins example bug. `jobFullName` is the correct name.