### PR TITLE
refactor: simplify pagerduty test onnection

### DIFF
--- a/backend/plugins/pagerduty/api/connection.go
+++ b/backend/plugins/pagerduty/api/connection.go
@@ -19,39 +19,29 @@ package api
 
 import (
 	"context"
-	"fmt"
+	"net/http"
+
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/pagerduty/models"
-	"net/http"
-	"time"
 )
 
 // @Summary test pagerduty connection
 // @Description Test Pagerduty Connection
 // @Tags plugins/pagerduty
-// @Param body body models.TestConnectionRequest true "json body"
+// @Param body body models.PagerDutyConn true "json body"
 // @Success 200  {object} shared.ApiBody "Success"
 // @Failure 400  {string} errcode.Error "Bad Request"
 // @Failure 500  {string} errcode.Error "Internal Error"
 // @Router /plugins/pagerduty/test [POST]
 func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
-	var params models.TestConnectionRequest
-	err := api.Decode(input.Body, &params, vld)
+	var connection models.PagerDutyConn
+	err := api.Decode(input.Body, &connection, vld)
 	if err != nil {
 		return nil, err
 	}
-	apiClient, err := api.NewApiClient(
-		context.TODO(),
-		params.Endpoint,
-		map[string]string{
-			"Authorization": fmt.Sprintf("Token token=%s", params.Token),
-		},
-		3*time.Second,
-		params.Proxy,
-		basicRes,
-	)
+	apiClient, err := api.NewApiClientFromConnection(context.TODO(), basicRes, &connection)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/plugins/pagerduty/models/connection.go
+++ b/backend/plugins/pagerduty/models/connection.go
@@ -18,19 +18,32 @@ limitations under the License.
 package models
 
 import (
+	"fmt"
+	"net/http"
+
+	"github.com/apache/incubator-devlake/core/errors"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 )
 
-// This object conforms to what the frontend currently sends.
-type PagerDutyConnection struct {
-	helper.BaseConnection `mapstructure:",squash"`
-	helper.AccessToken    `mapstructure:",squash"`
+// AccessToken implements HTTP Token Authentication with Access Token
+type PagerDutyAccessToken helper.AccessToken
+
+// SetupAuthentication sets up the request headers for authentication
+func (at *PagerDutyAccessToken) SetupAuthentication(request *http.Request) errors.Error {
+	request.Header.Set("Authorization", fmt.Sprintf("Token token=%s", at.Token))
+	return nil
 }
 
-type TestConnectionRequest struct {
-	Endpoint string `json:"endpoint" validate:"required,url"`
-	Token    string `json:"token" validate:"required"`
-	Proxy    string `json:"proxy"`
+// PagerDutyConn holds the essential information to connect to the PagerDuty API
+type PagerDutyConn struct {
+	helper.RestConnection `mapstructure:",squash"`
+	PagerDutyAccessToken  `mapstructure:",squash"`
+}
+
+// PagerDutyConnection holds GitlabConn plus ID/Name for database storage
+type PagerDutyConnection struct {
+	helper.BaseConnection `mapstructure:",squash"`
+	PagerDutyConn         `mapstructure:",squash"`
 }
 
 // This object conforms to what the frontend currently expects.

--- a/backend/plugins/pagerduty/models/migrationscripts/20230203_add_endpoint_proxy_to_conn.go
+++ b/backend/plugins/pagerduty/models/migrationscripts/20230203_add_endpoint_proxy_to_conn.go
@@ -21,25 +21,30 @@ import (
 	"github.com/apache/incubator-devlake/core/context"
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/helpers/migrationhelper"
-	"github.com/apache/incubator-devlake/plugins/tapd/models/migrationscripts/archived"
 )
 
-type increaseFieldLength struct{}
+type connection20230203 struct {
+	Endpoint         string `mapstructure:"endpoint" validate:"required" json:"endpoint"`
+	Proxy            string `mapstructure:"proxy" json:"proxy"`
+	RateLimitPerHour int    `comment:"api request rate limit per hour" json:"rateLimit"`
+}
 
-func (*increaseFieldLength) Up(basicRes context.BasicRes) errors.Error {
+func (*connection20230203) TableName() string {
+	return "_tool_pagerduty_connections"
+}
+
+type addEndpointAndProxyToConnection struct{}
+
+func (*addEndpointAndProxyToConnection) Up(basicRes context.BasicRes) errors.Error {
 	return migrationhelper.AutoMigrateTables(basicRes,
-		&archived.TapdBug{},
-		&archived.TapdBugCustomFields{},
-		&archived.TapdStory{},
-		&archived.TapdStoryCustomFields{},
-		&archived.TapdTask{},
-		&archived.TapdTaskCustomFields{})
+		&connection20230203{},
+	)
 }
 
-func (*increaseFieldLength) Version() uint64 {
-	return 20230103201138
+func (*addEndpointAndProxyToConnection) Version() uint64 {
+	return 20230203201814
 }
 
-func (*increaseFieldLength) Name() string {
-	return "Increase field length"
+func (*addEndpointAndProxyToConnection) Name() string {
+	return "add endpoint/proxy to pagerduty connection"
 }

--- a/backend/plugins/pagerduty/models/migrationscripts/register.go
+++ b/backend/plugins/pagerduty/models/migrationscripts/register.go
@@ -25,6 +25,6 @@ import (
 func All() []plugin.MigrationScript {
 	return []plugin.MigrationScript{
 		new(addInitTables),
-		new(increaseFieldLength),
+		new(addEndpointAndProxyToConnection),
 	}
 }


### PR DESCRIPTION
### Summary
1. simplify pagerduty test onnection
2. remove incorrect migrationscript
3. fix pagerduty connection table

### Does this close any open issues?
Part of #4298 


### Screenshots
test connection
![pagerduty-testconn](https://user-images.githubusercontent.com/61080/216598779-6d30b095-2a60-419a-a1d9-cc113a386e8d.png)

create connection
![pagerduty-createconn](https://user-images.githubusercontent.com/61080/216598959-73ff17d8-d3e5-4270-a1c6-91155a366e22.png)

