### PR TITLE
fix: add tasks.ConvertIssueLabelsMeta to SubTaskMetas

### DIFF
--- a/backend/plugins/jira/impl/impl.go
+++ b/backend/plugins/jira/impl/impl.go
@@ -108,6 +108,8 @@ func (p Jira) SubTaskMetas() []plugin.SubTaskMeta {
 		tasks.CollectIssuesMeta,
 		tasks.ExtractIssuesMeta,
 
+		tasks.ConvertIssueLabelsMeta,
+
 		tasks.CollectIssueChangelogsMeta,
 		tasks.ExtractIssueChangelogsMeta,
 


### PR DESCRIPTION
### Summary
Add tasks.ConvertIssueLabelsMeta to SubTaskMetas. Fix the bug of missing records in the table `issue_labels`

### Does this close any open issues?
Closes #4500 

### Screenshots
![image](https://user-images.githubusercontent.com/8455907/220833357-3890bd10-f71e-4efd-904a-c672fbee9dd3.png)


