### PR TITLE
feat: add `dal.RawCursor` back for compatibility

### DIFF
--- a/impl/dalgorm/dalgorm.go
+++ b/impl/dalgorm/dalgorm.go
@@ -365,6 +365,11 @@ func (d *Dalgorm) IsDuplicationError(err errors.Error) bool {
 	return strings.Contains(strings.ToLower(err.Error()), "duplicate")
 }
 
+// RawCursor (Deprecated) executes raw sql query and returns a database cursor
+func (d *Dalgorm) RawCursor(query string, params ...interface{}) (*sql.Rows, errors.Error) {
+	return errors.Convert01(d.db.Raw(query, params...).Rows())
+}
+
 // NewDalgorm creates a *Dalgorm
 func NewDalgorm(db *gorm.DB) *Dalgorm {
 	return &Dalgorm{db}

--- a/plugins/core/dal/dal.go
+++ b/plugins/core/dal/dal.go
@@ -144,6 +144,8 @@ type Dal interface {
 	IsErrorNotFound(err errors.Error) bool
 	// IsDuplicationError returns true if error is duplicate-error
 	IsDuplicationError(err errors.Error) bool
+	// RawCursor (Deprecated) executes raw sql query and returns a database cursor.
+	RawCursor(query string, params ...interface{}) (*sql.Rows, errors.Error)
 }
 
 type Transaction interface {


### PR DESCRIPTION
### Summary
Add `dal.RawCursor` back due to sometimes users might need to execute complicated SQL queries.
