### PR TITLE
fix: decrease page size for github graphql pr collector

### DIFF
--- a/backend/plugins/github_graphql/tasks/pr_collector.go
+++ b/backend/plugins/github_graphql/tasks/pr_collector.go
@@ -164,7 +164,7 @@ func CollectPr(taskCtx plugin.SubTaskContext) errors.Error {
 
 	err = collectorWithState.InitGraphQLCollector(api.GraphqlCollectorArgs{
 		GraphqlClient: data.GraphqlClient,
-		PageSize:      30,
+		PageSize:      10,
 		Incremental:   incremental,
 		/*
 			(Optional) Return query string for request, or you can plug them into UrlTemplate directly


### PR DESCRIPTION
### Summary
![image](https://user-images.githubusercontent.com/3294100/225218233-329b9254-720d-4c73-8dfc-69fa44c8fd20.png)

fix: decrease page size for github graphql pr collector

It may slow than the old pr collector about 20%.

### Does this close any open issues?
Related to #3708
