### PR TITLE
fix(config-ui): missed timeAfter after change data scope

### DIFF
--- a/config-ui/src/pages/blueprint/detail/panel/configuration.tsx
+++ b/config-ui/src/pages/blueprint/detail/panel/configuration.tsx
@@ -96,7 +96,7 @@ export const Configuration = ({ blueprint, operating, onUpdate, onRefresh }: Pro
   const handleUpdateConnection = (updated: any) =>
     onUpdate({
       settings: {
-        version: '2.0.0',
+        ...blueprint.settings,
         connections: blueprint.settings.connections.map((cs) =>
           cs.plugin === updated.plugin && cs.connectionId === updated.connectionId ? updated : cs,
         ),


### PR DESCRIPTION
### Summary
Missed `timeAfter` after change data scope.

