### PR TITLE
feat: add `dal.RawCursor` back for compatibility

### DIFF
--- a/backend/core/dal/dal.go
+++ b/backend/core/dal/dal.go
@@ -143,6 +143,8 @@ type Dal interface {
 	IsErrorNotFound(err errors.Error) bool
 	// IsDuplicationError returns true if error is duplicate-error
 	IsDuplicationError(err errors.Error) bool
+	// RawCursor (Deprecated) executes raw sql query and returns a database cursor.
+	RawCursor(query string, params ...interface{}) (*sql.Rows, errors.Error)
 }
 
 type Transaction interface {

--- a/backend/impls/dalgorm/dalgorm.go
+++ b/backend/impls/dalgorm/dalgorm.go
@@ -364,6 +364,11 @@ func (d *Dalgorm) IsDuplicationError(err errors.Error) bool {
 	return strings.Contains(strings.ToLower(err.Error()), "duplicate")
 }
 
+// RawCursor (Deprecated) executes raw sql query and returns a database cursor
+func (d *Dalgorm) RawCursor(query string, params ...interface{}) (*sql.Rows, errors.Error) {
+	return errors.Convert01(d.db.Raw(query, params...).Rows())
+}
+
 // NewDalgorm creates a *Dalgorm
 func NewDalgorm(db *gorm.DB) *Dalgorm {
 	return &Dalgorm{db}


### PR DESCRIPTION
### Summary
Cherry-pick #4215 to `main` branch due to the fact it is useful for private plugin
