### PR TITLE
fix: board id can not match project_mapping row_id by webhook plugin

### DIFF
--- a/backend/plugins/webhook/api/blueprint_v200.go
+++ b/backend/plugins/webhook/api/blueprint_v200.go
@@ -19,6 +19,7 @@ package api
 
 import (
 	"fmt"
+
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/models/domainlayer"
 	"github.com/apache/incubator-devlake/core/models/domainlayer/devops"
@@ -42,8 +43,6 @@ func MakeDataSourcePipelinePlanV200(connectionId uint64) (plugin.PipelinePlan, [
 		},
 		Name: connection.Name,
 	})
-	// NOTICE:
-	//if utils.StringsContains(bpScope.Entities, plugin.DOMAIN_TYPE_TICKET) {}
-	// issue board will be created when post issue
+
 	return nil, scopes, nil
 }

--- a/backend/plugins/webhook/api/connection.go
+++ b/backend/plugins/webhook/api/connection.go
@@ -19,10 +19,11 @@ package api
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/plugins/webhook/models"
-	"net/http"
 )
 
 // PostConnections
@@ -128,7 +129,7 @@ func GetConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, e
 func formatConnection(connection *models.WebhookConnection) *WebhookConnectionResponse {
 	response := &WebhookConnectionResponse{WebhookConnection: *connection}
 	response.PostIssuesEndpoint = fmt.Sprintf(`/plugins/webhook/%d/issues`, connection.ID)
-	response.CloseIssuesEndpoint = fmt.Sprintf(`/plugins/webhook/%d/issue/:boardKey/:issueKey/close`, connection.ID)
+	response.CloseIssuesEndpoint = fmt.Sprintf(`/plugins/webhook/%d/issue/:issueKey/close`, connection.ID)
 	response.PostPipelineTaskEndpoint = fmt.Sprintf(`/plugins/webhook/%d/cicd_tasks`, connection.ID)
 	response.PostPipelineDeployTaskEndpoint = fmt.Sprintf(`/plugins/webhook/%d/deployments`, connection.ID)
 	response.ClosePipelineEndpoint = fmt.Sprintf(`/plugins/webhook/%d/cicd_pipeline/:pipelineName/finish`, connection.ID)

--- a/backend/plugins/webhook/api/issue.go
+++ b/backend/plugins/webhook/api/issue.go
@@ -34,7 +34,6 @@ import (
 )
 
 type WebhookIssueRequest struct {
-	BoardKey                string     `mapstructure:"board_key" validate:"required"`
 	Url                     string     `mapstructure:"url"`
 	IssueKey                string     `mapstructure:"issue_key" validate:"required"`
 	Title                   string     `mapstructure:"title" validate:"required"`
@@ -65,7 +64,7 @@ type WebhookIssueRequest struct {
 
 // PostIssue
 // @Summary receive a record as defined and save it
-// @Description receive a record as follow and save it, example: {"board_key":"DLK","url":"","issue_key":"DLK-1234","title":"a feature from DLK","description":"","epic_key":"","type":"BUG","status":"TODO","original_status":"created","story_point":0,"resolution_date":null,"created_date":"2020-01-01T12:00:00+00:00","updated_date":null,"lead_time_minutes":0,"parent_issue_key":"DLK-1200","priority":"","original_estimate_minutes":0,"time_spent_minutes":0,"time_remaining_minutes":0,"creator_id":"user1131","creator_name":"Nick name 1","assignee_id":"user1132","assignee_name":"Nick name 2","severity":"","component":""}
+// @Description receive a record as follow and save it, example: {"url":"","issue_key":"DLK-1234","title":"a feature from DLK","description":"","epic_key":"","type":"BUG","status":"TODO","original_status":"created","story_point":0,"resolution_date":null,"created_date":"2020-01-01T12:00:00+00:00","updated_date":null,"lead_time_minutes":0,"parent_issue_key":"DLK-1200","priority":"","original_estimate_minutes":0,"time_spent_minutes":0,"time_remaining_minutes":0,"creator_id":"user1131","creator_name":"Nick name 1","assignee_id":"user1132","assignee_name":"Nick name 2","severity":"","component":""}
 // @Tags plugins/webhook
 // @Param body body WebhookIssueRequest true "json body"
 // @Success 200  {string} noResponse ""
@@ -94,7 +93,7 @@ func PostIssue(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, error
 	db := basicRes.GetDal()
 	domainIssue := &ticket.Issue{
 		DomainEntity: domainlayer.DomainEntity{
-			Id: fmt.Sprintf("%s:%d:%s:%s", "webhook", connection.ID, request.BoardKey, request.IssueKey),
+			Id: fmt.Sprintf("%s:%d:%s", "webhook", connection.ID, request.IssueKey),
 		},
 		Url:                     request.Url,
 		IssueKey:                request.IssueKey,
@@ -125,10 +124,10 @@ func PostIssue(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, error
 		domainIssue.AssigneeId = fmt.Sprintf("%s:%d:%s", "webhook", connection.ID, request.AssigneeId)
 	}
 	if request.ParentIssueKey != "" {
-		domainIssue.ParentIssueId = fmt.Sprintf("%s:%d:%s:%s", "webhook", connection.ID, request.BoardKey, request.ParentIssueKey)
+		domainIssue.ParentIssueId = fmt.Sprintf("%s:%d:%s", "webhook", connection.ID, request.ParentIssueKey)
 	}
 
-	domainBoardId := fmt.Sprintf("%s:%d:%s", "webhook", connection.ID, request.BoardKey)
+	domainBoardId := fmt.Sprintf("%s:%d", "webhook", connection.ID)
 
 	boardIssue := &ticket.BoardIssue{
 		BoardId: domainBoardId,
@@ -175,7 +174,7 @@ func PostIssue(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, error
 // @Success 200  {string} noResponse ""
 // @Failure 400  {string} errcode.Error "Bad Request"
 // @Failure 500  {string} errcode.Error "Internal Error"
-// @Router /plugins/webhook/:connectionId/issue/:boardKey/:issueKey/close [POST]
+// @Router /plugins/webhook/:connectionId/issue/:issueKey/close [POST]
 func CloseIssue(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
 	connection := &models.WebhookConnection{}
 	err := connectionHelper.First(connection, input.Params)
@@ -185,7 +184,7 @@ func CloseIssue(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, erro
 
 	db := basicRes.GetDal()
 	domainIssue := &ticket.Issue{}
-	err = db.First(domainIssue, dal.Where("id = ?", fmt.Sprintf("%s:%d:%s:%s", "webhook", connection.ID, input.Params[`boardKey`], input.Params[`issueKey`])))
+	err = db.First(domainIssue, dal.Where("id = ?", fmt.Sprintf("%s:%d:%s", "webhook", connection.ID, input.Params[`issueKey`])))
 	if err != nil {
 		return nil, errors.NotFound.Wrap(err, `issue not found`)
 	}

--- a/backend/plugins/webhook/impl/impl.go
+++ b/backend/plugins/webhook/impl/impl.go
@@ -84,7 +84,7 @@ func (p Webhook) ApiResources() map[string]map[string]plugin.ApiResourceHandler 
 		":connectionId/issues": {
 			"POST": api.PostIssue,
 		},
-		":connectionId/issue/:boardKey/:issueKey/close": {
+		":connectionId/issue/:issueKey/close": {
 			"POST": api.CloseIssue,
 		},
 	}


### PR DESCRIPTION
### Summary
board id can not match project_mapping row_id by webhook plugin. 
remove the boardKey, same to Jira.

### Does this close any open issues?
Closes #4574 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
