### PR TITLE
fix: check array length before accessing for github run collector

### DIFF
--- a/backend/plugins/github/tasks/cicd_run_collector.go
+++ b/backend/plugins/github/tasks/cicd_run_collector.go
@@ -93,6 +93,10 @@ func CollectRuns(taskCtx plugin.SubTaskContext) errors.Error {
 				return nil, err
 			}
 
+			if len(body.GithubWorkflowRuns) == 0 {
+				return nil, nil
+			}
+
 			// time filter or diff sync
 			if createdAfter != nil {
 				// if the first record of the page was created before minCreated, return emtpy set and stop


### PR DESCRIPTION
### Summary
fix: check array length before accessing for github run collector


