### PR TITLE
feat: set project mapping by plugin org

### DIFF
--- a/backend/core/dal/dal.go
+++ b/backend/core/dal/dal.go
@@ -19,6 +19,7 @@ package dal
 
 import (
 	"database/sql"
+	"fmt"
 	"reflect"
 
 	"github.com/apache/incubator-devlake/core/errors"
@@ -239,7 +240,8 @@ func GetPrimarykeyColumnNames(d Dal, dst Tabler) (names []string, err errors.Err
 		return
 	}
 	for _, pkColumn := range pkColumns {
-		names = append(names, pkColumn.Name())
+		// in case the column name is a reserved identifier
+		names = append(names, fmt.Sprintf("%s.%s", dst.TableName(), pkColumn.Name()))
 	}
 	return
 }

--- a/backend/core/plugin/plugin_blueprint.go
+++ b/backend/core/plugin/plugin_blueprint.go
@@ -141,6 +141,11 @@ type MetricPluginBlueprintV200 interface {
 	MakeMetricPluginPipelinePlanV200(projectName string, options json.RawMessage) (PipelinePlan, errors.Error)
 }
 
+// ProjectMapper is implemented by the plugin org, which binding project and scopes
+type ProjectMapper interface {
+	MapProject(projectName string, scopes []Scope) (PipelinePlan, errors.Error)
+}
+
 // CompositeDataSourcePluginBlueprintV200 is for unit test
 type CompositeDataSourcePluginBlueprintV200 interface {
 	PluginMeta
@@ -153,11 +158,17 @@ type CompositeMetricPluginBlueprintV200 interface {
 	MetricPluginBlueprintV200
 }
 
-// CompositeMetricPluginBlueprintV200 is for unit test
+// CompositePluginBlueprintV200 is for unit test
 type CompositePluginBlueprintV200 interface {
 	PluginMeta
 	DataSourcePluginBlueprintV200
 	MetricPluginBlueprintV200
+}
+
+// CompositeProjectMapper is for unit test
+type CompositeProjectMapper interface {
+	PluginMeta
+	ProjectMapper
 }
 
 type BlueprintSyncPolicy struct {

--- a/backend/plugins/org/api/types.go
+++ b/backend/plugins/org/api/types.go
@@ -18,9 +18,11 @@ limitations under the License.
 package api
 
 import (
+	"strings"
+
+	"github.com/apache/incubator-devlake/core/models/common"
 	"github.com/apache/incubator-devlake/core/models/domainlayer"
 	"github.com/apache/incubator-devlake/core/models/domainlayer/crossdomain"
-	"strings"
 )
 
 const TimeFormat = "2006-01-02"
@@ -267,6 +269,12 @@ func (*projectMapping) toDomainLayer(tt []projectMapping) []*crossdomain.Project
 			ProjectName: t.ProjectName,
 			Table:       t.Table,
 			RowId:       t.RowId,
+			NoPKModel: common.NoPKModel{
+				RawDataOrigin: common.RawDataOrigin{
+					// set the RawDataParams equals to projectName. In the case of importing from CSV file, records would be deleted in terms of this field
+					RawDataParams: t.ProjectName,
+				},
+			},
 		})
 	}
 	return result

--- a/backend/plugins/org/e2e/project_mapping_test.go
+++ b/backend/plugins/org/e2e/project_mapping_test.go
@@ -1,0 +1,75 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/apache/incubator-devlake/core/models/domainlayer/crossdomain"
+	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/helpers/e2ehelper"
+	"github.com/apache/incubator-devlake/plugins/org/impl"
+	"github.com/apache/incubator-devlake/plugins/org/tasks"
+)
+
+type scope struct {
+	id        string
+	tableName string
+}
+
+func (s scope) ScopeId() string {
+	return s.id
+}
+
+func (s scope) ScopeName() string {
+	panic("implement me")
+}
+
+func (s scope) TableName() string {
+	return s.tableName
+}
+
+func TestProjectMappingDataFlow(t *testing.T) {
+	dataflowTester := e2ehelper.NewDataFlowTester(t, "org", impl.Org{})
+	scopes := []plugin.Scope{scope{
+		id:        "bitbucket:BitbucketRepo:4:thenicetgp/lake",
+		tableName: "boards",
+	}, scope{
+		id:        "github:GithubRepo:1:1",
+		tableName: "repos",
+	}}
+	taskData := &tasks.TaskData{
+		Options: &tasks.Options{
+			ProjectMappings: []tasks.ProjectMapping{tasks.NewProjectMapping("my_project", scopes)},
+		},
+	}
+
+	// import raw data table
+	dataflowTester.FlushTabler(&crossdomain.ProjectMapping{})
+
+	dataflowTester.Subtask(tasks.SetProjectMappingMeta, taskData)
+	dataflowTester.VerifyTable(
+		crossdomain.ProjectMapping{},
+		"./snapshot_tables/project_mapping.csv",
+		e2ehelper.ColumnWithRawData(
+			"project_name",
+			"table",
+			"row_id",
+		),
+	)
+}

