### PR TITLE
fix(bamboo): change connection auth type

### DIFF
--- a/backend/plugins/bamboo/models/connection.go
+++ b/backend/plugins/bamboo/models/connection.go
@@ -37,13 +37,13 @@ type BambooConnection struct {
 type BambooConn struct {
 	api.RestConnection `mapstructure:",squash"`
 	//TODO you may need to use helper.BasicAuth instead of helper.AccessToken
-	api.AccessToken `mapstructure:",squash"`
+	api.BasicAuth `mapstructure:",squash"`
 }
 
 // PrepareApiClient test api and set the IsPrivateToken,version,UserId and so on.
 func (conn *BambooConn) PrepareApiClient(apiClient apihelperabstract.ApiClientAbstract) errors.Error {
 	header := http.Header{}
-	header.Set("Authorization", fmt.Sprintf("Bearer %v", conn.Token))
+	header.Set("Authorization", fmt.Sprintf("Basic %v", conn.GetEncodedToken()))
 
 	res, err := apiClient.Get("info.json", nil, header)
 	if err != nil {

--- a/backend/plugins/bamboo/models/migrationscripts/20230216_add_init_tables.go
+++ b/backend/plugins/bamboo/models/migrationscripts/20230216_add_init_tables.go
@@ -34,7 +34,7 @@ func (u *addInitTables) Up(baseRes context.BasicRes) errors.Error {
 }
 
 func (*addInitTables) Version() uint64 {
-	return 20230216205024
+	return 20230216205025
 }
 
 func (*addInitTables) Name() string {

--- a/backend/plugins/bamboo/models/migrationscripts/archived/connection.go
+++ b/backend/plugins/bamboo/models/migrationscripts/archived/connection.go
@@ -36,15 +36,15 @@ type RestConnection struct {
 	RateLimitPerHour int    `comment:"api request rate limit per hour" json:"rateLimitPerHour"`
 }
 
-// AccessToken FIXME ...
-type AccessToken struct {
-	Token string `mapstructure:"token" validate:"required" json:"token" encrypt:"yes"`
+type BasicAuth struct {
+	Username string `mapstructure:"username" validate:"required" json:"username"`
+	Password string `mapstructure:"password" validate:"required" json:"password"`
 }
 
 type BambooConn struct {
 	RestConnection `mapstructure:",squash"`
 	//TODO you may need to use helper.BasicAuth instead of helper.AccessToken
-	AccessToken `mapstructure:",squash"`
+	BasicAuth `mapstructure:",squash"`
 }
 
 // TODO Please modify the following code to fit your needs
@@ -55,9 +55,9 @@ type BambooConnection struct {
 }
 
 type TestConnectionRequest struct {
-	Endpoint    string `json:"endpoint"`
-	Proxy       string `json:"proxy"`
-	AccessToken `mapstructure:",squash"`
+	Endpoint  string `json:"endpoint"`
+	Proxy     string `json:"proxy"`
+	BasicAuth `mapstructure:",squash"`
 }
 
 // This object conforms to what the frontend currently expects.


### PR DESCRIPTION
### Summary
As we need to support bamboo 6.8.1, we have to use basic auth

### Does this close any open issues?
part of #3322 
### Screenshots
<img width="1018" alt="image" src="https://user-images.githubusercontent.com/39366025/219601843-9da4e2cc-a686-4dba-9b39-db3dd8417538.png">

### Other Information
Any other information that is important to this PR.
