### PR TITLE
fix: fix the license issues

### DIFF
--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,9 +1,0 @@
-Apache DevLake is an effort undergoing incubation at The Apache Software
-Foundation (ASF), sponsored by the Apache Incubator PMC.
-
-Incubation is required of all newly accepted projects until a further review
-indicates that the infrastructure, communications, and decision making process
-have stabilized in a manner consistent with other successful ASF projects.
-
-While incubation status is not necessarily a reflection of the completeness or stability of the code,
-it does indicate that the project has yet to be fully endorsed by the ASF.

--- a/DISCLAIMER-WIP
+++ b/DISCLAIMER-WIP
@@ -1,0 +1,20 @@
+Apache DevLake is an effort undergoing incubation at The Apache Software
+Foundation (ASF), sponsored by the Apache Incubator PMC.
+
+Incubation is required of all newly accepted projects until a further review
+indicates that the infrastructure, communications, and decision making process
+have stabilized in a manner consistent with other successful ASF projects.
+
+While incubation status is not necessarily a reflection of the completeness or stability of the code,
+it does indicate that the project has yet to be fully endorsed by the ASF.
+
+Some of the incubating project’s releases may not be fully compliant with ASF policy.
+For example, releases may have incomplete or un-reviewed licensing conditions.
+What follows is a list of issues the project is currently aware of (this list is likely to be incomplete):
+
+ * Releases may have incomplete licensing conditions.
+
+If you are planning to incorporate this work into your product/project, please be aware that you will
+need to conduct a thorough licensing review to determine the overall implications of including this work.
+For the current status of this project through the Apache Incubator,
+visit: https://incubator.apache.org/projects/devlake.html

--- a/LICENSE
+++ b/LICENSE
@@ -254,3 +254,27 @@ Copyright 2020 MANYPIXELS PTE LTD
 All images, assets and vectors published on ManyPixels can be used for free. You can use them for noncommercial and commercial purposes. You do not need to ask permission from or provide credit to the creator or ManyPixels.
 
 More precisely, ManyPixels grants you an nonexclusive, worldwide copyright license to download, copy, modify, distribute, perform, and use the assets provided from ManyPixels for free, including for commercial purposes, without permission from or attributing the creator or ManyPixels. This license does not include the right to compile assets, vectors or images from ManyPixels to replicate a similar or competing service, in any form or distribute the assets in packs or otherwise. This extends to automated and non-automated ways to link, embed.
+
+
+--------------------------------------------------------------------------------
+This product bundles various third-party components under other open source licenses.
+This section summarizes those components and their licenses.
+
+----------------------------------
+Mozilla Public License 2.0 License
+github.com/hashicorp/hcl
+----------------------------------
+ISC License
+github.com/davecgh/go-spew
+----------------------------------
+Simplified BSD License
+github.com/russross/blackfriday
+github.com/emirpasic/gods
+----------------------------------
+BSD License 2.0
+github.com/gogo/protobuf
+github.com/go-git/gcfg
+github.com/pmezard/go-difflib
+----------------------------------
+MIT License
+github.com/kevinburke/ssh_config

--- a/NOTICE
+++ b/NOTICE
@@ -3,3 +3,16 @@ Copyright 2023 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).
+
+This software includes the following open-source software:
+
+- [github.com/hashicorp/hcl] (https://github.com/hashicorp/hcl), licensed under the Mozilla Public License 2.0 License
+- [github.com/davecgh/go-spew] (https://github.com/davecgh/go-spew), licensed under the ISC License
+- [github.com/russross/blackfriday] (https://github.com/russross/blackfriday), licensed under the Simplified BSD License
+- [github.com/gogo/protobuf] (https://github.com/gogo/protobuf), licensed under the BSD License 2.0
+- [github.com/emirpasic/gods] (https://github.com/emirpasic/gods), licensed under the Simplified BSD License
+- [github.com/go-git/gcfg] (https://github.com/go-git/gcfg), licensed under the BSD License 2.0
+- [github.com/kevinburke/ssh_config] (https://github.com/kevinburke/ssh_config), licensed under the MIT License
+- [github.com/pmezard/go-difflib] (https://github.com/pmezard/go-difflib), licensed under the BSD License 2.0
+
+A copy of each license can be found in the file LICENSE

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 setuptools
 wheel
-tap-pagerduty==0.2.0


### PR DESCRIPTION
### Summary
- remove pagerduty from the `requirements.txt`
- update the LICENSE file
- update the NOTICE file and supply the following information:

>  - [github.com/hashicorp/hcl] (https://github.com/hashicorp/hcl), licensed under the Mozilla Public License 2.0 License
> - [github.com/davecgh/go-spew] (https://github.com/davecgh/go-spew), licensed under the ISC License
> - [github.com/russross/blackfriday] (https://github.com/russross/blackfriday), licensed under the Simplified BSD License
> - [github.com/gogo/protobuf] (https://github.com/gogo/protobuf), licensed under the BSD License 2.0
> - [github.com/emirpasic/gods] (https://github.com/emirpasic/gods), licensed under the Simplified BSD License
> - [github.com/go-git/gcfg] (https://github.com/go-git/gcfg), licensed under the BSD License 2.0
> - [github.com/kevinburke/ssh_config] (https://github.com/kevinburke/ssh_config), licensed under the MIT License
> - [github.com/pmezard/go-difflib] (https://github.com/pmezard/go-difflib), licensed under the BSD License 2.0


