### PR TITLE
Fix type annotations

### DIFF
--- a/backend/python/pydevlake/pydevlake/domain_layer/code.py
+++ b/backend/python/pydevlake/pydevlake/domain_layer/code.py
@@ -75,7 +75,7 @@ class Commit(NoPKModel, table=True):
     __tablename__ = 'commits'
     sha: str = Field(primary_key=True)
     additions: str
-    deletions: str = Optional[str]
+    deletions: Optional[str]
     dev_eq: Optional[str]
     message: str
     author_name: str

--- a/backend/python/pydevlake/pydevlake/domain_layer/devops.py
+++ b/backend/python/pydevlake/pydevlake/domain_layer/devops.py
@@ -83,7 +83,7 @@ class CICDTask(DomainModel, table=True):
     __tablename__ = 'cicd_tasks'
     name: str
     pipeline_id: str
-    result: str = Optional[CICDResult]
+    result: Optional[CICDResult]
     status: Optional[CICDStatus]
     type: Optional[CICDType]
     environment: Optional[CICDEnvironment]


### PR DESCRIPTION
### Summary
I don't think these are right. Without this change it seems as though the value in the DB will always be set to something like:

```
typing.Optional[pydevlake.domain_layer.devops.CICDResult]
```


### Does this close any open issues?
N/A

### Screenshots
N/A

### Other Information
N/A
