### PR TITLE
refactor: simplify bitbucket apiclient creation

### DIFF
--- a/backend/plugins/bitbucket/api/blueprint_test.go
+++ b/backend/plugins/bitbucket/api/blueprint_test.go
@@ -44,14 +44,16 @@ func TestMakePipelinePlan(t *testing.T) {
 				ID: 1,
 			},
 		},
-		RestConnection: helper.RestConnection{
-			Endpoint:         "https://TestBitBucket/",
-			Proxy:            "",
-			RateLimitPerHour: 0,
-		},
-		BasicAuth: helper.BasicAuth{
-			Username: "Username",
-			Password: "Password",
+		BitbucketConn: models.BitbucketConn{
+			RestConnection: helper.RestConnection{
+				Endpoint:         "https://TestBitBucket/",
+				Proxy:            "",
+				RateLimitPerHour: 0,
+			},
+			BasicAuth: helper.BasicAuth{
+				Username: "Username",
+				Password: "Password",
+			},
 		},
 	}
 

--- a/backend/plugins/bitbucket/api/connection.go
+++ b/backend/plugins/bitbucket/api/connection.go
@@ -19,20 +19,19 @@ package api
 
 import (
 	"context"
-	"fmt"
+	"net/http"
+
 	"github.com/apache/incubator-devlake/core/errors"
 	plugin "github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/bitbucket/models"
 	_ "github.com/apache/incubator-devlake/server/api/shared"
-	"net/http"
-	"time"
 )
 
 // @Summary test bitbucket connection
 // @Description Test bitbucket Connection
 // @Tags plugins/bitbucket
-// @Param body body models.TestConnectionRequest true "json body"
+// @Param body body models.BitbucketConn true "json body"
 // @Success 200  {object} shared.ApiBody "Success"
 // @Failure 400  {string} errcode.Error "Bad Request"
 // @Failure 500  {string} errcode.Error "Internal Error"
@@ -40,21 +39,12 @@ import (
 func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
 	// decode
 	var err errors.Error
-	var connection models.TestConnectionRequest
+	var connection models.BitbucketConn
 	if err := api.Decode(input.Body, &connection, vld); err != nil {
 		return nil, errors.BadInput.Wrap(err, "could not decode request parameters")
 	}
 	// test connection
-	apiClient, err := api.NewApiClient(
-		context.TODO(),
-		connection.Endpoint,
-		map[string]string{
-			"Authorization": fmt.Sprintf("Basic %v", connection.GetEncodedToken()),
-		},
-		3*time.Second,
-		connection.Proxy,
-		basicRes,
-	)
+	apiClient, err := api.NewApiClientFromConnection(context.TODO(), basicRes, connection)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/plugins/bitbucket/models/connection.go
+++ b/backend/plugins/bitbucket/models/connection.go
@@ -21,23 +21,6 @@ import (
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 )
 
-type EpicResponse struct {
-	Id    int
-	Title string
-	Value string
-}
-
-type TestConnectionRequest struct {
-	Endpoint         string `json:"endpoint"`
-	Proxy            string `json:"proxy"`
-	helper.BasicAuth `mapstructure:",squash"`
-}
-
-type BoardResponse struct {
-	Id    int
-	Title string
-	Value string
-}
 type TransformationRules struct {
 	IssueStatusTODO       []string `mapstructure:"issueStatusTodo" json:"issueStatusTodo"`
 	IssueStatusINPROGRESS []string `mapstructure:"issueStatusInProgress" json:"issueStatusInProgress"`
@@ -45,10 +28,16 @@ type TransformationRules struct {
 	IssueStatusOTHER      []string `mapstructure:"issueStatusOther" json:"issueStatusOther"`
 }
 
-type BitbucketConnection struct {
-	helper.BaseConnection `mapstructure:",squash"`
+// BitbucketConn holds the essential information to connect to the Bitbucket API
+type BitbucketConn struct {
 	helper.RestConnection `mapstructure:",squash"`
 	helper.BasicAuth      `mapstructure:",squash"`
+}
+
+// BitbucketConnection holds BitbucketConn plus ID/Name for database storage
+type BitbucketConnection struct {
+	helper.BaseConnection `mapstructure:",squash"`
+	BitbucketConn         `mapstructure:",squash"`
 }
 
 func (BitbucketConnection) TableName() string {

--- a/backend/plugins/bitbucket/tasks/api_client.go
+++ b/backend/plugins/bitbucket/tasks/api_client.go
@@ -27,6 +27,9 @@ import (
 func CreateApiClient(taskCtx plugin.TaskContext, connection *models.BitbucketConnection) (*api.ApiAsyncClient, errors.Error) {
 	// create synchronize api client so we can calculate api rate limit dynamically
 	apiClient, err := api.NewApiClientFromConnection(taskCtx.GetContext(), taskCtx, connection)
+	if err != nil {
+		return nil, err
+	}
 
 	// create rate limit calculator
 	rateLimiter := &api.ApiRateLimitCalculator{

--- a/backend/plugins/bitbucket/tasks/api_client.go
+++ b/backend/plugins/bitbucket/tasks/api_client.go
@@ -18,27 +18,15 @@ limitations under the License.
 package tasks
 
 import (
-	"fmt"
 	"github.com/apache/incubator-devlake/core/errors"
 	plugin "github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/bitbucket/models"
-	"net/http"
 )
 
 func CreateApiClient(taskCtx plugin.TaskContext, connection *models.BitbucketConnection) (*api.ApiAsyncClient, errors.Error) {
-	// load configuration
-	token := connection.GetEncodedToken()
 	// create synchronize api client so we can calculate api rate limit dynamically
-	apiClient, err := api.NewApiClient(taskCtx.GetContext(), connection.Endpoint, nil, 0, connection.Proxy, taskCtx)
-	if err != nil {
-		return nil, err
-	}
-	// Rotates token on each request.
-	apiClient.SetBeforeFunction(func(req *http.Request) errors.Error {
-		req.Header.Set("Authorization", fmt.Sprintf("Basic %v", token))
-		return nil
-	})
+	apiClient, err := api.NewApiClientFromConnection(taskCtx.GetContext(), taskCtx, connection)
 
 	// create rate limit calculator
 	rateLimiter := &api.ApiRateLimitCalculator{


### PR DESCRIPTION
### Summary
1. simplify bitbucket apiclient creation
2. remove unused struct: EpicResponse / BoardResponse

### Does this close any open issues?
Part of #4298 

### Screenshots
test connection
![bitbucket-testconn](https://user-images.githubusercontent.com/61080/216516715-4019e8e1-f38c-42cf-b98a-4a5cbb187c92.png)

create connection
![bitbucket-createconn](https://user-images.githubusercontent.com/61080/216516707-1ea5bf43-e083-47da-9b75-1c79efba2824.png)

pipline
![bitbucket-pipeline](https://user-images.githubusercontent.com/61080/216516712-7b91d9ec-67b1-4c1b-a79f-e1160c5f8436.png)

