### PR TITLE
ci: sync image tags to helm chart

### DIFF
--- a/.github/workflows/sync-helm.yml
+++ b/.github/workflows/sync-helm.yml
@@ -1,0 +1,66 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: sync-helm
+on:
+  push:
+    tags-ignore:
+      - '*test*'
+
+env:
+  HELM_CHART_REPO: incubator-devlake-helm-chart
+  TAG: ${{ github.ref_name }}
+  FORK_REPO: aFlyBird0/incubator-devlake-helm-chart
+
+jobs:
+  sync-helm-images:
+    if: (github.repository == 'apache/incubator-devlake')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Helm Chart
+        uses: actions/checkout@v3
+        with:
+          path: ${{ env.HELM_CHART_REPO }}
+          repository: apache/${{ env.HELM_CHART_REPO }}
+      - name: Update Helm Chart Image Tag
+        run: |
+          versionWithoutV=$(echo ${{ env.TAG }} | sed 's/^v//')
+          sed -i "s/imageTag: .*/imageTag: ${{ env.TAG }}/g" ${{ env.HELM_CHART_REPO }}/charts/devlake/values.yaml
+          sed -i "s/version: .*/version: ${versionWithoutV}/g" ${{ env.HELM_CHART_REPO }}/charts/devlake/Chart.yaml
+          sed -i "s/appVersion: .*/appVersion: ${{ env.TAG }}/g" ${{ env.HELM_CHART_REPO }}/charts/devlake/Chart.yaml
+      - name: Create Pull Request
+        # reference: https://github.com/peter-evans/create-pull-request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          # this GitHub Personal Access Token should have 'repo' scope to the forked repo
+          # or any other way in this link:
+          # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs
+          token: ${{ secrets.GH_PAT }}
+          path: ${{ env.HELM_CHART_REPO }}
+          branch: sync-helm-images
+          branch-suffix: timestamp
+          title: "feat: sync image tags(auto by bot)"
+          commit-message: "feat: sync image tags(auto by bot)"
+#          body: "Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action"
+          delete-branch: true
+          push-to-fork: ${{ env.FORK_REPO }}
+          # if you want to active the configuration below,
+          # you should use token with admin rights to devlake helm chart repo
+#          reviewers: user1,user2
+#          team-reviewers:
+#          assignees:
+#          labels: bot


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary

Sync devlake helm chart(by creating a pull request) when a new tag is pushed.

### Does this close any open issues?

None.

This PR is generated by the actions of my [fork repo](https://github.com/aFlyBird0/incubator-devlake/actions/runs/4355738566): https://github.com/apache/incubator-devlake-helm-chart/pull/83

### Screenshots

<img width="999" alt="image" src="https://user-images.githubusercontent.com/36830265/223470583-e742b1c8-678d-4f59-88b9-2494993a8cda.png">

<img width="1188" alt="image" src="https://user-images.githubusercontent.com/36830265/223470716-06799e33-786c-485a-9a42-41a0497dc29a.png">


### Other Information

**Note: The maintainer of devlake must do things below to set up the actions**

1. Prepare a GitHub Account(such as a bot account, this account does not need to have any permissions for any Apache projects.) and fork `incubator-devlake-helm-chart` repo
2. Apply a GitHub Personal Access Token with `repo` scope of that account, and set it to `GH_PAT` in secrets of `incubator-devlake`.
3. Update `env.FORK_REPO` to `<USER_OF_GH_PAT>/incubator-devlake-helm-chart` in `.github/workflows/sync-helm.yml`

<img width="621" alt="image" src="https://user-images.githubusercontent.com/36830265/223473159-8b920419-3891-4a3a-b8b9-7ccef9c44253.png">

4. Update other configurations in `.github/workflows/sync-helm.yml` if you want.
