### PR TITLE
fix: fix can not create index with name idx_name for pg

### DIFF
--- a/plugins/github/models/migrationscripts/archived/transformation_rules.go
+++ b/plugins/github/models/migrationscripts/archived/transformation_rules.go
@@ -25,7 +25,7 @@ import (
 
 type GithubTransformationRule struct {
 	archived.Model
-	Name                 string `mapstructure:"name" json:"name" gorm:"type:varchar(255);index:idx_name,unique" validate:"required"`
+	Name                 string `mapstructure:"name" json:"name" gorm:"type:varchar(255);index:idx_name_github,unique" validate:"required"`
 	PrType               string `mapstructure:"prType" json:"prType" gorm:"type:varchar(255)"`
 	PrComponent          string `mapstructure:"prComponent" json:"prComponent" gorm:"type:varchar(255)"`
 	PrBodyClosePattern   string `mapstructure:"prBodyClosePattern" json:"prBodyClosePattern" gorm:"type:varchar(255)"`

--- a/plugins/github/models/transformation_rule.go
+++ b/plugins/github/models/transformation_rule.go
@@ -24,7 +24,7 @@ import (
 
 type GithubTransformationRule struct {
 	common.Model         `mapstructure:"-"`
-	Name                 string            `mapstructure:"name" json:"name" gorm:"type:varchar(255);index:idx_name,unique" validate:"required"`
+	Name                 string            `mapstructure:"name" json:"name" gorm:"type:varchar(255);index:idx_name_github,unique" validate:"required"`
 	PrType               string            `mapstructure:"prType,omitempty" json:"prType" gorm:"type:varchar(255)"`
 	PrComponent          string            `mapstructure:"prComponent,omitempty" json:"prComponent" gorm:"type:varchar(255)"`
 	PrBodyClosePattern   string            `mapstructure:"prBodyClosePattern,omitempty" json:"prBodyClosePattern" gorm:"type:varchar(255)"`

--- a/plugins/gitlab/models/migrationscripts/archived/transformation_rules.go
+++ b/plugins/gitlab/models/migrationscripts/archived/transformation_rules.go
@@ -24,7 +24,7 @@ import (
 
 type GitlabTransformationRule struct {
 	archived.Model
-	Name                 string `gorm:"type:varchar(255);index:idx_name,unique" validate:"required"`
+	Name                 string `gorm:"type:varchar(255);index:idx_name_gitlab,unique" validate:"required"`
 	PrType               string `mapstructure:"prType" json:"prType" gorm:"type:varchar(255)"`
 	PrComponent          string `mapstructure:"prComponent" json:"prComponent" gorm:"type:varchar(255)"`
 	PrBodyClosePattern   string `mapstructure:"prBodyClosePattern" json:"prBodyClosePattern" gorm:"type:varchar(255)"`

--- a/plugins/gitlab/models/transformation_rule.go
+++ b/plugins/gitlab/models/transformation_rule.go
@@ -24,7 +24,7 @@ import (
 
 type GitlabTransformationRule struct {
 	common.Model
-	Name                 string            `gorm:"type:varchar(255);index:idx_name,unique" validate:"required" mapstructure:"name" json:"name"`
+	Name                 string            `gorm:"type:varchar(255);index:idx_name_gitlab,unique" validate:"required" mapstructure:"name" json:"name"`
 	PrType               string            `mapstructure:"prType" json:"prType"`
 	PrComponent          string            `mapstructure:"prComponent" json:"prComponent"`
 	PrBodyClosePattern   string            `mapstructure:"prBodyClosePattern" json:"prBodyClosePattern"`

--- a/plugins/jenkins/models/migrationscripts/archived/transformation_rules.go
+++ b/plugins/jenkins/models/migrationscripts/archived/transformation_rules.go
@@ -23,7 +23,7 @@ import (
 
 type JenkinsTransformationRule struct {
 	archived.Model
-	Name              string `gorm:"type:varchar(255);index:idx_name,unique" validate:"required"`
+	Name              string `gorm:"type:varchar(255);index:idx_name_jenkins,unique" validate:"required"`
 	DeploymentPattern string `gorm:"type:varchar(255)" mapstructure:"deploymentPattern" json:"deploymentPattern"`
 	ProductionPattern string `gorm:"type:varchar(255)" mapstructure:"deploymentPattern,omitempty" json:"productionPattern"`
 }

--- a/plugins/jenkins/models/transformation_rule.go
+++ b/plugins/jenkins/models/transformation_rule.go
@@ -21,7 +21,7 @@ import "github.com/apache/incubator-devlake/models/common"
 
 type JenkinsTransformationRule struct {
 	common.Model      `mapstructure:"-"`
-	Name              string `gorm:"type:varchar(255);index:idx_name,unique" validate:"required" mapstructure:"name" json:"name"`
+	Name              string `gorm:"type:varchar(255);index:idx_name_jenkins,unique" validate:"required" mapstructure:"name" json:"name"`
 	DeploymentPattern string `gorm:"type:varchar(255)" mapstructure:"deploymentPattern,omitempty" json:"deploymentPattern"`
 	ProductionPattern string `gorm:"type:varchar(255)" mapstructure:"productionPattern,omitempty" json:"productionPattern"`
 }

--- a/plugins/jira/models/migrationscripts/archived/transformation_rule.go
+++ b/plugins/jira/models/migrationscripts/archived/transformation_rule.go
@@ -25,7 +25,7 @@ import (
 
 type JiraTransformationRule struct {
 	archived.Model
-	Name                       string          `gorm:"type:varchar(255);index:idx_name,unique" validate:"required"`
+	Name                       string          `gorm:"type:varchar(255);index:idx_name_jira,unique" validate:"required"`
 	EpicKeyField               string          `json:"epicKeyField" gorm:"type:varchar(255)"`
 	StoryPointField            string          `json:"storyPointField" gorm:"type:varchar(255)"`
 	RemotelinkCommitShaPattern string          `json:"remotelinkCommitShaPattern" gorm:"type:varchar(255)"`

--- a/plugins/jira/models/transformation_rules.go
+++ b/plugins/jira/models/transformation_rules.go
@@ -25,7 +25,7 @@ import (
 
 type JiraTransformationRule struct {
 	common.Model               `mapstructure:"-"`
-	Name                       string          `mapstructure:"name" json:"name" gorm:"type:varchar(255);index:idx_name,unique" validate:"required"`
+	Name                       string          `mapstructure:"name" json:"name" gorm:"type:varchar(255);index:idx_name_jira,unique" validate:"required"`
 	EpicKeyField               string          `mapstructure:"epicKeyField,omitempty" json:"epicKeyField" gorm:"type:varchar(255)"`
 	StoryPointField            string          `mapstructure:"storyPointField,omitempty" json:"storyPointField" gorm:"type:varchar(255)"`
 	RemotelinkCommitShaPattern string          `mapstructure:"remotelinkCommitShaPattern,omitempty" json:"remotelinkCommitShaPattern" gorm:"type:varchar(255)"`


### PR DESCRIPTION
### Summary
change the index name for the columns:
- `_tool_gitlab_transformation_rules.idx_name` ->  `_tool_gitlab_transformation_rules.idx_name_gitlab` 
- `_tool_github_transformation_rules.idx_name` ->  `_tool_github_transformation_rules.idx_name_github` 
- `_tool_jenkins_transformation_rules.idx_name` ->  `_tool_jenkins_transformation_rules.idx_name_jenkins` 
- `_tool_jira_transformation_rules.idx_name` ->  `_tool_ira_transformation_rules.idx_name_jira` 

otherwise, it would create the index for only **one** table on the Postgres database

### Does this close any open issues?
Closes xx

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
