### PR TITLE
fix: decrease page size for github graphql job collector

### DIFF
--- a/backend/plugins/github_graphql/tasks/job_collector.go
+++ b/backend/plugins/github_graphql/tasks/job_collector.go
@@ -140,7 +140,7 @@ func CollectGraphqlJobs(taskCtx plugin.SubTaskContext) errors.Error {
 
 	err = collectorWithState.InitGraphQLCollector(helper.GraphqlCollectorArgs{
 		Input:         iterator,
-		InputStep:     60,
+		InputStep:     20,
 		Incremental:   incremental,
 		GraphqlClient: data.GraphqlClient,
 		BuildQuery: func(reqData *helper.GraphqlRequestData) (interface{}, map[string]interface{}, error) {


### PR DESCRIPTION
### Summary
fix: decrease page size for github graphql pr collector

It may slow than the old pr collector about 20%.

### Does this close any open issues?
Related to #3708 
