### PR TITLE
refactor: Rename state table used by Singer framework

### DIFF
--- a/backend/core/models/migrationscripts/20230405_rename_tap_collector_state.go
+++ b/backend/core/models/migrationscripts/20230405_rename_tap_collector_state.go
@@ -16,3 +16,30 @@ limitations under the License.
 */
 
 package migrationscripts
+
+import (
+	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+)
+
+var _ plugin.MigrationScript = (*renameCollectorTapStateTable)(nil)
+
+type renameCollectorTapStateTable struct{}
+
+func (*renameCollectorTapStateTable) Up(basicRes context.BasicRes) errors.Error {
+	db := basicRes.GetDal()
+	err := db.RenameTable("_devlake_collector_state", "_devlake_collector_tap_state")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (*renameCollectorTapStateTable) Version() uint64 {
+	return 20230405000001
+}
+
+func (*renameCollectorTapStateTable) Name() string {
+	return "Rename Collector state table for Singer Taps"
+}

--- a/backend/core/models/migrationscripts/20230405_rename_tap_collector_state.go
+++ b/backend/core/models/migrationscripts/20230405_rename_tap_collector_state.go
@@ -1,0 +1,18 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts

--- a/backend/core/models/migrationscripts/register.go
+++ b/backend/core/models/migrationscripts/register.go
@@ -75,5 +75,6 @@ func All() []plugin.MigrationScript {
 		new(addCommitShaIndex),
 		new(removeCreatedDateAfterFromCollectorMeta20230223),
 		new(addHostNamespaceRepoName),
+		new(renameCollectorTapStateTable),
 	}
 }

--- a/backend/helpers/pluginhelper/tap/models.go
+++ b/backend/helpers/pluginhelper/tap/models.go
@@ -58,7 +58,7 @@ type (
 
 // TableName the table name
 func (*RawState) TableName() string {
-	return "_devlake_collector_state"
+	return "_devlake_collector_tap_state"
 }
 
 // FromState converts State to RawState


### PR DESCRIPTION
### Summary
Rename the table used by singer-tap state tracking logic so it's not confused by the one already used by the normal state table. 

### Does this close any open issues?
Closes #4249 

### Screenshots
![image](https://user-images.githubusercontent.com/25063936/230224106-b9117d6b-eaf0-4c91-9831-4f6a78de367c.png)

### Other Information
Any other information that is important to this PR.
