### PR TITLE
fix: fix zentao cannot run in pg; add min version tips

### DIFF
--- a/backend/plugins/zentao/models/archived/department.go
+++ b/backend/plugins/zentao/models/archived/department.go
@@ -25,7 +25,7 @@ type ZentaoDepartment struct {
 	ConnectionId uint64 `gorm:"primaryKey;type:BIGINT  NOT NULL"`
 	ID           int64  `json:"id" gorm:"primaryKey;type:BIGINT  NOT NULL" `
 	Name         string `json:"name" gorm:"type:varchar(100);index"`
-	Parent       int    `json:"parent" gorm:"type:varchar(100)"`
+	Parent       int    `json:"parent" gorm:"type:BIGINT  NOT NULL"`
 	Path         string `json:"path" gorm:"type:varchar(100)"`
 	Grade        int    `json:"grade"`
 	OrderIn      int    `json:"order"`

--- a/backend/plugins/zentao/models/department.go
+++ b/backend/plugins/zentao/models/department.go
@@ -25,7 +25,7 @@ type ZentaoDepartment struct {
 	ConnectionId uint64 `gorm:"primaryKey;type:BIGINT  NOT NULL"`
 	ID           int64  `json:"id" gorm:"primaryKey;type:BIGINT  NOT NULL" `
 	Name         string `json:"name" gorm:"type:varchar(100);index"`
-	Parent       int64  `json:"parent" gorm:"type:varchar(100)"`
+	Parent       int64  `json:"parent" gorm:"type:BIGINT  NOT NULL"`
 	Path         string `json:"path" gorm:"type:varchar(100)"`
 	Grade        int    `json:"grade"`
 	OrderIn      int    `json:"order"`

--- a/backend/plugins/zentao/models/migrationscripts/20221121_add_init_tables.go
+++ b/backend/plugins/zentao/models/migrationscripts/20221121_add_init_tables.go
@@ -36,6 +36,7 @@ func (*addInitTables) Up(basicRes context.BasicRes) errors.Error {
 		&archived.ZentaoStory{},
 		&archived.ZentaoBug{},
 		&archived.ZentaoTask{},
+		&archived.ZentaoDepartment{},
 		"_tool_zentao_bugs`",
 		"_tool_zentao_executions`",
 		"_tool_zentao_products`",
@@ -60,7 +61,7 @@ func (*addInitTables) Up(basicRes context.BasicRes) errors.Error {
 }
 
 func (*addInitTables) Version() uint64 {
-	return 20221121000001
+	return 20230303000001
 }
 
 func (*addInitTables) Name() string {

--- a/config-ui/src/plugins/register/zentao/config.ts
+++ b/config-ui/src/plugins/register/zentao/config.ts
@@ -34,7 +34,7 @@ export const ZenTaoConfig: PluginConfigType = {
       'name',
       {
         key: 'endpoint',
-        subLabel: 'Provide the Zentao instance API endpoint. E.g. https://YOUR_DOMAIN:YOUR_PORT/',
+        subLabel: 'Provide the Zentao instance API endpoint (Opensource v16+). E.g. http://<host>:<port>/zentao/api.php/v1',
       },
       'username',
       'password',


### PR DESCRIPTION
### Summary
What does this PR do?
1. fix zentao cannot run in pg; 
2. add min version tips

### Does this close any open issues?
Closes #4578 

### Screenshots
![image](https://user-images.githubusercontent.com/3294100/222627969-71d590d9-fbdb-4217-bce4-c89704efd45f.png)

All data are collected in at least 1 row.
![image](https://user-images.githubusercontent.com/3294100/222628027-e81ce41d-ce5f-41b2-806a-c5dd41233070.png)


