### PR TITLE
fix(framework): adapt old port in dotenv

### DIFF
--- a/backend/server/api/api.go
+++ b/backend/server/api/api.go
@@ -105,6 +105,7 @@ func CreateApiService() {
 
 	RegisterRouter(router)
 	port := v.GetString("PORT")
+	port = strings.TrimLeft(port, ":")
 	if remotePluginsEnabled {
 		go bootstrapRemotePlugins(v)
 	}


### PR DESCRIPTION
### Summary
pr #4518 just changed logic of extracting port from .env, but didn't considered old port in .env, so this pr  just cut the prefix `:` if port contains that

### Does this close any open issues?
Closes #4496 

### Screenshots
<img width="760" alt="image" src="https://user-images.githubusercontent.com/39366025/222056282-edddd81d-e481-47a0-8311-f1ce24106ed1.png">
### Other Information
Any other information that is important to this PR.