--- a/backend/plugins/org/e2e/snapshot_tables/project_mapping.csv
+++ b/backend/plugins/org/e2e/snapshot_tables/project_mapping.csv
@@ -1,0 +1,3 @@
+project_name,table,row_id,_raw_data_params,_raw_data_table,_raw_data_id,_raw_data_remark
+my_project,boards,bitbucket:BitbucketRepo:4:thenicetgp/lake,my_project,,0,
+my_project,repos,github:GithubRepo:1:1,my_project,,0,

--- a/backend/plugins/org/tasks/project_mapping.go
+++ b/backend/plugins/org/tasks/project_mapping.go
@@ -1,0 +1,69 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"github.com/apache/incubator-devlake/core/dal"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/models/common"
+	"github.com/apache/incubator-devlake/core/models/domainlayer/crossdomain"
+	"github.com/apache/incubator-devlake/core/plugin"
+)
+
+var SetProjectMappingMeta = plugin.SubTaskMeta{
+	Name:             "setProjectMapping",
+	EntryPoint:       SetProjectMapping,
+	EnabledByDefault: true,
+	Description:      "set project mapping",
+	DomainTypes:      []string{plugin.DOMAIN_TYPE_CROSS},
+}
+
+// SetProjectMapping binds projects and scopes
+func SetProjectMapping(taskCtx plugin.SubTaskContext) errors.Error {
+	db := taskCtx.GetDal()
+	data := taskCtx.GetData().(*TaskData)
+	var err errors.Error
+
+	for _, mapping := range data.Options.ProjectMappings {
+		err = db.Delete(&crossdomain.ProjectMapping{}, dal.Where("project_name = ?", mapping.ProjectName))
+		if err != nil {
+			return err
+		}
+		var projectMappings []crossdomain.ProjectMapping
+		for _, scope := range mapping.Scopes {
+			projectMappings = append(projectMappings, crossdomain.ProjectMapping{
+				ProjectName: mapping.ProjectName,
+				Table:       scope.Table,
+				RowId:       scope.RowID,
+				NoPKModel: common.NoPKModel{
+					RawDataOrigin: common.RawDataOrigin{
+						// set the RawDataParams equals to projectName. In the case of importing from CSV file, records would be deleted in terms of this field
+						RawDataParams: mapping.ProjectName,
+					},
+				},
+			})
+		}
+		if len(projectMappings) > 0 {
+			err = db.CreateOrUpdate(projectMappings)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/backend/plugins/org/tasks/task_data.go
+++ b/backend/plugins/org/tasks/task_data.go
@@ -17,8 +17,38 @@ limitations under the License.
 
 package tasks
 
+import "github.com/apache/incubator-devlake/core/plugin"
+
 type Options struct {
-	ConnectionId uint64 `json:"connectionId"`
+	ConnectionId    uint64           `json:"connectionId"`
+	ProjectMappings []ProjectMapping `json:"projectMappings"`
+}
+
+// ProjectMapping represents the relations between project and scopes
+type ProjectMapping struct {
+	ProjectName string  `json:"projectName"`
+	Scopes      []Scope `json:"scopes"`
+}
+
+// Scope represents a scope by specifies the table and id
+type Scope struct {
+	Table string `json:"table"`
+	RowID string `json:"rowId"`
+}
+
+// NewProjectMapping is the construct function of ProjectMapping
+func NewProjectMapping(projectName string, pluginScopes []plugin.Scope) ProjectMapping {
+	var scopes []Scope
+	for _, ps := range pluginScopes {
+		scopes = append(scopes, Scope{
+			Table: ps.TableName(),
+			RowID: ps.ScopeId(),
+		})
+	}
+	return ProjectMapping{
+		ProjectName: projectName,
+		Scopes:      scopes,
+	}
 }
 
 type TaskData struct {


### PR DESCRIPTION
### Summary
The binding between project and scopes is performed by the subtask `SetProjectMapping`.  We defined a new interface `ProjectMapper` implemented by the plugin org. While creating the blueprint, the framework will find the org plugin and invoke its `MapProject` method. 

### Does this close any open issues?
Closes #4534

### Screenshots
Include any relevant screenshots here.

