### PR TITLE
fix: gitextractor can not clone bitbucket private repos

### DIFF
--- a/backend/plugins/bitbucket/api/blueprint_V200_test.go
+++ b/backend/plugins/bitbucket/api/blueprint_V200_test.go
@@ -90,7 +90,7 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 				Options: map[string]interface{}{
 					"proxy":  "",
 					"repoId": "bitbucket:BitbucketRepo:1:likyh/likyhphp",
-					"url":    "https://git:Password@this_is_cloneUrl",
+					"url":    "https://Username:Password@this_is_cloneUrl",
 				},
 			},
 		},

--- a/backend/plugins/bitbucket/api/blueprint_v200.go
+++ b/backend/plugins/bitbucket/api/blueprint_v200.go
@@ -134,7 +134,7 @@ func makeDataSourcePipelinePlanV200(
 			if err != nil {
 				return nil, err
 			}
-			cloneUrl.User = url.UserPassword("git", connection.Password)
+			cloneUrl.User = url.UserPassword(connection.Username, connection.Password)
 			stage = append(stage, &plugin.PipelineTask{
 				Plugin: "gitextractor",
 				Options: map[string]interface{}{


### PR DESCRIPTION
### Summary
Fix the gitextractor can not clone bitbucket private repos.
It was caused by using `git` rather than the actual username when constructing the clone URL 

### Does this close any open issues?
Closes #4558 

