### PR TITLE
fix: fix graphql cannot cancel

### DIFF
--- a/plugins/helper/graphql_async_client.go
+++ b/plugins/helper/graphql_async_client.go
@@ -141,7 +141,7 @@ func (apiClient *GraphqlAsyncClient) SetGetRateCost(getRateCost func(q interface
 // Query send a graphql request when get lock
 // []graphql.DataError are the errors returned in response body
 // errors.Error is other error
-func (apiClient *GraphqlAsyncClient) Query(q interface{}, variables map[string]interface{}) ([]graphql.DataError, errors.Error) {
+func (apiClient *GraphqlAsyncClient) Query(q interface{}, variables map[string]interface{}) ([]graphql.DataError, error) {
 	apiClient.waitGroup.Add(1)
 	defer apiClient.waitGroup.Done()
 	apiClient.mu.Lock()
@@ -165,7 +165,7 @@ func (apiClient *GraphqlAsyncClient) Query(q interface{}, variables map[string]i
 			var dataErrors []graphql.DataError
 			dataErrors, err := apiClient.client.Query(apiClient.ctx, q, variables)
 			if err == context.Canceled {
-				return nil, errors.Default.Wrap(err, `context canceled`)
+				return nil, err
 			}
 			if err != nil {
 				apiClient.logger.Warn(err, "retry #%d graphql calling after %ds", retryTime, apiClient.waitBeforeRetry/time.Second)
@@ -189,7 +189,7 @@ func (apiClient *GraphqlAsyncClient) Query(q interface{}, variables map[string]i
 }
 
 // NextTick to return the NextTick of scheduler
-func (apiClient *GraphqlAsyncClient) NextTick(task func() errors.Error, taskErrorChecker func(err errors.Error)) {
+func (apiClient *GraphqlAsyncClient) NextTick(task func() errors.Error, taskErrorChecker func(err error)) {
 	// to make sure task will be enqueued
 	apiClient.waitGroup.Add(1)
 	go func() {

--- a/plugins/helper/graphql_async_client.go
+++ b/plugins/helper/graphql_async_client.go
@@ -198,7 +198,7 @@ func (apiClient *GraphqlAsyncClient) NextTick(task func() errors.Error, taskErro
 			return
 		default:
 			go func() {
-				// if set waitGroup done here, a serial of goroutine will block until son goruntine finish.
+				// if set waitGroup done here, a serial of goroutine will block until sub-goroutine finish.
 				// But if done out of this go func, so task will run after waitGroup finish
 				// I have no idea about this now...
 				defer apiClient.waitGroup.Done()

--- a/plugins/helper/graphql_collector.go
+++ b/plugins/helper/graphql_collector.go
@@ -18,6 +18,7 @@ limitations under the License.
 package helper
 
 import (
+	"context"
 	"encoding/json"
 	"github.com/apache/incubator-devlake/errors"
 	"github.com/apache/incubator-devlake/models/common"
@@ -256,7 +257,12 @@ func (collector *GraphqlCollector) fetchAsync(divider *BatchSaveDivider, reqData
 	logger := collector.args.Ctx.GetLogger()
 	dataErrors, err := collector.args.GraphqlClient.Query(query, variables)
 	if err != nil {
-		collector.checkError(errors.Default.Wrap(err, `graphql query failed`))
+		if errors.Is(err, context.Canceled) {
+			// direct error message for error combine
+			collector.checkError(errors.Default.Wrap(err, `graphql query canceled`))
+		} else {
+			collector.checkError(errors.Default.Wrap(err, `graphql query failed`))
+		}
 		return
 	}
 	if len(dataErrors) > 0 {

--- a/plugins/helper/graphql_collector.go
+++ b/plugins/helper/graphql_collector.go
@@ -255,13 +255,13 @@ func (collector *GraphqlCollector) fetchAsync(divider *BatchSaveDivider, reqData
 	}
 
 	logger := collector.args.Ctx.GetLogger()
-	dataErrors, queryErr := collector.args.GraphqlClient.Query(query, variables)
-	if queryErr != nil {
-		if errors.Is(queryErr, context.Canceled) {
+	dataErrors, err := collector.args.GraphqlClient.Query(query, variables)
+	if err != nil {
+		if err == context.Canceled {
 			// direct error message for error combine
-			collector.checkError(queryErr)
+			collector.checkError(err)
 		} else {
-			collector.checkError(errors.Default.Wrap(queryErr, `graphql query failed`))
+			collector.checkError(errors.Default.Wrap(err, `graphql query failed`))
 		}
 		return
 	}
@@ -355,7 +355,7 @@ func (collector *GraphqlCollector) fetchAsync(divider *BatchSaveDivider, reqData
 	}
 }
 
-func (collector *GraphqlCollector) checkError(err errors.Error) {
+func (collector *GraphqlCollector) checkError(err error) {
 	if err == nil {
 		return
 	}

--- a/plugins/helper/graphql_collector.go
+++ b/plugins/helper/graphql_collector.go
@@ -255,13 +255,13 @@ func (collector *GraphqlCollector) fetchAsync(divider *BatchSaveDivider, reqData
 	}
 
 	logger := collector.args.Ctx.GetLogger()
-	dataErrors, err := collector.args.GraphqlClient.Query(query, variables)
-	if err != nil {
-		if errors.Is(err, context.Canceled) {
+	dataErrors, queryErr := collector.args.GraphqlClient.Query(query, variables)
+	if queryErr != nil {
+		if errors.Is(queryErr, context.Canceled) {
 			// direct error message for error combine
-			collector.checkError(errors.Default.Wrap(err, `graphql query canceled`))
+			collector.checkError(queryErr)
 		} else {
-			collector.checkError(errors.Default.Wrap(err, `graphql query failed`))
+			collector.checkError(errors.Default.Wrap(queryErr, `graphql query failed`))
 		}
 		return
 	}


### PR DESCRIPTION
### Summary
fix graphql cannot cancel.

cancel when getting ratelimit:
![437b4c74-2806-439a-be0d-9ceec8da16a8](https://user-images.githubusercontent.com/3294100/211709648-b954177f-74d1-438f-a445-0b1e2e4d82bd.jpeg)

cancel when querying:
![1288e944-f311-4f76-89f2-93fe14f683fa](https://user-images.githubusercontent.com/3294100/211709662-d0ad8f39-0808-498e-98ef-6651b91645af.jpeg)


cancel when retry:
![image](https://user-images.githubusercontent.com/3294100/211709628-404fe81f-6642-4b09-83f1-ab9afa6efd30.png)
