### PR TITLE
fix(sonarqube): put scope bug

### DIFF
--- a/backend/plugins/sonarqube/api/scope.go
+++ b/backend/plugins/sonarqube/api/scope.go
@@ -26,8 +26,6 @@ import (
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/sonarqube/models"
-
-	"github.com/mitchellh/mapstructure"
 )
 
 type req struct {
@@ -51,7 +49,8 @@ func PutScope(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors
 		return nil, errors.BadInput.New("invalid connectionId")
 	}
 	var projects req
-	err := errors.Convert(mapstructure.Decode(input.Body, &projects))
+	// As we need to process *api.Iso8601Time, we need to use DecodeMapStruct instead of mapstructure.Decode
+	err := errors.Convert(api.DecodeMapStruct(input.Body, &projects))
 	if err != nil {
 		return nil, errors.BadInput.Wrap(err, "decoding Sonarqube project error")
 	}

--- a/backend/plugins/sonarqube/models/migrationscripts/archived/sonarqube_project.go
+++ b/backend/plugins/sonarqube/models/migrationscripts/archived/sonarqube_project.go
@@ -24,7 +24,7 @@ import (
 )
 
 type SonarqubeProject struct {
-	ConnectionId     uint64     `gorm:"primaryKey"`
+	ConnectionId     uint64     `json:"connectionId" gorm:"primaryKey"`
 	ProjectKey       string     `json:"projectKey" gorm:"type:varchar(64);primaryKey"`
 	Name             string     `json:"name" gorm:"type:varchar(255)"`
 	Qualifier        string     `json:"qualifier" gorm:"type:varchar(255)"`

--- a/backend/plugins/sonarqube/models/sonarqube_project.go
+++ b/backend/plugins/sonarqube/models/sonarqube_project.go
@@ -24,7 +24,7 @@ import (
 
 type SonarqubeProject struct {
 	common.NoPKModel `json:"-" mapstructure:"-"`
-	ConnectionId     uint64           `gorm:"primaryKey"`
+	ConnectionId     uint64           `json:"connectionId" gorm:"primaryKey"`
 	ProjectKey       string           `json:"projectKey" gorm:"type:varchar(64);primaryKey"`
 	Name             string           `json:"name" gorm:"type:varchar(255)"`
 	Qualifier        string           `json:"qualifier" gorm:"type:varchar(255)"`


### PR DESCRIPTION
### Summary
1. In SonarqubeProject, add `json:"connectionId" for ConnectionId
2. change decode method in put scope, because we should process time.  mapstructure.Decode cannot convert string to a time.Time or Iso8601Time

### Does this close any open issues?
part of #2305

### Screenshots
![image](https://user-images.githubusercontent.com/39366025/219343882-3cd301a4-6ffb-4b89-83c1-6a7813c6f5ba.png)



### Other Information
Any other information that is important to this PR.
