### PR TITLE
fix(sonarqube): modify connection to conform pr4260

### DIFF
--- a/backend/plugins/ae/api/connection.go
+++ b/backend/plugins/ae/api/connection.go
@@ -44,7 +44,7 @@ func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, 
 	// decode
 	var err errors.Error
 	var connection models.AeConn
-	if err := api.Decode(input.Body, &connection, vld); err != nil {
+	if err = api.Decode(input.Body, &connection, vld); err != nil {
 		return nil, errors.BadInput.Wrap(err, "could not decode request parameters")
 	}
 

--- a/backend/plugins/sonarqube/impl/impl.go
+++ b/backend/plugins/sonarqube/impl/impl.go
@@ -73,7 +73,7 @@ func (p Sonarqube) PrepareTaskData(taskCtx plugin.TaskContext, options map[strin
 		return nil, errors.Default.Wrap(err, "unable to get Sonarqube connection by the given connection ID")
 	}
 
-	apiClient, err := tasks.NewSonarqubeApiClient(taskCtx, connection)
+	apiClient, err := tasks.CreateApiClient(taskCtx, connection)
 	if err != nil {
 		return nil, errors.Default.Wrap(err, "unable to get Sonarqube API client instance")
 	}

--- a/backend/plugins/sonarqube/models/connection.go
+++ b/backend/plugins/sonarqube/models/connection.go
@@ -47,8 +47,7 @@ func (sat SonarqubeAccessToken) GetEncodedToken() string {
 type SonarqubeConnection struct {
 	helper.BaseConnection `mapstructure:",squash"`
 	helper.RestConnection `mapstructure:",squash"`
-	// For sonarqube, we can `use user_token:`
-	SonarqubeAccessToken `mapstructure:",squash"`
+	SonarqubeAccessToken  `mapstructure:",squash"`
 }
 
 // SonarqubeConn holds the essential information to connect to the sonarqube API

--- a/backend/plugins/sonarqube/tasks/api_client.go
+++ b/backend/plugins/sonarqube/tasks/api_client.go
@@ -18,57 +18,24 @@ limitations under the License.
 package tasks
 
 import (
-	"fmt"
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
-	"net/http"
-	"strconv"
-	"time"
-
 	"github.com/apache/incubator-devlake/plugins/sonarqube/models"
 )
 
-func NewSonarqubeApiClient(taskCtx plugin.TaskContext, connection *models.SonarqubeConnection) (*api.ApiAsyncClient, errors.Error) {
-	// create synchronize api client so we can calculate api rate limit dynamically
-	headers := map[string]string{
-		"Authorization": fmt.Sprintf("Basic %s", connection.GetEncodedToken()),
-	}
-	apiClient, err := api.NewApiClient(taskCtx.GetContext(), connection.Endpoint, headers, 30*time.Second, connection.Proxy, taskCtx)
+// CreateApiClient creates a new asynchronize API Client for AE
+func CreateApiClient(taskCtx plugin.TaskContext, connection *models.SonarqubeConnection) (*api.ApiAsyncClient, errors.Error) {
+	apiClient, err := api.NewApiClientFromConnection(taskCtx.GetContext(), taskCtx, connection)
 	if err != nil {
 		return nil, err
 	}
-	apiClient.SetAfterFunction(func(res *http.Response) errors.Error {
-		if res.StatusCode == http.StatusUnauthorized {
-			return errors.HttpStatus(res.StatusCode).New("authentication failed, please check your AccessToken")
-		}
-		return nil
-	})
 
-	// create rate limit calculator
-	rateLimiter := &api.ApiRateLimitCalculator{
-		UserRateLimitPerHour: connection.RateLimitPerHour,
-		DynamicRateLimit: func(res *http.Response) (int, time.Duration, errors.Error) {
-			rateLimitHeader := res.Header.Get("RateLimit-Limit")
-			if rateLimitHeader == "" {
-				// use default
-				return 0, 0, nil
-			}
-			rateLimit, err := strconv.Atoi(rateLimitHeader)
-			if err != nil {
-				return 0, 0, errors.Default.Wrap(err, "failed to parse RateLimit-Limit header")
-			}
-			// seems like {{ .plugin-ame }} rate limit is on minute basis
-			return rateLimit, 1 * time.Minute, nil
-		},
-	}
-	asyncApiClient, err := api.CreateAsyncApiClient(
-		taskCtx,
-		apiClient,
-		rateLimiter,
-	)
+	// create ae api client
+	asyncApiCLient, err := api.CreateAsyncApiClient(taskCtx, apiClient, nil)
 	if err != nil {
 		return nil, err
 	}
-	return asyncApiClient, nil
+
+	return asyncApiCLient, nil
 }


### PR DESCRIPTION
### Summary
According pr #4260, we modify sonarqube's connection to conform the new pattern. Then we can use multi-auth very easily in future

### Does this close any open issues?
Relate to #4260 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
