### PR TITLE
fix:  bitbucket got invalid page error on collecting pr commit

### DIFF
--- a/backend/helpers/pluginhelper/api/api_client.go
+++ b/backend/helpers/pluginhelper/api/api_client.go
@@ -42,7 +42,7 @@ import (
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/common"
 )
 
-// ErrIgnoreAndContinue is a error which should be ignored
+// ErrIgnoreAndContinue is an error which should be ignored
 var ErrIgnoreAndContinue = errors.Default.New("ignore and continue")
 
 // ApiClient is designed for simple api requests

--- a/backend/plugins/bitbucket/tasks/api_common.go
+++ b/backend/plugins/bitbucket/tasks/api_common.go
@@ -245,3 +245,17 @@ func ignoreHTTPStatus404(res *http.Response) errors.Error {
 	}
 	return nil
 }
+
+func ignoreSomeHTTPStatus(statusCodes ...int) func(res *http.Response) errors.Error {
+	return func(res *http.Response) errors.Error {
+		if res.StatusCode == http.StatusUnauthorized {
+			return errors.Unauthorized.New("authentication failed, please check your AccessToken")
+		}
+		for _, status := range statusCodes {
+			if res.StatusCode == status {
+				return api.ErrIgnoreAndContinue
+			}
+		}
+		return nil
+	}
+}

--- a/backend/plugins/bitbucket/tasks/api_common.go
+++ b/backend/plugins/bitbucket/tasks/api_common.go
@@ -236,16 +236,6 @@ func GetPipelinesIterator(taskCtx plugin.SubTaskContext, collectorWithState *api
 	return api.NewDalCursorIterator(db, cursor, reflect.TypeOf(BitbucketUuidInput{}))
 }
 
-func ignoreHTTPStatus404(res *http.Response) errors.Error {
-	if res.StatusCode == http.StatusUnauthorized {
-		return errors.Unauthorized.New("authentication failed, please check your AccessToken")
-	}
-	if res.StatusCode == http.StatusNotFound {
-		return api.ErrIgnoreAndContinue
-	}
-	return nil
-}
-
 func ignoreSomeHTTPStatus(statusCodes ...int) func(res *http.Response) errors.Error {
 	return func(res *http.Response) errors.Error {
 		if res.StatusCode == http.StatusUnauthorized {

--- a/backend/plugins/bitbucket/tasks/api_common_test.go
+++ b/backend/plugins/bitbucket/tasks/api_common_test.go
@@ -1,0 +1,70 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func Test_ignoreSomeHTTPStatus(t *testing.T) {
+	type args struct {
+		statusCodes []int
+		res         *http.Response
+	}
+	tests := []struct {
+		name string
+		args args
+		want errors.Error
+	}{
+		{
+			"400",
+			args{
+				statusCodes: []int{http.StatusBadRequest, http.StatusNotFound},
+				res:         &http.Response{StatusCode: http.StatusBadRequest},
+			},
+			api.ErrIgnoreAndContinue,
+		},
+		{
+			"404",
+			args{
+				statusCodes: []int{http.StatusBadRequest, http.StatusNotFound},
+				res:         &http.Response{StatusCode: http.StatusNotFound},
+			},
+			api.ErrIgnoreAndContinue,
+		},
+		{
+			"200",
+			args{
+				statusCodes: []int{http.StatusBadRequest, http.StatusNotFound},
+				res:         &http.Response{StatusCode: http.StatusOK},
+			},
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ignoreSomeHTTPStatus(tt.args.statusCodes...)(tt.args.res); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ignoreSomeHTTPStatus() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/plugins/bitbucket/tasks/issue_collector.go
+++ b/backend/plugins/bitbucket/tasks/issue_collector.go
@@ -18,8 +18,10 @@ limitations under the License.
 package tasks
 
 import (
+	"net/http"
+
 	"github.com/apache/incubator-devlake/core/errors"
-	plugin "github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/core/plugin"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 )
 
@@ -54,7 +56,7 @@ func CollectApiIssues(taskCtx plugin.SubTaskContext) errors.Error {
 		GetTotalPages:  GetTotalPagesFromResponse,
 		ResponseParser: GetRawMessageFromResponse,
 		// some repo have no issue tracker
-		AfterResponse: ignoreHTTPStatus404,
+		AfterResponse: ignoreSomeHTTPStatus(http.StatusNotFound),
 	})
 	if err != nil {
 		return err

--- a/backend/plugins/bitbucket/tasks/issue_comment_collector.go
+++ b/backend/plugins/bitbucket/tasks/issue_comment_collector.go
@@ -18,8 +18,10 @@ limitations under the License.
 package tasks
 
 import (
+	"net/http"
+
 	"github.com/apache/incubator-devlake/core/errors"
-	plugin "github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/core/plugin"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 )
 
@@ -58,7 +60,7 @@ func CollectApiIssueComments(taskCtx plugin.SubTaskContext) errors.Error {
 				`page,pagelen,size`),
 		GetTotalPages:  GetTotalPagesFromResponse,
 		ResponseParser: GetRawMessageFromResponse,
-		AfterResponse:  ignoreHTTPStatus404,
+		AfterResponse:  ignoreSomeHTTPStatus(http.StatusNotFound),
 	})
 	if err != nil {
 		return err

--- a/backend/plugins/bitbucket/tasks/pr_commit_collector.go
+++ b/backend/plugins/bitbucket/tasks/pr_commit_collector.go
@@ -22,6 +22,7 @@ import (
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"net/http"
 	"net/url"
 )
 
@@ -70,7 +71,8 @@ func CollectApiPullRequestCommits(taskCtx plugin.SubTaskContext) errors.Error {
 		ResponseParser: GetRawMessageFromResponse,
 		// some pr have no commit
 		// such as: https://bitbucket.org/amdatulabs/amdatu-kubernetes-deployer/pull-requests/21
-		AfterResponse: ignoreHTTPStatus404,
+		// in the case of the value of page was too large, the status code could be 400
+		AfterResponse: ignoreSomeHTTPStatus(http.StatusBadRequest, http.StatusNotFound),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
### Summary
For the endpoint `repositories/{workspace}/{repository-slug}/pullrequests/{id}/commits?page={page}`, if the page was set too large, the response status code would be 400, with the body:
```json
{"type": "error", "error": {"message": "Invalid page"}}
```
It is fixed by setting `AfterResponse` to `ignoreSomeHTTPStatus(http.StatusNotFound)`

### Does this close any open issues?
Closes #4539
