### PR TITLE
cherry pick#4503 fix: add tasks.ConvertIssueLabelsMeta to SubTaskMetas (#4503)

### DIFF
--- a/plugins/jira/impl/impl.go
+++ b/plugins/jira/impl/impl.go
@@ -105,6 +105,8 @@ func (plugin Jira) SubTaskMetas() []core.SubTaskMeta {
 		tasks.CollectIssuesMeta,
 		tasks.ExtractIssuesMeta,
 
+		tasks.ConvertIssueLabelsMeta,
+
 		tasks.CollectIssueChangelogsMeta,
 		tasks.ExtractIssueChangelogsMeta,
 


### PR DESCRIPTION
### Summary
Cherry-pick #4503 fix: add tasks.ConvertIssueLabelsMeta to SubTaskMetas

### Does this close any open issues?
Closes #4500 

