### PR TITLE
feat: jira supports timefilter by updated_at

### DIFF
--- a/models/collector_state.go
+++ b/models/collector_state.go
@@ -27,7 +27,7 @@ type CollectorLatestState struct {
 	RawDataParams      string    `gorm:"primaryKey;column:raw_data_params;type:varchar(255);index" json:"raw_data_params"`
 	RawDataTable       string    `gorm:"primaryKey;column:raw_data_table;type:varchar(255)" json:"raw_data_table"`
 	CreatedDateAfter   *time.Time
-	UpdatedDateAfter   *time.Time
+	TimeAfter          *time.Time
 	LatestSuccessStart *time.Time
 }
 

--- a/models/migrationscripts/20230213_add_updated_date_after_to_collector_state.go
+++ b/models/migrationscripts/20230213_add_updated_date_after_to_collector_state.go
@@ -26,23 +26,23 @@ import (
 )
 
 type collectorLatestState20230213 struct {
-	UpdatedDateAfter *time.Time
+	TimeAfter *time.Time
 }
 
 func (collectorLatestState20230213) TableName() string {
 	return "_devlake_collector_latest_state"
 }
 
-type addUpdatedDateAfterToCollectorMeta20230213 struct{}
+type addTimeAfterToCollectorMeta20230213 struct{}
 
