### PR TITLE
fix: revert webhook migrator changes

### DIFF
--- a/backend/plugins/webhook/impl/impl.go
+++ b/backend/plugins/webhook/impl/impl.go
@@ -23,6 +23,7 @@ import (
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/plugins/webhook/api"
+	"github.com/apache/incubator-devlake/plugins/webhook/models/migrationscripts"
 )
 
 // make sure interface is implemented
@@ -57,7 +58,7 @@ func (p Webhook) RootPkgPath() string {
 }
 
 func (p Webhook) MigrationScripts() []plugin.MigrationScript {
-	return nil
+	return migrationscripts.All()
 }
 
 func (p Webhook) ApiResources() map[string]map[string]plugin.ApiResourceHandler {


### PR DESCRIPTION
### Summary
revert webhook migrator changes. It's a bug imported when path moving.

Related to https://github.com/apache/incubator-devlake/issues/2078,  https://github.com/apache/incubator-devlake/pull/3884/files#diff-d10872fce1824a1b10e8d38d64f631b56ccbb8b3f987a27d229f9b1b80b79018R60