### PR TITLE
fix(Makefile): wrong python-dep path

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -29,7 +29,7 @@ go-dep:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
 
 python-dep:
-	pip install -r requirements.txt
+	pip install -r python/requirements.txt
 
 dep: go-dep python-dep
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
It seems that the target `python-dep` has the wrong path.
