### PR TITLE
refactor(bamboo): change back to NewApiCollector

### DIFF
--- a/backend/plugins/bamboo/tasks/job_build_collector.go
+++ b/backend/plugins/bamboo/tasks/job_build_collector.go
@@ -43,10 +43,6 @@ type SimpleJob struct {
 func CollectJobBuild(taskCtx plugin.SubTaskContext) errors.Error {
 	rawDataSubTaskArgs, data := CreateRawDataSubTaskArgs(taskCtx, RAW_JOB_BUILD_TABLE)
 	db := taskCtx.GetDal()
-	collectorWithState, err := helper.NewApiCollectorWithState(*rawDataSubTaskArgs, nil)
-	if err != nil {
-		return err
-	}
 	clauses := []dal.Clause{
 		dal.Select("job_key, plan_name, plan_key"),
 		dal.From(models.BambooJob{}.TableName()),
@@ -63,11 +59,12 @@ func CollectJobBuild(taskCtx plugin.SubTaskContext) errors.Error {
 		return err
 	}
 
-	err = collectorWithState.InitCollector(helper.ApiCollectorArgs{
-		ApiClient:   data.ApiClient,
-		PageSize:    100,
-		Input:       iterator,
-		UrlTemplate: "result/{{ .Input.JobKey }}.json",
+	collector, err := helper.NewApiCollector(helper.ApiCollectorArgs{
+		RawDataSubTaskArgs: *rawDataSubTaskArgs,
+		ApiClient:          data.ApiClient,
+		PageSize:           100,
+		Input:              iterator,
+		UrlTemplate:        "result/{{ .Input.JobKey }}.json",
 		Query: func(reqData *helper.RequestData) (url.Values, errors.Error) {
 			query := url.Values{}
 			query.Set("showEmpty", fmt.Sprintf("%v", true))
@@ -103,7 +100,7 @@ func CollectJobBuild(taskCtx plugin.SubTaskContext) errors.Error {
 	if err != nil {
 		return err
 	}
-	return collectorWithState.Execute()
+	return collector.Execute()
 }
 
 var CollectJobBuildMeta = plugin.SubTaskMeta{

--- a/backend/plugins/bamboo/tasks/plan_build_collector.go
+++ b/backend/plugins/bamboo/tasks/plan_build_collector.go
@@ -37,10 +37,6 @@ var _ plugin.SubTaskEntryPoint = CollectPlanBuild
 func CollectPlanBuild(taskCtx plugin.SubTaskContext) errors.Error {
 	rawDataSubTaskArgs, data := CreateRawDataSubTaskArgs(taskCtx, RAW_PLAN_BUILD_TABLE)
 	db := taskCtx.GetDal()
-	collectorWithState, err := helper.NewApiCollectorWithState(*rawDataSubTaskArgs, nil)
-	if err != nil {
-		return err
-	}
 	clauses := []dal.Clause{
 		dal.Select("plan_key"),
 		dal.From(models.BambooPlan{}.TableName()),
@@ -57,11 +53,12 @@ func CollectPlanBuild(taskCtx plugin.SubTaskContext) errors.Error {
 		return err
 	}
 
-	err = collectorWithState.InitCollector(helper.ApiCollectorArgs{
-		ApiClient:   data.ApiClient,
-		PageSize:    100,
-		Input:       iterator,
-		UrlTemplate: "result/{{ .Input.PlanKey }}.json",
+	collector, err := helper.NewApiCollector(helper.ApiCollectorArgs{
+		RawDataSubTaskArgs: *rawDataSubTaskArgs,
+		ApiClient:          data.ApiClient,
+		PageSize:           100,
+		Input:              iterator,
+		UrlTemplate:        "result/{{ .Input.PlanKey }}.json",
 		Query: func(reqData *helper.RequestData) (url.Values, errors.Error) {
 			query := url.Values{}
 			query.Set("showEmpty", fmt.Sprintf("%v", true))
@@ -97,7 +94,7 @@ func CollectPlanBuild(taskCtx plugin.SubTaskContext) errors.Error {
 	if err != nil {
 		return err
 	}
-	return collectorWithState.Execute()
+	return collector.Execute()
 }
 
 var CollectPlanBuildMeta = plugin.SubTaskMeta{

--- a/backend/plugins/bamboo/tasks/plan_collector.go
+++ b/backend/plugins/bamboo/tasks/plan_collector.go
@@ -34,16 +34,11 @@ var _ plugin.SubTaskEntryPoint = CollectPlan
 
 func CollectPlan(taskCtx plugin.SubTaskContext) errors.Error {
 	rawDataSubTaskArgs, data := CreateRawDataSubTaskArgs(taskCtx, RAW_PLAN_TABLE)
-
-	collectorWithState, err := helper.NewApiCollectorWithState(*rawDataSubTaskArgs, nil)
-	if err != nil {
-		return err
-	}
-
-	err = collectorWithState.InitCollector(helper.ApiCollectorArgs{
-		ApiClient:   data.ApiClient,
-		PageSize:    100,
-		UrlTemplate: "project/{{ .Params.ProjectKey }}.json",
+	collector, err := helper.NewApiCollector(helper.ApiCollectorArgs{
+		RawDataSubTaskArgs: *rawDataSubTaskArgs,
+		ApiClient:          data.ApiClient,
+		PageSize:           100,
+		UrlTemplate:        "project/{{ .Params.ProjectKey }}.json",
 		Query: func(reqData *helper.RequestData) (url.Values, errors.Error) {
 			query := url.Values{}
 			query.Set("showEmpty", fmt.Sprintf("%v", true))
@@ -56,7 +51,7 @@ func CollectPlan(taskCtx plugin.SubTaskContext) errors.Error {
 			var body struct {
 				SizeInfo models.ApiBambooSizeData `json:"plans"`
 			}
-			err = helper.UnmarshalResponse(res, &body)
+			err := helper.UnmarshalResponse(res, &body)
 			if err != nil {
 				return 0, err
 			}
@@ -65,7 +60,7 @@ func CollectPlan(taskCtx plugin.SubTaskContext) errors.Error {
 
 		ResponseParser: func(res *http.Response) ([]json.RawMessage, errors.Error) {
 			body := &models.ApiBambooProject{}
-			err = helper.UnmarshalResponse(res, body)
+			err := helper.UnmarshalResponse(res, body)
 			if err != nil {
 				return nil, err
 			}
@@ -75,7 +70,7 @@ func CollectPlan(taskCtx plugin.SubTaskContext) errors.Error {
 	if err != nil {
 		return err
 	}
-	return collectorWithState.Execute()
+	return collector.Execute()
 }
 
 var CollectPlanMeta = plugin.SubTaskMeta{

--- a/backend/plugins/bamboo/tasks/task_data.go
+++ b/backend/plugins/bamboo/tasks/task_data.go
@@ -33,12 +33,10 @@ type BambooOptions struct {
 	// options means some custom params required by plugin running.
 	// Such As How many rows do your want
 	// You can use it in sub tasks and you need pass it in main.go and pipelines.
-	ConnectionId     uint64   `json:"connectionId"`
-	ProjectKey       string   `json:"projectKey"`
-	CreatedDateAfter string   `json:"createdDateAfter" mapstructure:"createdDateAfter,omitempty"`
-	Tasks            []string `json:"tasks,omitempty"`
-
-	TransformationRuleId             uint64 `mapstructure:"transformationRuleId" json:"transformationRuleId"`
+	ConnectionId                     uint64   `json:"connectionId"`
+	ProjectKey                       string   `json:"projectKey"`
+	Tasks                            []string `json:"tasks,omitempty"`
+	TransformationRuleId             uint64   `mapstructure:"transformationRuleId" json:"transformationRuleId"`
 	*models.BambooTransformationRule `mapstructure:"transformationRules" json:"transformationRules"`
 }
 


### PR DESCRIPTION
### Summary
change `NewApiCollectorWithState` back to NewApiCollector as we don't need bamboo to support diff sync for right now.

### Does this close any open issues?
part of #3322 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
