### PR TITLE
fix: add db close connection

### DIFF
--- a/backend/plugins/starrocks/tasks/tasks.go
+++ b/backend/plugins/starrocks/tasks/tasks.go
@@ -78,6 +78,12 @@ func ExportData(c plugin.SubTaskContext) errors.Error {
 		return errors.Convert(err)
 	}
 	starrocksDb := dalgorm.NewDalgorm(sr)
+	
+	sqlStarrocksDB, err := sr.DB()
+	if err != nil {
+		return errors.Convert(err)
+	}
+	defer sqlStarrocksDB.Close()
 
 	for _, table := range starrocksTables {
 		select {
@@ -414,6 +420,11 @@ func getDbInstance(c plugin.SubTaskContext) (db dal.Dal, err error) {
 			return nil, errors.NotFound.New(fmt.Sprintf("unsupported source type %s", config.SourceType))
 		}
 		db = dalgorm.NewDalgorm(o)
+		sqlDB, err := o.DB()
+		if err != nil {
+			return nil, err
+		}
+		defer sqlDB.Close()
 	} else {
 		db = c.GetDal()
 	}

--- a/backend/plugins/starrocks/tasks/tasks.go
+++ b/backend/plugins/starrocks/tasks/tasks.go
@@ -78,7 +78,6 @@ func ExportData(c plugin.SubTaskContext) errors.Error {
 		return errors.Convert(err)
 	}
 	starrocksDb := dalgorm.NewDalgorm(sr)
-	
 	sqlStarrocksDB, err := sr.DB()
 	if err != nil {
 		return errors.Convert(err)


### PR DESCRIPTION
### Summary
add gorm close.

When using GORM to connect to the database, if you do not manually call the db.Close() method to close the connection, the connection will be returned to the GORM connection pool after the program is executed. At this point, the state of the connection will change to "idle", indicating that the connection is idle and available for other requests.

In GORM, if there is no connection available in the connection pool, then GORM will create a new connection. If there is a free connection in the connection pool, GORM will get a connection from the connection pool and assign it to the request.

Under normal circumstances, there should always be some idle connections in the connection pool, so as to meet the needs of concurrent requests. If the number of idle connections in the connection pool is low, it may cause requests to wait for a long time to obtain a connection, thereby affecting the performance of the application.

Therefore, although it is not necessary to explicitly call the db.Close() method to close the connection when using GORM to connect to the database, it is recommended to call this method explicitly before the program exits to ensure that the connection in the connection pool is released and avoid "idle" Too many connections cause the connection pool to fail, thereby affecting the performance of the application.

### Does this close any open issues?
Closes #4711 

### Screenshots
![img_v2_93e99a5e-a708-4c92-8bfb-8cef800b346g](https://user-images.githubusercontent.com/101256042/226257891-a4b5d15b-384a-4e29-b339-0dde3b996494.jpg)


### Other Information
Any other information that is important to this PR.
