### PR TITLE
doc: Replace supported data-sources in Readme with a hyperlink to website

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,8 @@ Apache DevLake is designed for developer teams looking to make better sense of t
 
 ## 💪 Supported Data Sources
 
-| Data Source                   | Domain(s)                                                  | Supported Versions                                          | Config UI Availability | Triggered Plugins           | Collection Mode       |
-|-------------------------------|------------------------------------------------------------|-------------------------------------------------------------|------------------------|---------------------------- | --------------------- |
-| GitHub (include GitHub Action)| Source Code Management, Code Review, Issue Tracking, CI/CD | Cloud                                                       |Available               |`github`, `gitextractor`     | Full Refresh, Incremental Sync(for `issues`, `PRs`) |
-| GitLab (include GitLabCI)     | Source Code Management, Code Review, Issue Tracking, CI/CD | Cloud, Community Edition 13.x+                              |Available               |`gitlab`, `gitextractor`     | Full Refresh, Incremental Sync(for `issues`)|
-| Gitee                         | Source Code Management, Code Review, Issue Tracking        | Cloud                                                       |Not Available           |`gitee`, `gitextractor`      | Incremental Sync      |
-| BitBucket                     | Source Code Management, Code Review                        | Cloud                                                       |Not Available           |`bitbucket`, `gitextractor`  | Full Refresh          |
-| Jira                          | Issue Tracking                                             | Cloud, Server 8.x+, Data Center 8.x+                        |Available               |`jira`                       | Full Refresh, Incremental Sync(for `issues`, `changelogs`, `worklogs`) |
-| TAPD                          | Issue Tracking                                             | Cloud                                                       |Not Available           |`tapd`                       | Full Refresh, Incremental Sync(for `stories`, `bugs`, `tasks`)          |
-| Jenkins                       | CI/CD                                                      | 2.263.x+                                                    |Available               |`jenkins`                    | Full Refresh          |
-| Feishu                        | Calendar                                                   | Cloud                                                       |Not Available           |`feishu`                     | Full Refresh          |
-| AE                            | Source Code Management                                     |                                                             |Not Available           | `ae`                        | Full Refresh          |
-| Pagerduty                     | Issue Tracking                                             | [Singer-tap](https://github.com/singer-io/tap-pagerduty)    |Not Available           | `pagerduty`                 | Full Refresh          |
+[Here](https://devlake.apache.org/docs/SupportedDataSources#data-sources-and-data-plugins) you can find all data sources supported by DevLake, their scopes, supported versions and more!
+
 
 ## 🚀 Getting Started
 


### PR DESCRIPTION
### Summary
Currently the supported-datasources table is duplicated in both the Readme and the Website docs. This PR will hyperlink the Readme to the website so that we only have a single source. This will ease the maintenance burden.

### Does this close any open issues?
Closes #3095 

