### PR TITLE
feat: gitlab pipeline could have a different ratelimit to other subtasks

### DIFF
--- a/backend/helpers/pluginhelper/api/worker_scheduler_test.go
+++ b/backend/helpers/pluginhelper/api/worker_scheduler_test.go
@@ -19,10 +19,11 @@ package api
 
 import (
 	"context"
-	"github.com/apache/incubator-devlake/core/errors"
-	"github.com/apache/incubator-devlake/helpers/unithelper"
 	"testing"
 	"time"
+
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/helpers/unithelper"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -31,7 +32,8 @@ func TestWorkerSchedulerQpsControl(t *testing.T) {
 	// assuming we want 2 requests per second
 	testChannel := make(chan int, 100)
 	ctx, cancel := context.WithCancel(context.Background())
-	s, _ := NewWorkerScheduler(ctx, 5, 2, 1*time.Second, unithelper.DummyLogger())
+	tickInterval, _ := CalcTickInterval(2, 1*time.Second)
+	s, _ := NewWorkerScheduler(ctx, 5, tickInterval, unithelper.DummyLogger())
 	defer s.Release()
 	for i := 1; i <= 5; i++ {
 		t := i
@@ -56,7 +58,7 @@ func TestWorkerSchedulerQpsControl(t *testing.T) {
 	if len(testChannel) > 4 {
 		t.Fatal(`worker run too fast after a second`)
 	}
-	assert.Nil(t, s.Wait())
+	assert.Nil(t, s.WaitAsync())
 	if len(testChannel) != 5 {
 		t.Fatal(`worker not wait until finish`)
 	}

--- a/backend/plugins/gitlab/tasks/api_client.go
+++ b/backend/plugins/gitlab/tasks/api_client.go
@@ -48,12 +48,7 @@ func NewGitlabApiClient(taskCtx plugin.TaskContext, connection *models.GitlabCon
 			if err != nil {
 				return 0, 0, errors.Default.Wrap(err, "failed to parse RateLimit-Limit header")
 			}
-			// seems like gitlab rate limit is on minute basis
-			if rateLimit > 200 {
-				return 200, 1 * time.Minute, nil
-			} else {
-				return rateLimit, 1 * time.Minute, nil
-			}
+			return rateLimit, 1 * time.Minute, nil
 		},
 	}
 	asyncApiClient, err := api.CreateAsyncApiClient(

--- a/backend/plugins/gitlab/tasks/pipeline_collector.go
+++ b/backend/plugins/gitlab/tasks/pipeline_collector.go
@@ -19,10 +19,12 @@ package tasks
 
 import (
 	"fmt"
+	"net/url"
+	"time"
+
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
-	"net/url"
 )
 
 const RAW_PIPELINE_TABLE = "gitlab_api_pipeline"
@@ -42,10 +44,15 @@ func CollectApiPipelines(taskCtx plugin.SubTaskContext) errors.Error {
 		return err
 	}
 
+	tickInterval, err := helper.CalcTickInterval(200, 1*time.Minute)
+	if err != nil {
+		return err
+	}
 	incremental := collectorWithState.IsIncremental()
 	err = collectorWithState.InitCollector(helper.ApiCollectorArgs{
 		RawDataSubTaskArgs: *rawDataSubTaskArgs,
 		ApiClient:          data.ApiClient,
+		MinTickInterval:    &tickInterval,
 		PageSize:           100,
 		Incremental:        incremental,
 		UrlTemplate:        "projects/{{ .Params.ProjectId }}/pipelines",


### PR DESCRIPTION
### Summary
1. Added option `MinTickInterval` to `ApiCollector` to restrict the maximum RateLimit for a specific Collector
2. Set Gitlab pipeline Maximum RateLimit to 200reqs/min
3. Simplify WorkScheduler

### Does this close any open issues?
Closes #4210

### Screenshots
![gitlab-pipeline-ratelimit](https://user-images.githubusercontent.com/61080/217786808-7e69606c-99da-4219-b597-22036a7b875d.png)

