### PR TITLE
fix(config-ui): github does not list private membership organizations

### DIFF
--- a/config-ui/src/plugins/register/github/api.ts
+++ b/config-ui/src/plugins/register/github/api.ts
@@ -25,8 +25,8 @@ type PaginationParams = {
 
 export const getUser = (prefix: string) => request(`${prefix}/user`);
 
-export const getUserOrgs = (prefix: string, username: string, params: PaginationParams) =>
-  request(`${prefix}/users/${username}/orgs`, {
+export const getUserOrgs = (prefix: string, params: PaginationParams) =>
+  request(`${prefix}/user/orgs`, {
     method: 'get',
     data: params,
   });

--- a/config-ui/src/plugins/register/github/components/miller-columns/use-miller-columns.ts
+++ b/config-ui/src/plugins/register/github/components/miller-columns/use-miller-columns.ts
@@ -84,7 +84,7 @@ export const useMillerColumns = ({ connectionId }: UseMillerColumnsProps) => {
   useEffect(() => {
     (async () => {
       const user = await API.getUser(prefix);
-      const orgs = await API.getUserOrgs(prefix, user.login, {
+      const orgs = await API.getUserOrgs(prefix, {
         page: 1,
         per_page: DEFAULT_PAGE_SIZE,
       });
@@ -149,7 +149,7 @@ export const useMillerColumns = ({ connectionId }: UseMillerColumnsProps) => {
 
       loaded = !repos.length || repos.length < DEFAULT_PAGE_SIZE;
     } else {
-      orgs = await API.getUserOrgs(prefix, user.login, {
+      orgs = await API.getUserOrgs(prefix, {
         page,
         per_page: DEFAULT_PAGE_SIZE,
       });


### PR DESCRIPTION
### Summary
GitHub does not list private membership organizations.

### Does this close any open issues?
Closes #4439 

### Screenshots
![screenshot-20230220-143830](https://user-images.githubusercontent.com/37237996/220043087-4f013965-18d5-4604-a017-9c19c20552a0.png)

![screenshot-20230220-154145](https://user-images.githubusercontent.com/37237996/220043094-497df4a9-3305-4376-a4b2-0861cfbcbafd.png)

