### PR TITLE
feat: allow protocol used in proxying to be overridden

### DIFF
--- a/config-ui/nginx.conf
+++ b/config-ui/nginx.conf
@@ -16,7 +16,7 @@ ${SERVER_CONF}
     rewrite /api/(.*) /$1  break;
     proxy_send_timeout 10s;
     proxy_read_timeout 10s;
-    proxy_pass http://$target;
+    proxy_pass ${DEVLAKE_ENDPOINT_PROTO}://$target;
   }
 
   location /grafana/ {
@@ -27,6 +27,6 @@ ${SERVER_CONF}
     proxy_set_header Authorization "";
     proxy_send_timeout 10s;
     proxy_read_timeout 10s;
-    proxy_pass http://$target;
+    proxy_pass ${GRAFANA_ENDPOINT_PROTO}://$target;
   }
 }

--- a/config-ui/nginx.sh
+++ b/config-ui/nginx.sh
@@ -26,7 +26,9 @@ if [ -n "$ADMIN_USER" ] && [ -n "$ADMIN_PASS" ]; then
 fi
 export DNS=$(grep nameserver /etc/resolv.conf | awk '{print $2}')
 export DNS_VALID=${DNS_VALID:-300s}
-envsubst '${DEVLAKE_ENDPOINT} ${GRAFANA_ENDPOINT} ${SERVER_CONF} ${DNS} ${DNS_VALID}' \
+export DEVLAKE_ENDPOINT_PROTO=${DEVLAKE_ENDPOINT_PROTO:-http}
+export GRAFANA_ENDPOINT_PROTO=${GRAFANA_ENDPOINT_PROTO:-http}
+envsubst '${DEVLAKE_ENDPOINT} ${DEVLAKE_ENDPOINT_PROTO} ${GRAFANA_ENDPOINT} ${GRAFANA_ENDPOINT_PROTO} ${SERVER_CONF} ${DNS} ${DNS_VALID}' \
     < /etc/nginx/conf.d/default.conf.tpl \
     > /etc/nginx/conf.d/default.conf
 nginx -g 'daemon off;'


### PR DESCRIPTION
### Summary
In our deployment Grafana and Devlake are using HTTPS. This change allows us to proxy to those endpoints without having to modify the image ourselves.

This should retain the existing behavior and therefore be backwards compatible.

### Does this close any open issues?
N/A
### Screenshots
N/A
### Other Information
N/A