### PR TITLE
feat: add GetNextPageCustomData to support request pages one by one

### DIFF
--- a/backend/helpers/pluginhelper/api/api_collector.go
+++ b/backend/helpers/pluginhelper/api/api_collector.go
@@ -213,7 +213,7 @@ func (collector *ApiCollector) exec(input interface{}) {
 	if collector.args.PageSize <= 0 {
 		collector.fetchAsync(reqData, nil)
 	} else if collector.args.GetNextPageCustomData != nil {
-		collector.fetchPagesInOrder(reqData)
+		collector.fetchPagesSequentially(reqData)
 	} else if collector.args.GetTotalPages != nil {
 		collector.fetchPagesDetermined(reqData)
 	} else {
@@ -221,8 +221,8 @@ func (collector *ApiCollector) exec(input interface{}) {
 	}
 }
 
-// fetchPagesInOrder fetches data of all pages in order to build query by prev response
-func (collector *ApiCollector) fetchPagesInOrder(reqData *RequestData) {
+// fetchPagesSequentially fetches data of all pages in order to build RequestData by prev response
+func (collector *ApiCollector) fetchPagesSequentially(reqData *RequestData) {
 	var collect func() errors.Error
 	collect = func() errors.Error {
 		collector.fetchAsync(reqData, func(count int, body []byte, res *http.Response) errors.Error {

--- a/backend/helpers/pluginhelper/api/api_collector.go
+++ b/backend/helpers/pluginhelper/api/api_collector.go
@@ -44,6 +44,8 @@ type RequestData struct {
 	Params    interface{}
 	Input     interface{}
 	InputJSON []byte
+	// only exist when PageSize>0, PageInOrder=true and not the first request
+	PrevPageResponse *http.Response
 }
 
 // AsyncResponseHandler FIXME ...
@@ -60,18 +62,20 @@ type ApiCollectorArgs struct {
 	Query func(reqData *RequestData) (url.Values, errors.Error) ``
 	// Header would be sent out along with request
 	Header func(reqData *RequestData) (http.Header, errors.Error)
+	// GetTotalPages is to tell `ApiCollector` total number of pages based on response of the first page.
+	// so `ApiCollector` could collect those pages in parallel for us
+	GetTotalPages func(res *http.Response, args *ApiCollectorArgs) (int, errors.Error)
 	// PageSize tells ApiCollector the page size
 	PageSize int
-	// Incremental indicate if this is a incremental collection, the existing data won't get deleted if it was true
+	// Incremental indicate if this collection request each page in order and build query by the prev request
+	PageInOrder bool `comment:"indicate if this collection request each page in order"`
+	// Incremental indicate if this is an incremental collection, the existing data won't get deleted if it was true
 	Incremental bool `comment:"indicate if this collection is incremental update"`
 	// ApiClient is a asynchronize api request client with qps
 	ApiClient RateLimitedApiClient
 	// Input helps us collect data based on previous collected data, like collecting changelogs based on jira
 	// issue ids
 	Input Iterator
-	// GetTotalPages is to tell `ApiCollector` total number of pages based on response of the first page.
-	// so `ApiCollector` could collect those pages in parallel for us
-	GetTotalPages func(res *http.Response, args *ApiCollectorArgs) (int, errors.Error)
 	// Concurrency specify qps for api that doesn't return total number of pages/records
 	// NORMALLY, DO NOT SPECIFY THIS PARAMETER, unless you know what it means
 	Concurrency    int
@@ -208,11 +212,41 @@ func (collector *ApiCollector) exec(input interface{}) {
 	}
 	if collector.args.PageSize <= 0 {
 		collector.fetchAsync(reqData, nil)
+	} else if collector.args.PageInOrder {
+		collector.fetchPagesInOrder(reqData)
 	} else if collector.args.GetTotalPages != nil {
 		collector.fetchPagesDetermined(reqData)
 	} else {
 		collector.fetchPagesUndetermined(reqData)
 	}
+}
+
+// fetchPagesInOrder fetches data of all pages in order to build query by prev response
+func (collector *ApiCollector) fetchPagesInOrder(reqData *RequestData) {
+	reqDataCopy := RequestData{
+		Pager: &Pager{
+			Page: 1,
+			Size: collector.args.PageSize,
+			Skip: 0,
+		},
+		Input:            reqData.Input,
+		InputJSON:        reqData.InputJSON,
+		PrevPageResponse: nil,
+	}
+	var collect func() errors.Error
+	collect = func() errors.Error {
+		collector.fetchAsync(&reqDataCopy, func(count int, body []byte, res *http.Response) errors.Error {
+			if count < collector.args.PageSize {
+				return nil
+			}
+			reqDataCopy.Pager.Skip += collector.args.PageSize
+			reqDataCopy.Pager.Page += 1
+			reqDataCopy.PrevPageResponse = res
+			return collect()
+		})
+		return nil
+	}
+	collector.args.ApiClient.NextTick(collect)
 }
 
 // fetchPagesDetermined fetches data of all pages for APIs that return paging information


### PR DESCRIPTION
### Summary
add GetNextPageCustomData to support request pages one by one.

### Does this close any open issues?
Related to #4292

### Screenshots

add test code in collector:
```golang
	collector, err := helper.NewApiCollector(helper.ApiCollectorArgs{
		……
		PageSize:           50,
		Query: func(reqData *helper.RequestData) (url.Values, errors.Error) {
			query := url.Values{}
			query.Set("state", "all")
			query.Set("pagelen", fmt.Sprintf("%v", reqData.Pager.Size))
			if reqData.CustomData != nil {
				query.Set("page", reqData.CustomData.(string))
			}
			return query, nil
		},
		GetNextPageCustomData: func(reqData *helper.RequestData, prevPageResponse *http.Response) (interface{}, errors.Error) {
			resBody, err := io.ReadAll(prevPageResponse.Body)
			// decode json from body
			if rawMessages.Next == `` {
				return ``, helper.ErrFinishCollect
			}
			u, err := url.Parse(rawMessages.Next)
			println(u.Query()[`page`][0])
			return u.Query()[`page`][0], nil
		},
	})
```

api response:
![image](https://user-images.githubusercontent.com/3294100/216578216-5f26003e-b1b7-4239-8f89-ac70c3de5e0c.png)

log:
```
time="2023-02-03 18:09:51" level=info msg=" [collectApiPullRequestCommits] start api collection"
time="2023-02-03 18:09:52" level=info msg=" [collectApiPullRequestCommits] finished records: 1"

# the first number means the page
# the second json means which pr is
# the third number means what the next page token is
1 {"BitbucketId":1} xGCox
1 {"BitbucketId":3}
1 {"BitbucketId":2} xGCox
2 {"BitbucketId":1} 7nSyG
2 {"BitbucketId":2} 7nSyG
3 {"BitbucketId":1} LRCkr
3 {"BitbucketId":2} LRCkr
4 {"BitbucketId":1} RaSbR
4 {"BitbucketId":2} RaSbR
time="2023-02-03 18:09:55" level=info msg=" [collectApiPullRequestCommits] finished records: 10"
5 {"BitbucketId":1}
5 {"BitbucketId":2}
time="2023-02-03 18:09:56" level=info msg=" [collectApiPullRequestCommits] end api collection without error"
time="2023-02-03 18:09:56" level=info msg="finished step: 5 / 5"
```

We can find 3 pr's commits are collected parallelly and each page in a PR are collected in order.
