### PR TITLE
fix(framework): dont wrap contextCanceled and use this to calculate s…

### DIFF
--- a/test/services/pipeline_runner_e2e_test.go
+++ b/test/services/pipeline_runner_e2e_test.go
@@ -70,7 +70,7 @@ func TestComputePipelineStatus(t *testing.T) {
 	assert.NotZero(t, task_row2_col1.ID)
 
 	// pipeline.status == "failed" if SkipOnFailed=false and any tasks failed
-	status, err := services.ComputePipelineStatus(pipeline, false)
+	status, err := services.ComputePipelineStatus(pipeline)
 	if !assert.Nil(t, err) {
 		println(err.Messages().Format())
 	}
@@ -83,7 +83,7 @@ func TestComputePipelineStatus(t *testing.T) {
 	task_row2_col1.Status = models.TASK_COMPLETED
 	err = db.Update(task_row2_col1)
 	assert.Nil(t, err)
-	status, err = services.ComputePipelineStatus(pipeline, false)
+	status, err = services.ComputePipelineStatus(pipeline)
 	if !assert.Nil(t, err) {
 		println(err.Messages().Format())
 	}
@@ -92,7 +92,7 @@ func TestComputePipelineStatus(t *testing.T) {
 	pipeline.SkipOnFail = true
 	err = db.Update(pipeline)
 	assert.Nil(t, err)
-	status, err = services.ComputePipelineStatus(pipeline, false)
+	status, err = services.ComputePipelineStatus(pipeline)
 	assert.Nil(t, err)
 	assert.Equal(t, models.TASK_COMPLETED, status)
 
@@ -100,7 +100,7 @@ func TestComputePipelineStatus(t *testing.T) {
 	task_row1_col1.Status = models.TASK_FAILED
 	err = db.Update(task_row1_col1)
 	assert.Nil(t, err)
-	status, err = services.ComputePipelineStatus(pipeline, false)
+	status, err = services.ComputePipelineStatus(pipeline)
 	assert.Nil(t, err)
 	assert.Equal(t, models.TASK_PARTIAL, status)
 
@@ -114,7 +114,7 @@ func TestComputePipelineStatus(t *testing.T) {
 	task_row2_col1.Status = models.TASK_FAILED
 	err = db.Update(task_row2_col1)
 	assert.Nil(t, err)
-	status, err = services.ComputePipelineStatus(pipeline, false)
+	status, err = services.ComputePipelineStatus(pipeline)
 	assert.Nil(t, err)
 	assert.Equal(t, models.TASK_FAILED, status)
 
@@ -152,7 +152,7 @@ func TestComputePipelineStatus(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotZero(t, task_row2_col1.ID)
 
-	status, err = services.ComputePipelineStatus(pipeline, false)
+	status, err = services.ComputePipelineStatus(pipeline)
 	assert.Nil(t, err)
 	assert.Equal(t, models.TASK_COMPLETED, status)
 
@@ -160,7 +160,7 @@ func TestComputePipelineStatus(t *testing.T) {
 	task_row1_col1_rerun.Status = models.TASK_CANCELLED
 	err = db.Update(task_row1_col1_rerun)
 	assert.Nil(t, err)
-	status, err = services.ComputePipelineStatus(pipeline, false)
+	status, err = services.ComputePipelineStatus(pipeline)
 	assert.Nil(t, err)
-	assert.Equal(t, models.TASK_PARTIAL, status)
+	assert.Equal(t, models.TASK_CANCELLED, status)
 }


### PR DESCRIPTION
### Summary
1. If subtask.error is context.Canceled, we don't wrap it and just return 
<img width="1039" alt="image" src="https://user-images.githubusercontent.com/39366025/211597876-00069893-0731-4e5f-9374-81d433156e47.png">

2. Then if taskError is context.Canceled, we assign its status `CANCEL`
<img width="639" alt="image" src="https://user-images.githubusercontent.com/39366025/211598111-14126696-73e5-4ab7-b120-c2457382cec0.png">

3.  Calculate pipeline status with `Canceled`
<img width="555" alt="image" src="https://user-images.githubusercontent.com/39366025/211598247-121c7f89-2562-46e8-a397-ae5b0c7ba41f.png">