-func (script *addUpdatedDateAfterToCollectorMeta20230213) Up(basicRes core.BasicRes) errors.Error {
+func (script *addTimeAfterToCollectorMeta20230213) Up(basicRes core.BasicRes) errors.Error {
 	return migrationhelper.AutoMigrateTables(basicRes, &collectorLatestState20230213{})
 }
 
-func (*addUpdatedDateAfterToCollectorMeta20230213) Version() uint64 {
-	return 20230213200038
+func (*addTimeAfterToCollectorMeta20230213) Version() uint64 {
+	return 20230213200039
 }
 
-func (*addUpdatedDateAfterToCollectorMeta20230213) Name() string {
-	return "add updated_date_after to _devlake_collector_latest_state"
+func (*addTimeAfterToCollectorMeta20230213) Name() string {
+	return "add time_after to _devlake_collector_latest_state"
 }

--- a/models/migrationscripts/20230213_add_updated_date_after_to_collector_state.go
+++ b/models/migrationscripts/20230213_add_updated_date_after_to_collector_state.go
@@ -15,22 +15,34 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package models
+package migrationscripts
 
 import (
 	"time"
+
+	"github.com/apache/incubator-devlake/errors"
+	"github.com/apache/incubator-devlake/helpers/migrationhelper"
+	"github.com/apache/incubator-devlake/plugins/core"
 )
 
-type CollectorLatestState struct {
-	CreatedAt          time.Time `json:"createdAt"`
-	UpdatedAt          time.Time `json:"updatedAt"`
-	RawDataParams      string    `gorm:"primaryKey;column:raw_data_params;type:varchar(255);index" json:"raw_data_params"`
-	RawDataTable       string    `gorm:"primaryKey;column:raw_data_table;type:varchar(255)" json:"raw_data_table"`
-	CreatedDateAfter   *time.Time
-	UpdatedDateAfter   *time.Time
-	LatestSuccessStart *time.Time
+type collectorLatestState20230213 struct {
+	UpdatedDateAfter *time.Time
 }
 
-func (CollectorLatestState) TableName() string {
+func (collectorLatestState20230213) TableName() string {
 	return "_devlake_collector_latest_state"
+}
+
+type addUpdatedDateAfterToCollectorMeta20230213 struct{}
+
+func (script *addUpdatedDateAfterToCollectorMeta20230213) Up(basicRes core.BasicRes) errors.Error {
+	return migrationhelper.AutoMigrateTables(basicRes, &collectorLatestState20230213{})
+}
+
+func (*addUpdatedDateAfterToCollectorMeta20230213) Version() uint64 {
+	return 20230213200038
+}
+
+func (*addUpdatedDateAfterToCollectorMeta20230213) Name() string {
+	return "add updated_date_after to _devlake_collector_latest_state"
 }

--- a/models/migrationscripts/register.go
+++ b/models/migrationscripts/register.go
@@ -69,6 +69,6 @@ func All() []core.MigrationScript {
 		new(encryptTask221221),
 		new(renameProjectMetrics),
 		new(addOriginalTypeToIssue221230),
-		new(addUpdatedDateAfterToCollectorMeta20230213),
+		new(addTimeAfterToCollectorMeta20230213),
 	}
 }

--- a/models/migrationscripts/register.go
+++ b/models/migrationscripts/register.go
@@ -69,5 +69,6 @@ func All() []core.MigrationScript {
 		new(encryptTask221221),
 		new(renameProjectMetrics),
 		new(addOriginalTypeToIssue221230),
+		new(addUpdatedDateAfterToCollectorMeta20230213),
 	}
 }

--- a/plugins/core/plugin_blueprint.go
+++ b/plugins/core/plugin_blueprint.go
@@ -177,5 +177,5 @@ type BlueprintSyncPolicy struct {
 	SkipOnFail bool   `json:"skipOnFail"`
 	// Deprecating
 	CreatedDateAfter *time.Time `json:"createdDateAfter"`
-	UpdatedDateAfter *time.Time `json:"updatedDateAfter"`
+	TimeAfter        *time.Time `json:"timeAfter"`
 }

--- a/plugins/core/plugin_blueprint.go
+++ b/plugins/core/plugin_blueprint.go
@@ -19,8 +19,9 @@ package core
 
 import (
 	"encoding/json"
-	"github.com/apache/incubator-devlake/errors"
 	"time"
+
+	"github.com/apache/incubator-devlake/errors"
 )
 
 // PipelineTask represents a smallest unit of execution inside a PipelinePlan
@@ -172,7 +173,9 @@ type CompositePluginBlueprintV200 interface {
 }
 
 type BlueprintSyncPolicy struct {
-	Version          string     `json:"version" validate:"required,semver,oneof=1.0.0"`
-	SkipOnFail       bool       `json:"skipOnFail"`
+	Version    string `json:"version" validate:"required,semver,oneof=1.0.0"`
+	SkipOnFail bool   `json:"skipOnFail"`
+	// Deprecating
 	CreatedDateAfter *time.Time `json:"createdDateAfter"`
+	UpdatedDateAfter *time.Time `json:"updatedDateAfter"`
 }

--- a/plugins/helper/api_collector_with_state.go
+++ b/plugins/helper/api_collector_with_state.go
@@ -33,12 +33,12 @@ type ApiCollectorStateManager struct {
 	LatestState models.CollectorLatestState
 	// Deprecating
 	CreatedDateAfter *time.Time
-	UpdatedDateAfter *time.Time
+	TimeAfter        *time.Time
 	ExecuteStart     time.Time
 }
 
 // NewApiCollectorWithStateEx create a new ApiCollectorStateManager
-func NewApiCollectorWithStateEx(args RawDataSubTaskArgs, createdDateAfter *time.Time, updatedDateAfter *time.Time) (*ApiCollectorStateManager, errors.Error) {
+func NewApiCollectorWithStateEx(args RawDataSubTaskArgs, createdDateAfter *time.Time, timeAfter *time.Time) (*ApiCollectorStateManager, errors.Error) {
 	db := args.Ctx.GetDal()
 
 	rawDataSubTask, err := NewRawDataSubTask(args)
@@ -61,7 +61,7 @@ func NewApiCollectorWithStateEx(args RawDataSubTaskArgs, createdDateAfter *time.
 		RawDataSubTaskArgs: args,
 		LatestState:        latestState,
 		CreatedDateAfter:   createdDateAfter,
-		UpdatedDateAfter:   updatedDateAfter,
+		TimeAfter:          timeAfter,
 		ExecuteStart:       time.Now(),
 	}, nil
 }
@@ -77,9 +77,9 @@ func (m *ApiCollectorStateManager) IsIncremental() bool {
 	if m.LatestState.LatestSuccessStart == nil {
 		return false
 	}
-	// prioritize UpdatedDateAfter parameter: collector should filter data by `updated_date`
-	if m.UpdatedDateAfter != nil {
-		return m.LatestState.UpdatedDateAfter == nil || !m.UpdatedDateAfter.Before(*m.LatestState.UpdatedDateAfter)
+	// prioritize TimeAfter parameter: collector should filter data by `updated_date`
+	if m.TimeAfter != nil {
+		return m.LatestState.TimeAfter == nil || !m.TimeAfter.Before(*m.LatestState.TimeAfter)
 	}
 	// fallback to CreatedDateAfter: collector should filter data by `created_date`
 	return m.LatestState.CreatedDateAfter == nil || m.CreatedDateAfter != nil && !m.CreatedDateAfter.Before(*m.LatestState.CreatedDateAfter)
@@ -123,6 +123,6 @@ func (m ApiCollectorStateManager) updateState() errors.Error {
 	db := m.Ctx.GetDal()
 	m.LatestState.LatestSuccessStart = &m.ExecuteStart
 	m.LatestState.CreatedDateAfter = m.CreatedDateAfter
-	m.LatestState.UpdatedDateAfter = m.UpdatedDateAfter
+	m.LatestState.TimeAfter = m.TimeAfter
 	return db.CreateOrUpdate(&m.LatestState)
 }

--- a/plugins/helper/api_collector_with_state.go
+++ b/plugins/helper/api_collector_with_state.go
@@ -79,7 +79,7 @@ func (m *ApiCollectorStateManager) IsIncremental() bool {
 	}
 	// prioritize UpdatedDateAfter parameter: collector should filter data by `updated_date`
 	if m.UpdatedDateAfter != nil {
-		return m.LatestState.UpdatedDateAfter == nil || m.UpdatedDateAfter != nil && !m.UpdatedDateAfter.Before(*m.LatestState.UpdatedDateAfter)
+		return m.LatestState.UpdatedDateAfter == nil || !m.UpdatedDateAfter.Before(*m.LatestState.UpdatedDateAfter)
 	}
 	// fallback to CreatedDateAfter: collector should filter data by `created_date`
 	return m.LatestState.CreatedDateAfter == nil || m.CreatedDateAfter != nil && !m.CreatedDateAfter.Before(*m.LatestState.CreatedDateAfter)

--- a/plugins/helper/api_collector_with_state.go
+++ b/plugins/helper/api_collector_with_state.go
@@ -30,13 +30,15 @@ type ApiCollectorStateManager struct {
 	RawDataSubTaskArgs
 	*ApiCollector
 	*GraphqlCollector
-	LatestState      models.CollectorLatestState
+	LatestState models.CollectorLatestState
+	// Deprecating
 	CreatedDateAfter *time.Time
+	UpdatedDateAfter *time.Time
 	ExecuteStart     time.Time
 }
 
-// NewApiCollectorWithState create a new ApiCollectorStateManager
-func NewApiCollectorWithState(args RawDataSubTaskArgs, createdDateAfter *time.Time) (*ApiCollectorStateManager, errors.Error) {
+// NewApiCollectorWithStateEx create a new ApiCollectorStateManager
+func NewApiCollectorWithStateEx(args RawDataSubTaskArgs, createdDateAfter *time.Time, updatedDateAfter *time.Time) (*ApiCollectorStateManager, errors.Error) {
 	db := args.Ctx.GetDal()
 
 	rawDataSubTask, err := NewRawDataSubTask(args)
@@ -59,18 +61,28 @@ func NewApiCollectorWithState(args RawDataSubTaskArgs, createdDateAfter *time.Ti
 		RawDataSubTaskArgs: args,
 		LatestState:        latestState,
 		CreatedDateAfter:   createdDateAfter,
+		UpdatedDateAfter:   updatedDateAfter,
 		ExecuteStart:       time.Now(),
 	}, nil
 }
 
-// IsIncremental return if the old data can support collect incrementally.
-// only when latest collection is success &&
-// (m.LatestState.CreatedDateAfter == nil means all data have been collected ||
-// CreatedDateAfter at this time exists and no before than in the LatestState)
-// if CreatedDateAfter at this time not exists, collect incrementally only when "m.LatestState.CreatedDateAfter == nil"
-func (m ApiCollectorStateManager) IsIncremental() bool {
-	return m.LatestState.LatestSuccessStart != nil &&
-		(m.LatestState.CreatedDateAfter == nil || m.CreatedDateAfter != nil && !m.CreatedDateAfter.Before(*m.LatestState.CreatedDateAfter))
+// NewApiCollectorWithState create a new ApiCollectorStateManager
+func NewApiCollectorWithState(args RawDataSubTaskArgs, createdDateAfter *time.Time) (*ApiCollectorStateManager, errors.Error) {
+	return NewApiCollectorWithStateEx(args, createdDateAfter, nil)
+}
+
+// IsIncremental indicates if the collector should operate in incremental mode
+func (m *ApiCollectorStateManager) IsIncremental() bool {
+	// the initial collection
+	if m.LatestState.LatestSuccessStart == nil {
+		return false
+	}
+	// prioritize UpdatedDateAfter parameter: collector should filter data by `updated_date`
+	if m.UpdatedDateAfter != nil {
+		return m.LatestState.UpdatedDateAfter == nil || m.UpdatedDateAfter != nil && !m.UpdatedDateAfter.Before(*m.LatestState.UpdatedDateAfter)
+	}
+	// fallback to CreatedDateAfter: collector should filter data by `created_date`
+	return m.LatestState.CreatedDateAfter == nil || m.CreatedDateAfter != nil && !m.CreatedDateAfter.Before(*m.LatestState.CreatedDateAfter)
 }
 
 // InitCollector init the embedded collector
@@ -94,11 +106,7 @@ func (m ApiCollectorStateManager) Execute() errors.Error {
 		return err
 	}
 
-	db := m.Ctx.GetDal()
-	m.LatestState.LatestSuccessStart = &m.ExecuteStart
-	m.LatestState.CreatedDateAfter = m.CreatedDateAfter
-	err = db.CreateOrUpdate(&m.LatestState)
-	return err
+	return m.updateState()
 }
 
 // ExecuteGraphQL the embedded collector and record execute state
@@ -108,9 +116,13 @@ func (m ApiCollectorStateManager) ExecuteGraphQL() errors.Error {
 		return err
 	}
 
+	return m.updateState()
+}
+
+func (m ApiCollectorStateManager) updateState() errors.Error {
 	db := m.Ctx.GetDal()
 	m.LatestState.LatestSuccessStart = &m.ExecuteStart
 	m.LatestState.CreatedDateAfter = m.CreatedDateAfter
-	err = db.CreateOrUpdate(&m.LatestState)
-	return err
+	m.LatestState.UpdatedDateAfter = m.UpdatedDateAfter
+	return db.CreateOrUpdate(&m.LatestState)
 }

--- a/plugins/jira/impl/impl.go
+++ b/plugins/jira/impl/impl.go
@@ -237,14 +237,14 @@ func (plugin Jira) PrepareTaskData(taskCtx core.TaskContext, options map[string]
 		taskData.CreatedDateAfter = &createdDateAfter
 		logger.Debug("collect data created from %s", createdDateAfter)
 	}
-	if op.UpdatedDateAfter != "" {
-		var updatedDateAfter time.Time
-		updatedDateAfter, err = errors.Convert01(time.Parse(time.RFC3339, op.UpdatedDateAfter))
+	if op.TimeAfter != "" {
+		var timeAfter time.Time
+		timeAfter, err = errors.Convert01(time.Parse(time.RFC3339, op.TimeAfter))
 		if err != nil {
-			return nil, errors.BadInput.Wrap(err, "invalid value for `updatedDateAfter`")
+			return nil, errors.BadInput.Wrap(err, "invalid value for `timeAfter`")
 		}
-		taskData.UpdatedDateAfter = &updatedDateAfter
-		logger.Debug("collect data created from %s", updatedDateAfter)
+		taskData.TimeAfter = &timeAfter
+		logger.Debug("collect data created from %s", timeAfter)
 	}
 	return taskData, nil
 }

--- a/plugins/jira/impl/impl.go
+++ b/plugins/jira/impl/impl.go
@@ -219,14 +219,6 @@ func (plugin Jira) PrepareTaskData(taskCtx core.TaskContext, options map[string]
 		}
 	}
 
-	var createdDateAfter time.Time
-	if op.CreatedDateAfter != "" {
-		createdDateAfter, err = errors.Convert01(time.Parse(time.RFC3339, op.CreatedDateAfter))
-		if err != nil {
-			return nil, errors.BadInput.Wrap(err, "invalid value for `createdDateAfter`")
-		}
-	}
-
 	info, code, err := tasks.GetJiraServerInfo(jiraApiClient)
 	if err != nil || code != http.StatusOK || info == nil {
 		return nil, errors.HttpStatus(code).Wrap(err, "fail to get Jira server info")
@@ -236,11 +228,24 @@ func (plugin Jira) PrepareTaskData(taskCtx core.TaskContext, options map[string]
 		ApiClient:      jiraApiClient,
 		JiraServerInfo: *info,
 	}
-	if !createdDateAfter.IsZero() {
+	if op.CreatedDateAfter != "" {
+		var createdDateAfter time.Time
+		createdDateAfter, err = errors.Convert01(time.Parse(time.RFC3339, op.CreatedDateAfter))
+		if err != nil {
+			return nil, errors.BadInput.Wrap(err, "invalid value for `createdDateAfter`")
+		}
 		taskData.CreatedDateAfter = &createdDateAfter
 		logger.Debug("collect data created from %s", createdDateAfter)
 	}
-
+	if op.UpdatedDateAfter != "" {
+		var updatedDateAfter time.Time
+		updatedDateAfter, err = errors.Convert01(time.Parse(time.RFC3339, op.UpdatedDateAfter))
+		if err != nil {
+			return nil, errors.BadInput.Wrap(err, "invalid value for `updatedDateAfter`")
+		}
+		taskData.UpdatedDateAfter = &updatedDateAfter
+		logger.Debug("collect data created from %s", updatedDateAfter)
+	}
 	return taskData, nil
 }
 

--- a/plugins/jira/tasks/issue_collector.go
+++ b/plugins/jira/tasks/issue_collector.go
@@ -58,7 +58,7 @@ func CollectIssues(taskCtx core.SubTaskContext) errors.Error {
 			Table store raw data
 		*/
 		Table: RAW_ISSUE_TABLE,
-	}, data.CreatedDateAfter, data.UpdatedDateAfter)
+	}, data.CreatedDateAfter, data.TimeAfter)
 	if err != nil {
 		return err
 	}
@@ -69,8 +69,8 @@ func CollectIssues(taskCtx core.SubTaskContext) errors.Error {
 	jql := "created is not null ORDER BY created ASC"
 
 	// timer filter
-	if data.UpdatedDateAfter != nil {
-		jql = fmt.Sprintf("updated >= '%v' AND %v", data.UpdatedDateAfter.Format("2006/01/02 15:04"), jql)
+	if data.TimeAfter != nil {
+		jql = fmt.Sprintf("updated >= '%v' AND %v", data.TimeAfter.Format("2006/01/02 15:04"), jql)
 	} else if data.CreatedDateAfter != nil {
 		jql = fmt.Sprintf("created >= '%v' AND %v", data.CreatedDateAfter.Format("2006/01/02 15:04"), jql)
 	}

--- a/plugins/jira/tasks/issue_collector.go
+++ b/plugins/jira/tasks/issue_collector.go
@@ -68,13 +68,17 @@ func CollectIssues(taskCtx core.SubTaskContext) errors.Error {
 	//  `updated`, issue will be jumping between pages if it got updated during the collection process
 	jql := "created is not null ORDER BY created ASC"
 
-	incremental := collectorWithState.IsIncremental()
-	if incremental {
-		jql = fmt.Sprintf("updated >= '%v' AND %v", collectorWithState.LatestState.LatestSuccessStart.Format("2006/01/02 15:04"), jql)
-	} else if data.UpdatedDateAfter != nil {
+	// timer filter
+	if data.UpdatedDateAfter != nil {
 		jql = fmt.Sprintf("updated >= '%v' AND %v", data.UpdatedDateAfter.Format("2006/01/02 15:04"), jql)
 	} else if data.CreatedDateAfter != nil {
 		jql = fmt.Sprintf("created >= '%v' AND %v", data.CreatedDateAfter.Format("2006/01/02 15:04"), jql)
+	}
+
+	// diff sync
+	incremental := collectorWithState.IsIncremental()
+	if incremental {
+		jql = fmt.Sprintf("updated >= '%v' AND %v", collectorWithState.LatestState.LatestSuccessStart.Format("2006/01/02 15:04"), jql)
 	}
 
 	err = collectorWithState.InitCollector(helper.ApiCollectorArgs{

--- a/plugins/jira/tasks/issue_collector.go
+++ b/plugins/jira/tasks/issue_collector.go
@@ -44,7 +44,7 @@ var CollectIssuesMeta = core.SubTaskMeta{
 func CollectIssues(taskCtx core.SubTaskContext) errors.Error {
 	data := taskCtx.GetData().(*JiraTaskData)
 
-	collectorWithState, err := helper.NewApiCollectorWithState(helper.RawDataSubTaskArgs{
+	collectorWithState, err := helper.NewApiCollectorWithStateEx(helper.RawDataSubTaskArgs{
 		Ctx: taskCtx,
 		/*
 			This struct will be JSONEncoded and stored into database along with raw data itself, to identity minimal
@@ -58,7 +58,7 @@ func CollectIssues(taskCtx core.SubTaskContext) errors.Error {
 			Table store raw data
 		*/
 		Table: RAW_ISSUE_TABLE,
-	}, data.CreatedDateAfter)
+	}, data.CreatedDateAfter, data.UpdatedDateAfter)
 	if err != nil {
 		return err
 	}
@@ -66,16 +66,15 @@ func CollectIssues(taskCtx core.SubTaskContext) errors.Error {
 	// build jql
 	// IMPORTANT: we have to keep paginated data in a consistence order to avoid data-missing, if we sort issues by
 	//  `updated`, issue will be jumping between pages if it got updated during the collection process
-	createdDateAfter := data.CreatedDateAfter
 	jql := "created is not null ORDER BY created ASC"
-	if createdDateAfter != nil {
-		// prepend a time range criteria if `since` was specified, either by user or from database
-		jql = fmt.Sprintf("created >= '%v' AND %v", createdDateAfter.Format("2006/01/02 15:04"), jql)
-	}
 
 	incremental := collectorWithState.IsIncremental()
 	if incremental {
 		jql = fmt.Sprintf("updated >= '%v' AND %v", collectorWithState.LatestState.LatestSuccessStart.Format("2006/01/02 15:04"), jql)
+	} else if data.UpdatedDateAfter != nil {
+		jql = fmt.Sprintf("updated >= '%v' AND %v", data.UpdatedDateAfter.Format("2006/01/02 15:04"), jql)
+	} else if data.CreatedDateAfter != nil {
+		jql = fmt.Sprintf("created >= '%v' AND %v", data.CreatedDateAfter.Format("2006/01/02 15:04"), jql)
 	}
 
 	err = collectorWithState.InitCollector(helper.ApiCollectorArgs{

--- a/plugins/jira/tasks/task_data.go
+++ b/plugins/jira/tasks/task_data.go
@@ -96,7 +96,7 @@ type JiraOptions struct {
 	ConnectionId         uint64 `json:"connectionId"`
 	BoardId              uint64 `json:"boardId"`
 	CreatedDateAfter     string
-	UpdatedDateAfter     string
+	TimeAfter            string
 	TransformationRules  *JiraTransformationRule `json:"transformationRules"`
 	ScopeId              string
 	TransformationRuleId uint64
@@ -106,7 +106,7 @@ type JiraTaskData struct {
 	Options          *JiraOptions
 	ApiClient        *helper.ApiAsyncClient
 	CreatedDateAfter *time.Time
-	UpdatedDateAfter *time.Time
+	TimeAfter        *time.Time
 	JiraServerInfo   models.JiraServerInfo
 }
 

--- a/plugins/jira/tasks/task_data.go
+++ b/plugins/jira/tasks/task_data.go
@@ -20,8 +20,9 @@ package tasks
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/apache/incubator-devlake/errors"
 	"time"
+
+	"github.com/apache/incubator-devlake/errors"
 
 	"github.com/apache/incubator-devlake/plugins/helper"
 	"github.com/apache/incubator-devlake/plugins/jira/models"
@@ -95,6 +96,7 @@ type JiraOptions struct {
 	ConnectionId         uint64 `json:"connectionId"`
 	BoardId              uint64 `json:"boardId"`
 	CreatedDateAfter     string
+	UpdatedDateAfter     string
 	TransformationRules  *JiraTransformationRule `json:"transformationRules"`
 	ScopeId              string
 	TransformationRuleId uint64
@@ -104,6 +106,7 @@ type JiraTaskData struct {
 	Options          *JiraOptions
 	ApiClient        *helper.ApiAsyncClient
 	CreatedDateAfter *time.Time
+	UpdatedDateAfter *time.Time
 	JiraServerInfo   models.JiraServerInfo
 }
 


### PR DESCRIPTION
### Summary

In order to address issue #4403 , the following actions were taken:

1. added `TimeAfter` to `collector_state` as well as jira `TaskOptions` and `TaskData`
2. `ApiCollectorStateManager.IsIncremental` was modified to take `TimeAfter` as the First Factor to consider, or fallback to `CreatedDateAfter` if `TimeAfter` omitted. In other words, `TimeAfter` would override the `CreatedDateAfter` option
3. JIRA `issue_collector` was modified to follow the principle accordingly

### Does this close any open issues?
Closes #4403

### Screenshots

The initial collection, should respect the `timeAfter` option
![1st-collection](https://user-images.githubusercontent.com/61080/218660608-21259b8d-9597-4ca5-bc1a-1c80f0170ba9.png)


Whenever an older issue got updated, it should be collected.
![3th-newly-updated-issues-got-collected](https://user-images.githubusercontent.com/61080/218660709-4e7c9086-5c33-4e62-966c-f146528e9190.png)


