### PR TITLE
fix: extra csv file generated during e2e test

### DIFF
--- a/backend/plugins/bitbucket/e2e/repo_test.go
+++ b/backend/plugins/bitbucket/e2e/repo_test.go
@@ -62,7 +62,7 @@ func TestRepoDataFlow(t *testing.T) {
 	assert.Nil(t, err)
 	dataflowTester.VerifyTable(
 		models.BitbucketRepo{},
-		"./snapshot_tables/_tool_bitbucket_repos1.csv",
+		"./snapshot_tables/_tool_bitbucket_repos.csv",
 		e2ehelper.ColumnWithRawData(
 			"connection_id",
 			"bitbucket_id",


### PR DESCRIPTION
### Summary
Fix #4572 
This bug is caused by using the wrong file name

### Does this close any open issues?
Closes #4572 

