### PR TITLE
feat: change the default bind address of config-UI and grafana/dashboard to 0.0.0.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
     build:
       context: "config-ui"
     ports:
-      - "127.0.0.1:4000:4000"
+      - "4000:4000"
     env_file:
       - ./.env
     environment:


### PR DESCRIPTION
### Summary
modify the `docker-compose.yml` to set the default bind address of config-UI to `0.0.0.0`

### Does this close any open issues?
relate to #4288 
