### PR TITLE
fix(bamboo): use skip to replace page * size

### DIFF
--- a/backend/plugins/bamboo/tasks/job_build_collector.go
+++ b/backend/plugins/bamboo/tasks/job_build_collector.go
@@ -73,7 +73,7 @@ func CollectJobBuild(taskCtx plugin.SubTaskContext) errors.Error {
 			query.Set("showEmpty", fmt.Sprintf("%v", true))
 			query.Set("expand", "results.result.vcsRevisions")
 			query.Set("max-result", fmt.Sprintf("%v", reqData.Pager.Size))
-			query.Set("start-index", fmt.Sprintf("%v", (reqData.Pager.Page-1)*reqData.Pager.Size))
+			query.Set("start-index", fmt.Sprintf("%v", reqData.Pager.Skip))
 			return query, nil
 		},
 		GetTotalPages: func(res *http.Response, args *helper.ApiCollectorArgs) (int, errors.Error) {

--- a/backend/plugins/bamboo/tasks/job_collector.go
+++ b/backend/plugins/bamboo/tasks/job_collector.go
@@ -71,7 +71,7 @@ func CollectJob(taskCtx plugin.SubTaskContext) errors.Error {
 			query.Set("showEmpty", fmt.Sprintf("%v", true))
 			query.Set("expand", "jobs.job")
 			query.Set("max-result", fmt.Sprintf("%v", reqData.Pager.Size))
-			query.Set("start-index", fmt.Sprintf("%v", (reqData.Pager.Page-1)*reqData.Pager.Size))
+			query.Set("start-index", fmt.Sprintf("%v", reqData.Pager.Skip))
 			return query, nil
 		},
 		GetTotalPages: func(res *http.Response, args *helper.ApiCollectorArgs) (int, errors.Error) {

--- a/backend/plugins/bamboo/tasks/plan_build_collector.go
+++ b/backend/plugins/bamboo/tasks/plan_build_collector.go
@@ -67,7 +67,7 @@ func CollectPlanBuild(taskCtx plugin.SubTaskContext) errors.Error {
 			query.Set("showEmpty", fmt.Sprintf("%v", true))
 			query.Set("expand", "results.result.vcsRevisions")
 			query.Set("max-result", fmt.Sprintf("%v", reqData.Pager.Size))
-			query.Set("start-index", fmt.Sprintf("%v", (reqData.Pager.Page-1)*reqData.Pager.Size))
+			query.Set("start-index", fmt.Sprintf("%v", reqData.Pager.Skip))
 			return query, nil
 		},
 		GetTotalPages: func(res *http.Response, args *helper.ApiCollectorArgs) (int, errors.Error) {

--- a/backend/plugins/bamboo/tasks/plan_collector.go
+++ b/backend/plugins/bamboo/tasks/plan_collector.go
@@ -49,7 +49,7 @@ func CollectPlan(taskCtx plugin.SubTaskContext) errors.Error {
 			query.Set("showEmpty", fmt.Sprintf("%v", true))
 			query.Set("expand", "plans.plan")
 			query.Set("max-result", fmt.Sprintf("%v", reqData.Pager.Size))
-			query.Set("start-index", fmt.Sprintf("%v", (reqData.Pager.Page-1)*reqData.Pager.Size))
+			query.Set("start-index", fmt.Sprintf("%v", reqData.Pager.Skip))
 			return query, nil
 		},
 		GetTotalPages: func(res *http.Response, args *helper.ApiCollectorArgs) (int, errors.Error) {


### PR DESCRIPTION
### Summary
Before, we use reqData.page * size to express start_index for bamboo entities, according to review for #4460 , we can use reqData.skip instead.

### Does this close any open issues?
part of #3322 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
