### PR TITLE
fix: subtask convertPipelineSteps ended with error

### DIFF
--- a/backend/plugins/bitbucket/tasks/pipeline_steps_convertor.go
+++ b/backend/plugins/bitbucket/tasks/pipeline_steps_convertor.go
@@ -83,9 +83,11 @@ func ConvertPipelineSteps(taskCtx plugin.SubTaskContext) errors.Error {
 					Default:    devops.DONE,
 				}, bitbucketPipelineStep.State),
 			}
-			if bitbucketPipelineStep.StartedOn != nil {
-				domainTask.StartedDate = *bitbucketPipelineStep.StartedOn
+			// not save to domain layer if StartedOn is empty
+			if bitbucketPipelineStep.StartedOn == nil {
+				return nil, nil
 			}
+			domainTask.StartedDate = *bitbucketPipelineStep.StartedOn
 			// rebuild the FinishedDate
 			if domainTask.Status == devops.DONE {
 				domainTask.FinishedDate = bitbucketPipelineStep.CompletedOn


### PR DESCRIPTION
### Summary
Fix the subtask convertPipelineSteps ended with an error.
The bug was caused by trying to insert a record with an empty `started_date` in the database. In this PR, this type of record was ignored.

### Does this close any open issues?
Closes #4552 

