### PR TITLE
fix(tapd): return nil if row data is an empty array

### DIFF
--- a/backend/plugins/tapd/tasks/bug_status_extractor.go
+++ b/backend/plugins/tapd/tasks/bug_status_extractor.go
@@ -40,6 +40,9 @@ func ExtractBugStatus(taskCtx plugin.SubTaskContext) errors.Error {
 	extractor, err := api.NewApiExtractor(api.ApiExtractorArgs{
 		RawDataSubTaskArgs: *rawDataSubTaskArgs,
 		Extract: func(row *api.RawData) ([]interface{}, errors.Error) {
+			if string(row.Data) == "[]" {
+				return nil, nil
+			}
 			var statusRes struct {
 				Data map[string]string
 			}

--- a/backend/plugins/tapd/tasks/story_status_extractor.go
+++ b/backend/plugins/tapd/tasks/story_status_extractor.go
@@ -40,6 +40,9 @@ func ExtractStoryStatus(taskCtx plugin.SubTaskContext) errors.Error {
 	extractor, err := api.NewApiExtractor(api.ApiExtractorArgs{
 		RawDataSubTaskArgs: *rawDataSubTaskArgs,
 		Extract: func(row *api.RawData) ([]interface{}, errors.Error) {
+			if string(row.Data) == "[]" {
+				return nil, nil
+			}
 			var storyStatusRes struct {
 				Data map[string]string
 			}


### PR DESCRIPTION
### Summary
Tapd sometimes return `[]` for bugStatus and storyStatus, so we can just return nil if we meet this situation.

### Does this close any open issues?
part of  #4680 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
