### PR TITLE
Cherry pick 4670 to v0.16 - fix: nginx timeout is too short causing download log fails with 504

### DIFF
--- a/config-ui/nginx.conf
+++ b/config-ui/nginx.conf
@@ -14,8 +14,8 @@ ${SERVER_CONF}
     resolver_timeout 3s;
     set $target "${DEVLAKE_ENDPOINT}";
     rewrite /api/(.*) /$1  break;
-    proxy_send_timeout 10s;
-    proxy_read_timeout 10s;
+    proxy_send_timeout 60s;
+    proxy_read_timeout 60s;
     proxy_pass http://$target;
   }
 
@@ -25,8 +25,7 @@ ${SERVER_CONF}
     set $target "${GRAFANA_ENDPOINT}";
     rewrite /grafana/(.*) /$1  break;
     proxy_set_header Authorization "";
-    proxy_send_timeout 10s;
-    proxy_read_timeout 10s;
+    proxy_send_timeout 60s;
+    proxy_read_timeout 60s;
     proxy_pass http://$target;
-  }
 }


### PR DESCRIPTION
### Summary
Cherry pick #4670 to v0.16 
