### PR TITLE
fix: save the epic type issues as well as the normal issues

### DIFF
--- a/backend/plugins/jira/tasks/epic_extractor.go
+++ b/backend/plugins/jira/tasks/epic_extractor.go
@@ -54,7 +54,7 @@ func ExtractEpics(taskCtx plugin.SubTaskContext) errors.Error {
 			Table: RAW_EPIC_TABLE,
 		},
 		Extract: func(row *api.RawData) ([]interface{}, errors.Error) {
-			return extractIssues(data, mappings, true, row)
+			return extractIssues(data, mappings, row)
 		},
 	})
 	if err != nil {

--- a/backend/plugins/jira/tasks/issue_extractor.go
+++ b/backend/plugins/jira/tasks/issue_extractor.go
@@ -75,7 +75,7 @@ func ExtractIssues(taskCtx plugin.SubTaskContext) errors.Error {
 			Table: RAW_ISSUE_TABLE,
 		},
 		Extract: func(row *api.RawData) ([]interface{}, errors.Error) {
-			return extractIssues(data, mappings, false, row)
+			return extractIssues(data, mappings, row)
 		},
 	})
 	if err != nil {
@@ -84,7 +84,7 @@ func ExtractIssues(taskCtx plugin.SubTaskContext) errors.Error {
 	return extractor.Execute()
 }
 
-func extractIssues(data *JiraTaskData, mappings *typeMappings, ignoreBoard bool, row *api.RawData) ([]interface{}, errors.Error) {
+func extractIssues(data *JiraTaskData, mappings *typeMappings, row *api.RawData) ([]interface{}, errors.Error) {
 	var apiIssue apiv2models.Issue
 	err := errors.Convert(json.Unmarshal(row.Data, &apiIssue))
 	if err != nil {
@@ -156,13 +156,11 @@ func extractIssues(data *JiraTaskData, mappings *typeMappings, ignoreBoard bool,
 			results = append(results, user)
 		}
 	}
-	if !ignoreBoard {
-		results = append(results, &models.JiraBoardIssue{
-			ConnectionId: data.Options.ConnectionId,
-			BoardId:      data.Options.BoardId,
-			IssueId:      issue.IssueId,
-		})
-	}
+	results = append(results, &models.JiraBoardIssue{
+		ConnectionId: data.Options.ConnectionId,
+		BoardId:      data.Options.BoardId,
+		IssueId:      issue.IssueId,
+	})
 	labels := apiIssue.Fields.Labels
 	for _, v := range labels {
 		issueLabel := &models.JiraIssueLabel{


### PR DESCRIPTION
### Summary
The Jira `Epic` issues were not saved in the previous versions. It is fixed by storing them in the table `_tool_jirta_board_issues`, `board_issues`, and `issues`.

### Does this close any open issues?
Closes #4549
