### PR TITLE
fix: add some log; wait when query fail in RunPipelineInQueue

### DIFF
--- a/backend/core/models/blueprint.go
+++ b/backend/core/models/blueprint.go
@@ -60,7 +60,7 @@ func (bp *Blueprint) UnmarshalPlan() (plugin.PipelinePlan, errors.Error) {
 	var plan plugin.PipelinePlan
 	err := errors.Convert(json.Unmarshal(bp.Plan, &plan))
 	if err != nil {
-		return nil, errors.Convert(err)
+		return nil, errors.Default.Wrap(err, `unmarshal plan fail`)
 	}
 	return plan, nil
 }

--- a/backend/plugins/webhook/api/blueprint_v200.go
+++ b/backend/plugins/webhook/api/blueprint_v200.go
@@ -31,7 +31,7 @@ func MakeDataSourcePipelinePlanV200(connectionId uint64) (plugin.PipelinePlan, [
 	connection := &models.WebhookConnection{}
 	err := connectionHelper.FirstById(connection, connectionId)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Default.Wrap(err, `cannot find webhook connection`)
 	}
 
 	scopes := make([]plugin.Scope, 0)

--- a/backend/server/services/pipeline.go
+++ b/backend/server/services/pipeline.go
@@ -191,12 +191,13 @@ func RunPipelineInQueue(pipelineMaxParallel int64) {
 				dal.Orderby("id ASC"),
 				dal.Limit(1),
 			)
-			if err != nil && !db.IsErrorNotFound(err) {
-				globalPipelineLog.Error(err, "dequeue failed")
-			}
-			cronLocker.Unlock()
-			if !db.IsErrorNotFound(err) {
+			if err == nil {
+				// next pipeline found
 				break
+			}
+			if !db.IsErrorNotFound(err) {
+				// log unexpected err
+				globalPipelineLog.Error(err, "dequeue failed")
 			}
 			time.Sleep(time.Second)
 		}

--- a/backend/server/services/pipeline.go
+++ b/backend/server/services/pipeline.go
@@ -191,6 +191,7 @@ func RunPipelineInQueue(pipelineMaxParallel int64) {
 				dal.Orderby("id ASC"),
 				dal.Limit(1),
 			)
+			cronLocker.Unlock()
 			if err == nil {
 				// next pipeline found
 				break


### PR DESCRIPTION
### Summary
1. add some log; 
2. wait when the query fails in RunPipelineInQueue. The old logic will run pipeline when `err != nil` and err is not RecordNotFound.

### Does this close any open issues?
Related to #4486