### PR TITLE
fix: update apk to apt-get on tini

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -157,7 +157,7 @@ COPY --from=build /app/resources/tap /app/resources/tap
 ENV PATH="/app/bin:${PATH}"
 
 # add tini, prevent zombie process
-RUN apk add --no-cache tini
+RUN apt-get install -y tini
 ENTRYPOINT ["/sbin/tini", "--"]
 
 CMD ["lake"]


### PR DESCRIPTION
### Summary
due to alpine -->  debian, so we need to update `apk` to `apt-get` on tini, add docker init, solve zombie process.

### Does this close any open issues?
Closes #3919 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
