### PR TITLE
fix: jira error on unMarshaling RemotelinkRepoPattern

### DIFF
--- a/backend/plugins/jira/tasks/task_data.go
+++ b/backend/plugins/jira/tasks/task_data.go
@@ -74,14 +74,19 @@ func (r *JiraTransformationRule) ToDb() (*models.JiraTransformationRule, errors.
 
 func MakeTransformationRules(rule models.JiraTransformationRule) (*JiraTransformationRule, errors.Error) {
 	var typeMapping TypeMappings
-	err := json.Unmarshal(rule.TypeMappings, &typeMapping)
-	if err != nil {
-		return nil, errors.Default.Wrap(err, "unable to unmarshal the typeMapping")
+	var err error
+	if len(rule.TypeMappings) > 0 {
+		err = json.Unmarshal(rule.TypeMappings, &typeMapping)
+		if err != nil {
+			return nil, errors.Default.Wrap(err, "unable to unmarshal the typeMapping")
+		}
 	}
 	var remotelinkRepoPattern []string
-	err = json.Unmarshal(rule.RemotelinkRepoPattern, &remotelinkRepoPattern)
-	if err != nil {
-		return nil, errors.Default.Wrap(err, "error unMarshaling RemotelinkRepoPattern")
+	if len(rule.RemotelinkRepoPattern) > 0 {
+		err = json.Unmarshal(rule.RemotelinkRepoPattern, &remotelinkRepoPattern)
+		if err != nil {
+			return nil, errors.Default.Wrap(err, "error unMarshaling RemotelinkRepoPattern")
+		}
 	}
 	result := &JiraTransformationRule{
 		Name:                       rule.Name,

--- a/backend/plugins/jira/tasks/task_data_test.go
+++ b/backend/plugins/jira/tasks/task_data_test.go
@@ -1,0 +1,84 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/plugins/jira/models"
+)
+
+func TestMakeTransformationRules(t *testing.T) {
+	type args struct {
+		rule models.JiraTransformationRule
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  *JiraTransformationRule
+		want1 errors.Error
+	}{
+		{"non-null RemotelinkRepoPattern",
+			args{rule: models.JiraTransformationRule{
+				Name:                       "name",
+				EpicKeyField:               "epic",
+				StoryPointField:            "story",
+				RemotelinkCommitShaPattern: "commit sha pattern",
+				RemotelinkRepoPattern:      []byte(`["abc","efg"]`),
+				TypeMappings:               []byte(`{"10040":{"standardType":"Incident","statusMappings":null}}`),
+			}},
+			&JiraTransformationRule{
+				Name:                       "name",
+				EpicKeyField:               "epic",
+				StoryPointField:            "story",
+				RemotelinkCommitShaPattern: "commit sha pattern",
+				RemotelinkRepoPattern:      []string{"abc", "efg"},
+				TypeMappings: map[string]TypeMapping{"10040": {
+					StandardType:   "Incident",
+					StatusMappings: nil,
+				}},
+			},
+			nil,
+		},
+
+		{"null RemotelinkRepoPattern",
+			args{rule: models.JiraTransformationRule{
+				RemotelinkRepoPattern: nil,
+				TypeMappings:          nil,
+			}},
+			&JiraTransformationRule{
+				RemotelinkRepoPattern: nil,
+				TypeMappings:          nil,
+			},
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := MakeTransformationRules(tt.args.rule)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MakeTransformationRules() got = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(got1, tt.want1) {
+				t.Errorf("MakeTransformationRules() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary
Fix #4637 
The default value of `_tool_jira_transformation_rules.remotelink_repo_pattern` in the database could not be unmarshaled into a string slice.

### Does this close any open issues?
Closes #4637 

### Screenshots
![image](https://user-images.githubusercontent.com/8455907/224222544-ef75100d-a38f-4e44-b4fd-1f5891bf7bc1.png)

