### PR TITLE
[Bitbucket] Pagination params and merged date on PRs

### DIFF
--- a/backend/plugins/bitbucket/tasks/api_common.go
+++ b/backend/plugins/bitbucket/tasks/api_common.go
@@ -65,8 +65,8 @@ func CreateRawDataSubTaskArgs(taskCtx plugin.SubTaskContext, Table string) (*api
 func GetQuery(reqData *api.RequestData) (url.Values, errors.Error) {
 	query := url.Values{}
 	query.Set("state", "all")
-	query.Set("page", fmt.Sprintf("%v", reqData.Pager.Page))
-	query.Set("pagelen", fmt.Sprintf("%v", reqData.Pager.Size))
+	query.Set("start", fmt.Sprintf("%v", reqData.Pager.Page*reqData.Pager.Size))
+	query.Set("limit", fmt.Sprintf("%v", reqData.Pager.Size))
 
 	return query, nil
 }

--- a/backend/plugins/bitbucket/tasks/api_common.go
+++ b/backend/plugins/bitbucket/tasks/api_common.go
@@ -65,11 +65,23 @@ func CreateRawDataSubTaskArgs(taskCtx plugin.SubTaskContext, Table string) (*api
 func GetQuery(reqData *api.RequestData) (url.Values, errors.Error) {
 	query := url.Values{}
 	query.Set("state", "all")
-	query.Set("start", fmt.Sprintf("%v", reqData.Pager.Page*reqData.Pager.Size))
-	query.Set("limit", fmt.Sprintf("%v", reqData.Pager.Size))
-
+	query.Set("pagelen", fmt.Sprintf("%v", reqData.Pager.Size))
+	if reqData.CustomData != nil {
+		query.Set("page", reqData.CustomData.(string))
+	}
 	return query, nil
 }
+
+func GetNextPageCustomData(reqData *helper.RequestData, prevPageResponse *http.Response) (interface{}, errors.Error) {
+	resBody, err := io.ReadAll(prevPageResponse.Body)
+	// decode json from body
+	if rawMessages.Next == `` {
+		return ``, helper.ErrFinishCollect
+	}
+	u, err := url.Parse(rawMessages.Next)
+	println(u.Query()[`page`][0])
+	return u.Query()[`page`][0], nil
+},
 
 func GetTotalPagesFromResponse(res *http.Response, args *api.ApiCollectorArgs) (int, errors.Error) {
 	body := &BitbucketPagination{}

--- a/backend/plugins/bitbucket/tasks/api_common.go
+++ b/backend/plugins/bitbucket/tasks/api_common.go
@@ -62,26 +62,60 @@ func CreateRawDataSubTaskArgs(taskCtx plugin.SubTaskContext, Table string) (*api
 	return RawDataSubTaskArgs, data
 }
 
+func decodeResponse(res *http.Response, message interface{}) errors.Error {
+	if res == nil {
+		return errors.Default.New("res is nil")
+	}
+	defer res.Body.Close()
+	resBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return errors.Default.Wrap(err, fmt.Sprintf("error reading response from %s", res.Request.URL.String()))
+	}
+
+	err = errors.Convert(json.Unmarshal(resBody, &message))
+	if err != nil {
+		return errors.Default.Wrap(err, fmt.Sprintf("error decoding response from %s: raw response: %s", res.Request.URL.String(), string(resBody)))
+	}
+	return nil
+}
+
 func GetQuery(reqData *api.RequestData) (url.Values, errors.Error) {
 	query := url.Values{}
 	query.Set("state", "all")
+	query.Set("page", fmt.Sprintf("%v", reqData.Pager.Page))
 	query.Set("pagelen", fmt.Sprintf("%v", reqData.Pager.Size))
+
+	return query, nil
+}
+
+func GetQueryForNext(reqData *api.RequestData) (url.Values, errors.Error) {
+	query := url.Values{}
+	query.Set("state", "all")
+	query.Set("pagelen", fmt.Sprintf("%v", reqData.Pager.Size))
+
 	if reqData.CustomData != nil {
 		query.Set("page", reqData.CustomData.(string))
 	}
 	return query, nil
 }
 
-func GetNextPageCustomData(reqData *helper.RequestData, prevPageResponse *http.Response) (interface{}, errors.Error) {
-	resBody, err := io.ReadAll(prevPageResponse.Body)
-	// decode json from body
-	if rawMessages.Next == `` {
-		return ``, helper.ErrFinishCollect
+func GetNextPageCustomData(_ *api.RequestData, prevPageResponse *http.Response) (interface{}, errors.Error) {
+	var rawMessages struct {
+		Next string `json:"next"`
 	}
-	u, err := url.Parse(rawMessages.Next)
-	println(u.Query()[`page`][0])
+	err := decodeResponse(prevPageResponse, &rawMessages)
+	if err != nil {
+		return nil, err
+	}
+	if rawMessages.Next == `` {
+		return ``, api.ErrFinishCollect
+	}
+	u, err := errors.Convert01(url.Parse(rawMessages.Next))
+	if err != nil {
+		return nil, err
+	}
 	return u.Query()[`page`][0], nil
-},
+}
 
 func GetTotalPagesFromResponse(res *http.Response, args *api.ApiCollectorArgs) (int, errors.Error) {
 	body := &BitbucketPagination{}
@@ -100,18 +134,9 @@ func GetRawMessageFromResponse(res *http.Response) ([]json.RawMessage, errors.Er
 	var rawMessages struct {
 		Values []json.RawMessage `json:"values"`
 	}
-	if res == nil {
-		return nil, errors.Default.New("res is nil")
-	}
-	defer res.Body.Close()
-	resBody, err := io.ReadAll(res.Body)
+	err := decodeResponse(res, &rawMessages)
 	if err != nil {
-		return nil, errors.Default.Wrap(err, fmt.Sprintf("error reading response from %s", res.Request.URL.String()))
-	}
-
-	err = errors.Convert(json.Unmarshal(resBody, &rawMessages))
-	if err != nil {
-		return nil, errors.Default.Wrap(err, fmt.Sprintf("error decoding response from %s: raw response: %s", res.Request.URL.String(), string(resBody)))
+		return nil, err
 	}
 
 	return rawMessages.Values, nil

--- a/backend/plugins/bitbucket/tasks/pr_commit_collector.go
+++ b/backend/plugins/bitbucket/tasks/pr_commit_collector.go
@@ -43,15 +43,15 @@ func CollectApiPullRequestCommits(taskCtx plugin.SubTaskContext) errors.Error {
 	defer iterator.Close()
 
 	collector, err := helper.NewApiCollector(helper.ApiCollectorArgs{
-		RawDataSubTaskArgs: 	*rawDataSubTaskArgs,
-		ApiClient:          	data.ApiClient,
-		PageSize:           	100,
-		Incremental:        	false,
-		Input:              	iterator,
-		UrlTemplate:        	"repositories/{{ .Params.Owner }}/{{ .Params.Repo }}/pullrequests/{{ .Input.BitbucketId }}/commits",
-		GetNextPageCustomData: 	GetNextPageCustomData,
-		Query:              	GetQuery,
-		ResponseParser:     	GetRawMessageFromResponse,
+		RawDataSubTaskArgs:    *rawDataSubTaskArgs,
+		ApiClient:             data.ApiClient,
+		PageSize:              100,
+		Incremental:           false,
+		Input:                 iterator,
+		UrlTemplate:           "repositories/{{ .Params.Owner }}/{{ .Params.Repo }}/pullrequests/{{ .Input.BitbucketId }}/commits",
+		GetNextPageCustomData: GetNextPageCustomData,
+		Query:                 GetQueryForNext,
+		ResponseParser:        GetRawMessageFromResponse,
 	})
 
 	if err != nil {

--- a/backend/plugins/bitbucket/tasks/pr_commit_collector.go
+++ b/backend/plugins/bitbucket/tasks/pr_commit_collector.go
@@ -43,14 +43,15 @@ func CollectApiPullRequestCommits(taskCtx plugin.SubTaskContext) errors.Error {
 	defer iterator.Close()
 
 	collector, err := helper.NewApiCollector(helper.ApiCollectorArgs{
-		RawDataSubTaskArgs: *rawDataSubTaskArgs,
-		ApiClient:          data.ApiClient,
-		PageSize:           100,
-		Incremental:        false,
-		Input:              iterator,
-		UrlTemplate:        "repositories/{{ .Params.Owner }}/{{ .Params.Repo }}/pullrequests/{{ .Input.BitbucketId }}/commits",
-		Query:              GetQuery,
-		ResponseParser:     GetRawMessageFromResponse,
+		RawDataSubTaskArgs: 	*rawDataSubTaskArgs,
+		ApiClient:          	data.ApiClient,
+		PageSize:           	100,
+		Incremental:        	false,
+		Input:              	iterator,
+		UrlTemplate:        	"repositories/{{ .Params.Owner }}/{{ .Params.Repo }}/pullrequests/{{ .Input.BitbucketId }}/commits",
+		GetNextPageCustomData: 	GetNextPageCustomData,
+		Query:              	GetQuery,
+		ResponseParser:     	GetRawMessageFromResponse,
 	})
 
 	if err != nil {

--- a/backend/plugins/bitbucket/tasks/pr_convertor.go
+++ b/backend/plugins/bitbucket/tasks/pr_convertor.go
@@ -74,12 +74,10 @@ func ConvertPullRequests(taskCtx plugin.SubTaskContext) errors.Error {
 			// Getting the merge reference commit
 			mergeCommit := &models.BitbucketCommit{}
 			err = db.First(mergeCommit, dal.Where("LEFT(sha, 12) = ?", pr.MergeCommitSha))
-			if err != nil {
-				mergeCommit.CommittedDate = *pr.MergedAt
+			if err == nil {
+				// Setting the PR merged datetime to the commit commited datetime
+				pr.MergedAt = &mergeCommit.CommittedDate
 			}
-
-			// Setting the PR merged datetime to the commit commited datetime
-			pr.MergedAt = &mergeCommit.CommittedDate
 
 			domainPr := &code.PullRequest{
 				DomainEntity: domainlayer.DomainEntity{

--- a/backend/plugins/bitbucket/tasks/pr_convertor.go
+++ b/backend/plugins/bitbucket/tasks/pr_convertor.go
@@ -70,6 +70,17 @@ func ConvertPullRequests(taskCtx plugin.SubTaskContext) errors.Error {
 		},
 		Convert: func(inputRow interface{}) ([]interface{}, errors.Error) {
 			pr := inputRow.(*models.BitbucketPullRequest)
+
+			// Getting the merge reference commit
+			mergeCommit := &models.BitbucketCommit{}
+			err = db.First(mergeCommit, dal.Where("LEFT(sha, 12) = ?", pr.MergeCommitSha))
+			if err != nil {
+				mergeCommit.CommittedDate = *pr.MergedAt
+			}
+
+			// Setting the PR merged datetime to the commit commited datetime
+			pr.MergedAt = &mergeCommit.CommittedDate
+
 			domainPr := &code.PullRequest{
 				DomainEntity: domainlayer.DomainEntity{
 					Id: prIdGen.Generate(data.Options.ConnectionId, pr.BitbucketId),


### PR DESCRIPTION
### Summary
What does this PR do?
- Fix the pagination params on Bitbucket API and add a feature to get the PR merge datetime (in order to fix the Lead Time feature on DORA for Bitbucket plugin).

### Does this close any open issues?
Closes #4285

### Screenshots
After these modifications, DORA metrics dashboard shows these metrics.
![Imagem 01-02-2023 às 16 57](https://user-images.githubusercontent.com/3507471/216149922-dbb97fad-2086-480a-9ddd-ef59761eb2f9.jpg)

