### PR TITLE
fix: add missing go struct tags

### DIFF
--- a/backend/plugins/org/api/types.go
+++ b/backend/plugins/org/api/types.go
@@ -243,9 +243,9 @@ func (*team) fakeData() []team {
 }
 
 type projectMapping struct {
-	ProjectName string
-	Table       string
-	RowId       string
+	ProjectName string `csv:"project_name"`
+	Table       string `csv:"table"`
+	RowId       string `csv:"row_id"`
 }
 
 func (*projectMapping) fromDomainLayer(tt []crossdomain.ProjectMapping) []projectMapping {


### PR DESCRIPTION
### Summary
Without this change doing:

```
$ curl -X'PUT' -F 'file=@backend/plugins/dora/e2e/raw_tables/project_mapping.csv' 'http://localhost:8080/plugins/org/project_mapping.csv'
```

Inserts the following into the DB (`SELECT * FROM project_mapping;`):

```

project_name|table|row_id|created_at             |updated_at             |_raw_data_params|_raw_data_table|_raw_data_id|_raw_data_remark|
------------+-----+------+-----------------------+-----------------------+----------------+---------------+------------+----------------+
            |     |      |2023-03-16 17:27:12.826|2023-03-16 17:27:12.826|                |               |           0|                |
```

With this change you get what you expect:

```
project_name|table      |row_id|created_at             |updated_at             |_raw_data_params|_raw_data_table|_raw_data_id|_raw_data_remark|
------------+-----------+------+-----------------------+-----------------------+----------------+---------------+------------+----------------+
project1    |boards     |board1|2023-03-16 17:29:33.942|2023-03-16 17:29:33.942|                |               |           0|                |
project1    |boards     |board2|2023-03-16 17:29:33.942|2023-03-16 17:29:33.942|                |               |           0|                |
project1    |cicd_scopes|cicd1 |2023-03-16 17:29:33.942|2023-03-16 17:29:33.942|                |               |           0|                |
project1    |cicd_scopes|cicd2 |2023-03-16 17:29:33.942|2023-03-16 17:29:33.942|                |               |           0|                |
project1    |repos      |repo1 |2023-03-16 17:29:33.942|2023-03-16 17:29:33.942|                |               |           0|                |
project1    |repos      |repo2 |2023-03-16 17:29:33.942|2023-03-16 17:29:33.942|                |               |           0|                |
project2    |boards     |board3|2023-03-16 17:29:33.942|2023-03-16 17:29:33.942|                |               |           0|                |
project2    |cicd_scopes|cicd3 |2023-03-16 17:29:33.942|2023-03-16 17:29:33.942|                |               |           0|                |
```

### Does this close any open issues?
N/A

### Screenshots
N/A

### Other Information
The other structs in this file `user`, `account` etc. will presumably also be broken. For some of those cases I wasn't sure what columns in the CSV maps to which field. For example, I wasn't sure what `user.TeamIds` should be when importing `backend/plugins/org/e2e/raw_tables/users.csv`. I've left this unchanged because it's not blocking me right now.