### PR TITLE
refactor: simplify feishui apiclient creation

### DIFF
--- a/backend/plugins/ae/api/connection.go
+++ b/backend/plugins/ae/api/connection.go
@@ -48,7 +48,7 @@ func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, 
 		return nil, errors.BadInput.Wrap(err, "could not decode request parameters")
 	}
 
-	apiClient, err := api.NewApiClientFromConnection(context.TODO(), basicRes, connection)
+	apiClient, err := api.NewApiClientFromConnection(context.TODO(), basicRes, &connection)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/plugins/ae/models/connection.go
+++ b/backend/plugins/ae/models/connection.go
@@ -35,7 +35,7 @@ import (
 type AeAppKey helper.AppKey
 
 // SetupAuthentication sets up the HTTP Request Authentication
-func (aak AeAppKey) SetupAuthentication(req *http.Request) errors.Error {
+func (aak *AeAppKey) SetupAuthentication(req *http.Request) errors.Error {
 	nonceStr := plugin.RandLetterBytes(8)
 	timestamp := fmt.Sprintf("%v", time.Now().Unix())
 	sign := signRequest(req.URL.Query(), aak.AppId, aak.SecretKey, nonceStr, timestamp)
@@ -55,8 +55,7 @@ type AeConn struct {
 // AeConnection holds AeConn plus ID/Name for database storage
 type AeConnection struct {
 	helper.BaseConnection `mapstructure:",squash"`
-	helper.RestConnection `mapstructure:",squash"`
-	AeAppKey              `mapstructure:",squash"`
+	AeConn                `mapstructure:",squash"`
 }
 
 func (AeConnection) TableName() string {

--- a/backend/plugins/azure/api/connection.go
+++ b/backend/plugins/azure/api/connection.go
@@ -42,7 +42,7 @@ func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, 
 		return nil, errors.BadInput.Wrap(err, "could not decode request parameters")
 	}
 	// test connection
-	apiClient, err := api.NewApiClientFromConnection(context.TODO(), basicRes, connection)
+	apiClient, err := api.NewApiClientFromConnection(context.TODO(), basicRes, &connection)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/plugins/bitbucket/api/connection.go
+++ b/backend/plugins/bitbucket/api/connection.go
@@ -44,7 +44,7 @@ func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, 
 		return nil, errors.BadInput.Wrap(err, "could not decode request parameters")
 	}
 	// test connection
-	apiClient, err := api.NewApiClientFromConnection(context.TODO(), basicRes, connection)
+	apiClient, err := api.NewApiClientFromConnection(context.TODO(), basicRes, &connection)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/plugins/feishu/models/connection.go
+++ b/backend/plugins/feishu/models/connection.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	"github.com/apache/incubator-devlake/core/errors"
-	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api/apihelperabstract"
 	"github.com/apache/incubator-devlake/plugins/feishu/apimodels"
@@ -44,7 +43,7 @@ func (conn *FeishuConn) PrepareApiClient(apiClient apihelperabstract.ApiClientAb
 		return err
 	}
 	tokenResBody := &apimodels.ApiAccessTokenResponse{}
-	err = api.UnmarshalResponse(tokenRes, tokenResBody)
+	err = helper.UnmarshalResponse(tokenRes, tokenResBody)
 	if err != nil {
 		return err
 	}

--- a/backend/plugins/feishu/models/connection.go
+++ b/backend/plugins/feishu/models/connection.go
@@ -18,20 +18,49 @@ limitations under the License.
 package models
 
 import (
+	"fmt"
+
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/helpers/pluginhelper/api/apihelperabstract"
+	"github.com/apache/incubator-devlake/plugins/feishu/apimodels"
 )
 
-type TestConnectionRequest struct {
-	Endpoint  string `json:"endpoint" validate:"required,url"`
-	AppId     string `mapstructure:"app_id" validate:"required" json:"app_id"`
-	SecretKey string `mapstructure:"secret_key" validate:"required" json:"secret_key"`
-	Proxy     string `json:"proxy"`
-}
-
-type FeishuConnection struct {
-	helper.BaseConnection `mapstructure:",squash"`
+// FeishuConn holds the essential information to connect to the Feishu API
+type FeishuConn struct {
 	helper.RestConnection `mapstructure:",squash"`
 	helper.AppKey         `mapstructure:",squash"`
+}
+
+func (conn *FeishuConn) PrepareApiClient(apiClient apihelperabstract.ApiClientAbstract) errors.Error {
+	// request for access token
+	tokenReqBody := &apimodels.ApiAccessTokenRequest{
+		AppId:     conn.AppId,
+		AppSecret: conn.SecretKey,
+	}
+	tokenRes, err := apiClient.Post("auth/v3/tenant_access_token/internal", nil, tokenReqBody, nil)
+	if err != nil {
+		return err
+	}
+	tokenResBody := &apimodels.ApiAccessTokenResponse{}
+	err = api.UnmarshalResponse(tokenRes, tokenResBody)
+	if err != nil {
+		return err
+	}
+	if tokenResBody.AppAccessToken == "" && tokenResBody.TenantAccessToken == "" {
+		return errors.Default.New("failed to request access token")
+	}
+	apiClient.SetHeaders(map[string]string{
+		"Authorization": fmt.Sprintf("Bearer %v", tokenResBody.TenantAccessToken),
+	})
+	return nil
+}
+
+// FeishuConnection holds FeishuConn plus ID/Name for database storage
+type FeishuConnection struct {
+	helper.BaseConnection `mapstructure:",squash"`
+	FeishuConn            `mapstructure:",squash"`
 }
 
 func (FeishuConnection) TableName() string {

--- a/backend/plugins/feishu/tasks/api_client.go
+++ b/backend/plugins/feishu/tasks/api_client.go
@@ -29,6 +29,9 @@ import (
 
 func NewFeishuApiClient(taskCtx plugin.TaskContext, connection *models.FeishuConnection) (*api.ApiAsyncClient, errors.Error) {
 	apiClient, err := api.NewApiClientFromConnection(taskCtx.GetContext(), taskCtx, connection)
+	if err != nil {
+		return nil, err
+	}
 
 	// create async api client
 	asyncApiCLient, err := api.CreateAsyncApiClient(taskCtx, apiClient, &api.ApiRateLimitCalculator{

--- a/backend/plugins/feishu/tasks/meeting_top_user_item_collector.go
+++ b/backend/plugins/feishu/tasks/meeting_top_user_item_collector.go
@@ -19,13 +19,14 @@ package tasks
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/url"
+	"strconv"
+
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/feishu/apimodels"
-	"net/http"
-	"net/url"
-	"strconv"
 )
 
 const RAW_MEETING_TOP_USER_ITEM_TABLE = "feishu_meeting_top_user_item"
@@ -51,7 +52,7 @@ func CollectMeetingTopUserItem(taskCtx plugin.SubTaskContext) errors.Error {
 		ApiClient:   data.ApiClient,
 		Incremental: false,
 		Input:       iterator,
-		UrlTemplate: "/reports/get_top_user",
+		UrlTemplate: "vc/v1/reports/get_top_user",
 		Query: func(reqData *api.RequestData) (url.Values, errors.Error) {
 			query := url.Values{}
 			input := reqData.Input.(*api.DatePair)


### PR DESCRIPTION

### Summary
1. change `connection_auths.go` to pointer type to avoid memory copy
2. simplify feishui apiclient creation

### Does this close any open issues?
Part of #4298 

### Screenshots
test connection
![feishu-testconn](https://user-images.githubusercontent.com/61080/216545690-82291657-53c2-4262-b56a-4c3ed2035e36.png)

create connection
![feishu-createconn](https://user-images.githubusercontent.com/61080/216545477-fc632107-63bc-4794-8626-37616e8b109b.png)

pipeline
![feishu-pipeline](https://user-images.githubusercontent.com/61080/216545484-2217a145-8963-42e8-9934-41677d9d5d84.png)


