### PR TITLE
style(graphana): Corrected typo on word Review

### DIFF
--- a/grafana/dashboards/GitHub.json
+++ b/grafana/dashboards/GitHub.json
@@ -29,7 +29,7 @@
       },
       "id": 99,
       "options": {
-        "content": "- Use Cases: This dashboard shows the basic Git and Code Reivew metrics from GitHub.\n- Data Source Required: GitHub",
+        "content": "- Use Cases: This dashboard shows the basic Git and Code Review metrics from GitHub.\n- Data Source Required: GitHub",
         "mode": "markdown"
       },
       "pluginVersion": "8.0.6",

--- a/grafana/dashboards/Gitlab.json
+++ b/grafana/dashboards/Gitlab.json
@@ -29,7 +29,7 @@
       },
       "id": 101,
       "options": {
-        "content": "- Use Cases: This dashboard shows the basic Git and Code Reivew metrics from GitLab.\n- Data Source Required: GitLab",
+        "content": "- Use Cases: This dashboard shows the basic Git and Code Review metrics from GitLab.\n- Data Source Required: GitLab",
         "mode": "markdown"
       },
       "pluginVersion": "8.0.6",


### PR DESCRIPTION
### Summary
![image](https://user-images.githubusercontent.com/8844096/211638480-55ca78dc-85e6-4c30-b087-dd6838c1c236.png)

We have the word Reivew written in 2 dashboards of graphana (GIthub and gitlab). With the change once you load the json again you will have the typo fixed

### Does this close any open issues?
Closes xx

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
