### PR TITLE
fix(zentao): skip tasks if relevent id is zero

### DIFF
--- a/backend/plugins/zentao/tasks/execution_collector.go
+++ b/backend/plugins/zentao/tasks/execution_collector.go
@@ -34,6 +34,9 @@ var _ plugin.SubTaskEntryPoint = CollectExecution
 
 func CollectExecution(taskCtx plugin.SubTaskContext) errors.Error {
 	data := taskCtx.GetData().(*ZentaoTaskData)
+	if data.Options.ExecutionId == 0 {
+		return nil
+	}
 	collector, err := api.NewApiCollector(api.ApiCollectorArgs{
 		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
 			Ctx: taskCtx,

--- a/backend/plugins/zentao/tasks/project_collector.go
+++ b/backend/plugins/zentao/tasks/project_collector.go
@@ -33,6 +33,9 @@ var _ plugin.SubTaskEntryPoint = CollectProject
 
 func CollectProject(taskCtx plugin.SubTaskContext) errors.Error {
 	data := taskCtx.GetData().(*ZentaoTaskData)
+	if data.Options.ProjectId == 0 {
+		return nil
+	}
 	collector, err := api.NewApiCollector(api.ApiCollectorArgs{
 		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
 			Ctx: taskCtx,

--- a/backend/plugins/zentao/tasks/task_collector.go
+++ b/backend/plugins/zentao/tasks/task_collector.go
@@ -33,6 +33,9 @@ var _ plugin.SubTaskEntryPoint = CollectTask
 
 func CollectTask(taskCtx plugin.SubTaskContext) errors.Error {
 	data := taskCtx.GetData().(*ZentaoTaskData)
+	if data.Options.ExecutionId == 0 {
+		return nil
+	}
 	collector, err := api.NewApiCollector(api.ApiCollectorArgs{
 		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
 			Ctx: taskCtx,

--- a/backend/plugins/zentao/tasks/task_data.go
+++ b/backend/plugins/zentao/tasks/task_data.go
@@ -57,5 +57,8 @@ func DecodeAndValidateTaskOptions(options map[string]interface{}) (*ZentaoOption
 	if op.ConnectionId == 0 {
 		return nil, fmt.Errorf("connectionId is invalid")
 	}
+	if op.ProductId == 0 {
+		return nil, fmt.Errorf("please set productId")
+	}
 	return &op, nil
 }


### PR DESCRIPTION
### Summary
We just skip tasks which depend on executionId if executionId is not assigned

### Does this close any open issues?
Closes #4601 

### Screenshots
when execution id is 0, we can see we didn't collect any data
<img width="849" alt="image" src="https://user-images.githubusercontent.com/39366025/223382057-6bc89de2-a0d6-47ed-8f5e-6ed6ae9465d6.png">


### Other Information
Any other information that is important to this PR.
