### PR TITLE
fix(framework): assign labels to dbpipeline in CreateDbPipeline

### DIFF
--- a/backend/server/services/pipeline.go
+++ b/backend/server/services/pipeline.go
@@ -114,10 +114,6 @@ func CreatePipeline(newPipeline *models.NewPipeline) (*models.Pipeline, errors.E
 	if err != nil {
 		return nil, errors.Convert(err)
 	}
-	err = fillPipelineDetail(pipeline)
-	if err != nil {
-		return nil, errors.Convert(err)
-	}
 	return pipeline, nil
 }
 

--- a/backend/server/services/pipeline_helper.go
+++ b/backend/server/services/pipeline_helper.go
@@ -115,7 +115,7 @@ func CreateDbPipeline(newPipeline *models.NewPipeline) (*models.Pipeline, errors
 		globalPipelineLog.Error(err, "update pipline state failed: %v", err)
 		return nil, errors.Internal.Wrap(err, "update pipline state failed")
 	}
-
+	dbPipeline.Labels = newPipeline.Labels
 	return dbPipeline, nil
 }
 


### PR DESCRIPTION
### Summary
Directly assign labels from newPipeline to dbPipeline in `CreateDbPipeline`
In pr #4227, we didn't do this in `CreateDbPipeline`, we called `fillPipelineDetail` in `CreatePipeline`, this is not efficiency.


### Does this close any open issues?
Relate to #4227 

### Screenshots
<img width="1074" alt="image" src="https://user-images.githubusercontent.com/39366025/213107291-274af574-d0c5-41b3-91ca-46213224808e.png">


### Other Information
Any other information that is important to this PR.
