### PR TITLE
feat: add prepareFirstToken api; update tr helper decode type

### DIFF
--- a/backend/core/plugin/plugin_connection_abstract.go
+++ b/backend/core/plugin/plugin_connection_abstract.go
@@ -31,13 +31,6 @@ type ApiConnection interface {
 	GetRateLimitPerHour() int
 }
 
-type QueryData struct {
-	Page    int    `json:"page"`
-	PerPage int    `json:"per_page"`
-	Tag     string `json:"tag"`
-	Search  []string
-}
-
 // ApiAuthenticator is to be implemented by a Concreate Connection if Authorization is required
 type ApiAuthenticator interface {
 	// SetupAuthentication is a hook function for connection to set up authentication for the HTTP request

--- a/backend/helpers/pluginhelper/api/iso8601time_test.go
+++ b/backend/helpers/pluginhelper/api/iso8601time_test.go
@@ -70,17 +70,17 @@ func TestIso8601Time(t *testing.T) {
 		assert.Nil(t, err)
 
 		var record2 Iso8601TimeRecord
-		err = DecodeMapStruct(ms, &record2)
+		err = DecodeMapStruct(ms, &record2, true)
 		assert.Nil(t, err)
 		assert.Equal(t, expected, record2.Created.ToTime().UTC())
 
 		var record3 Iso8601TimeRecordP
-		err = DecodeMapStruct(ms, &record3)
+		err = DecodeMapStruct(ms, &record3, true)
 		assert.Nil(t, err)
 		assert.Equal(t, expected, record3.Created.ToTime().UTC())
 
 		var record4 TimeRecord
-		err = DecodeMapStruct(ms, &record4)
+		err = DecodeMapStruct(ms, &record4, true)
 		assert.Nil(t, err)
 		assert.Equal(t, expected, record4.Created.UTC())
 	}

--- a/backend/helpers/pluginhelper/api/mapstructure_test.go
+++ b/backend/helpers/pluginhelper/api/mapstructure_test.go
@@ -45,7 +45,7 @@ func TestDecodeMapStructJsonRawMessage(t *testing.T) {
 		Settings: json.RawMessage(`{"version": "1.0.101"}`),
 		Existing: json.RawMessage(`{"hello", "world"}`),
 	}
-	err := DecodeMapStruct(input, decoded)
+	err := DecodeMapStruct(input, decoded, true)
 	fmt.Println(string(decoded.Settings))
 	assert.Nil(t, err)
 	assert.Equal(t, decoded.Id, 100)

--- a/backend/helpers/pluginhelper/api/scope_helper.go
+++ b/backend/helpers/pluginhelper/api/scope_helper.go
@@ -81,7 +81,7 @@ func (c *ScopeApiHelper[Conn, Scope, Tr]) Put(input *plugin.ApiResourceInput) (*
 	var req struct {
 		Data []*Scope `json:"data"`
 	}
-	err := errors.Convert(DecodeMapStruct(input.Body, &req))
+	err := errors.Convert(DecodeMapStruct(input.Body, &req, true))
 	if err != nil {
 		return nil, errors.BadInput.Wrap(err, "decoding scope error")
 	}
@@ -143,7 +143,7 @@ func (c *ScopeApiHelper[Conn, Scope, Tr]) Update(input *plugin.ApiResourceInput,
 	if err != nil {
 		return &plugin.ApiResourceOutput{Body: nil, Status: http.StatusInternalServerError}, errors.Default.New("getting Scope error")
 	}
-	err = DecodeMapStruct(input.Body, &scope)
+	err = DecodeMapStruct(input.Body, &scope, true)
 	if err != nil {
 		return &plugin.ApiResourceOutput{Body: nil, Status: http.StatusInternalServerError}, errors.Default.Wrap(err, "patch scope error")
 	}

--- a/backend/helpers/pluginhelper/api/transformation_rule_helper.go
+++ b/backend/helpers/pluginhelper/api/transformation_rule_helper.go
@@ -58,7 +58,7 @@ func (t TransformationRuleHelper[Tr]) Create(input *plugin.ApiResourceInput) (*p
 		return nil, errors.Default.Wrap(e, "the connection ID should be an non-zero integer")
 	}
 	var rule Tr
-	if err := DecodeMapStruct(input.Body, &rule); err != nil {
+	if err := DecodeMapStruct(input.Body, &rule, false); err != nil {
 		return nil, errors.Default.Wrap(err, "error in decoding transformation rule")
 	}
 	if t.validator != nil {
@@ -90,7 +90,7 @@ func (t TransformationRuleHelper[Tr]) Update(input *plugin.ApiResourceInput) (*p
 	if err != nil {
 		return nil, errors.Default.Wrap(err, "error on saving TransformationRule")
 	}
-	err = DecodeMapStruct(input.Body, &old)
+	err = DecodeMapStruct(input.Body, &old, false)
 	if err != nil {
 		return nil, errors.Default.Wrap(err, "error decoding map into transformationRule")
 	}

--- a/backend/helpers/pluginhelper/api/transformation_rule_helper.go
+++ b/backend/helpers/pluginhelper/api/transformation_rule_helper.go
@@ -28,7 +28,6 @@ import (
 	"github.com/apache/incubator-devlake/core/log"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/go-playground/validator/v10"
-	"github.com/mitchellh/mapstructure"
 )
 
 // TransformationRuleHelper is used to write the CURD of transformation rule
@@ -59,17 +58,20 @@ func (t TransformationRuleHelper[Tr]) Create(input *plugin.ApiResourceInput) (*p
 		return nil, errors.Default.Wrap(e, "the connection ID should be an non-zero integer")
 	}
 	var rule Tr
-	err := Decode(input.Body, &rule, t.validator)
-	if err != nil {
-		return nil, errors.BadInput.Wrap(err, "error in decoding transformation rule")
+	if err := DecodeMapStruct(input.Body, &rule); err != nil {
+		return nil, errors.Default.Wrap(err, "error in decoding transformation rule")
+	}
+	if t.validator != nil {
+		if err := t.validator.Struct(rule); err != nil {
+			return nil, errors.Default.Wrap(err, "error validating transformation rule")
+		}
 	}
 	valueConnectionId := reflect.ValueOf(&rule).Elem().FieldByName("ConnectionId")
 	if valueConnectionId.IsValid() {
 		valueConnectionId.SetUint(connectionId)
 	}
 
-	err = t.db.Create(&rule)
-	if err != nil {
+	if err := t.db.Create(&rule); err != nil {
 		if t.db.IsDuplicationError(err) {
 			return nil, errors.BadInput.New("there was a transformation rule with the same name, please choose another name")
 		}
@@ -88,7 +90,7 @@ func (t TransformationRuleHelper[Tr]) Update(input *plugin.ApiResourceInput) (*p
 	if err != nil {
 		return nil, errors.Default.Wrap(err, "error on saving TransformationRule")
 	}
-	err = errors.Convert(mapstructure.Decode(input.Body, &old))
+	err = DecodeMapStruct(input.Body, &old)
 	if err != nil {
 		return nil, errors.Default.Wrap(err, "error decoding map into transformationRule")
 	}

--- a/backend/plugins/bamboo/api/remote.go
+++ b/backend/plugins/bamboo/api/remote.go
@@ -45,7 +45,7 @@ import (
 func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
 	return remoteHelper.GetScopesFromRemote(input,
 		nil,
-		func(basicRes context2.BasicRes, gid string, queryData *plugin.QueryData, connection models.BambooConnection) ([]models.ApiBambooProject, errors.Error) {
+		func(basicRes context2.BasicRes, gid string, queryData *api.RemoteQueryData, connection models.BambooConnection) ([]models.ApiBambooProject, errors.Error) {
 			query := initialQuery(queryData)
 			// create api client
 			apiClient, err := api.NewApiClientFromConnection(context.TODO(), basicRes, &connection)
@@ -82,7 +82,7 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 // @Router /plugins/bamboo/connections/{connectionId}/search-remote-scopes [GET]
 func SearchRemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
 	return remoteHelper.SearchRemoteScopes(input,
-		func(basicRes context2.BasicRes, queryData *plugin.QueryData, connection models.BambooConnection) ([]models.ApiBambooProject, errors.Error) {
+		func(basicRes context2.BasicRes, queryData *api.RemoteQueryData, connection models.BambooConnection) ([]models.ApiBambooProject, errors.Error) {
 			apiClient, err := api.NewApiClientFromConnection(context.TODO(), basicRes, &connection)
 			if err != nil {
 				return nil, errors.BadInput.Wrap(err, "failed to get create apiClient")
@@ -113,7 +113,7 @@ func SearchRemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutp
 		})
 }
 
-func initialQuery(queryData *plugin.QueryData) url.Values {
+func initialQuery(queryData *api.RemoteQueryData) url.Values {
 	query := url.Values{}
 	query.Set("showEmpty", fmt.Sprintf("%v", true))
 	query.Set("max-result", fmt.Sprintf("%v", queryData.PerPage))

--- a/backend/plugins/bitbucket/api/remote.go
+++ b/backend/plugins/bitbucket/api/remote.go
@@ -44,7 +44,7 @@ import (
 // @Router /plugins/bitbucket/connections/{connectionId}/remote-scopes [GET]
 func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
 	return remoteHelper.GetScopesFromRemote(input,
-		func(basicRes context2.BasicRes, gid string, queryData *plugin.QueryData, connection models.BitbucketConnection) ([]models.GroupResponse, errors.Error) {
+		func(basicRes context2.BasicRes, gid string, queryData *api.RemoteQueryData, connection models.BitbucketConnection) ([]models.GroupResponse, errors.Error) {
 			if gid != "" {
 				return nil, nil
 			}
@@ -70,7 +70,7 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 
 			return resBody.Values, err
 		},
-		func(basicRes context2.BasicRes, gid string, queryData *plugin.QueryData, connection models.BitbucketConnection) ([]models.BitbucketApiRepo, errors.Error) {
+		func(basicRes context2.BasicRes, gid string, queryData *api.RemoteQueryData, connection models.BitbucketConnection) ([]models.BitbucketApiRepo, errors.Error) {
 			if gid == "" {
 				return nil, nil
 			}
@@ -112,7 +112,7 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 // @Router /plugins/bitbucket/connections/{connectionId}/search-remote-scopes [GET]
 func SearchRemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
 	return remoteHelper.SearchRemoteScopes(input,
-		func(basicRes context2.BasicRes, queryData *plugin.QueryData, connection models.BitbucketConnection) ([]models.BitbucketApiRepo, errors.Error) {
+		func(basicRes context2.BasicRes, queryData *api.RemoteQueryData, connection models.BitbucketConnection) ([]models.BitbucketApiRepo, errors.Error) {
 			// create api client
 			apiClient, err := api.NewApiClientFromConnection(context.TODO(), basicRes, &connection)
 			if err != nil {
@@ -145,7 +145,7 @@ func SearchRemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutp
 	)
 }
 
-func initialQuery(queryData *plugin.QueryData) url.Values {
+func initialQuery(queryData *api.RemoteQueryData) url.Values {
 	query := url.Values{}
 	query.Set("page", fmt.Sprintf("%v", queryData.Page))
 	query.Set("pagelen", fmt.Sprintf("%v", queryData.PerPage))

--- a/backend/plugins/gitlab/api/remote.go
+++ b/backend/plugins/gitlab/api/remote.go
@@ -43,7 +43,7 @@ import (
 // @Router /plugins/gitlab/connections/{connectionId}/remote-scopes [GET]
 func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
 	return remoteHelper.GetScopesFromRemote(input,
-		func(basicRes context2.BasicRes, gid string, queryData *plugin.QueryData, connection models.GitlabConnection) ([]models.GroupResponse, errors.Error) {
+		func(basicRes context2.BasicRes, gid string, queryData *api.RemoteQueryData, connection models.GitlabConnection) ([]models.GroupResponse, errors.Error) {
 			apiClient, err := api.NewApiClientFromConnection(context.TODO(), basicRes, &connection)
 			if err != nil {
 				return nil, errors.BadInput.Wrap(err, "failed to get create apiClient")
@@ -69,7 +69,7 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 			}
 			return resBody, err
 		},
-		func(basicRes context2.BasicRes, gid string, queryData *plugin.QueryData, connection models.GitlabConnection) ([]models.GitlabApiProject, errors.Error) {
+		func(basicRes context2.BasicRes, gid string, queryData *api.RemoteQueryData, connection models.GitlabConnection) ([]models.GitlabApiProject, errors.Error) {
 			apiClient, err := api.NewApiClientFromConnection(context.TODO(), basicRes, &connection)
 			if err != nil {
 				return nil, errors.BadInput.Wrap(err, "failed to get create apiClient")
@@ -112,7 +112,7 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 // @Router /plugins/gitlab/connections/{connectionId}/search-remote-scopes [GET]
 func SearchRemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
 	return remoteHelper.SearchRemoteScopes(input,
-		func(basicRes context2.BasicRes, queryData *plugin.QueryData, connection models.GitlabConnection) ([]models.GitlabApiProject, errors.Error) {
+		func(basicRes context2.BasicRes, queryData *api.RemoteQueryData, connection models.GitlabConnection) ([]models.GitlabApiProject, errors.Error) {
 			apiClient, err := api.NewApiClientFromConnection(context.TODO(), basicRes, &connection)
 			if err != nil {
 				return nil, errors.BadInput.Wrap(err, "failed to get create apiClient")
@@ -138,7 +138,7 @@ func SearchRemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutp
 		})
 }
 
-func initialQuery(queryData *plugin.QueryData) url.Values {
+func initialQuery(queryData *api.RemoteQueryData) url.Values {
 	query := url.Values{}
 	query.Set("page", fmt.Sprintf("%v", queryData.Page))
 	query.Set("per_page", fmt.Sprintf("%v", queryData.PerPage))

--- a/backend/plugins/jira/api/transformation_rule.go
+++ b/backend/plugins/jira/api/transformation_rule.go
@@ -90,7 +90,7 @@ func UpdateTransformationRule(input *plugin.ApiResourceInput) (*plugin.ApiResour
 	if err != nil {
 		return nil, err
 	}
-	err = api.DecodeMapStruct(input.Body, oldTr)
+	err = api.DecodeMapStruct(input.Body, oldTr, true)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/plugins/sonarqube/api/remote.go
+++ b/backend/plugins/sonarqube/api/remote.go
@@ -42,7 +42,7 @@ import (
 func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
 	return remoteHelper.GetScopesFromRemote(input,
 		nil,
-		func(basicRes context2.BasicRes, gid string, queryData *plugin.QueryData, connection models.SonarqubeConnection) ([]models.SonarqubeApiProject, errors.Error) {
+		func(basicRes context2.BasicRes, gid string, queryData *api.RemoteQueryData, connection models.SonarqubeConnection) ([]models.SonarqubeApiProject, errors.Error) {
 			query := initialQuery(queryData)
 			// create api client
 			apiClient, err := api.NewApiClientFromConnection(context.TODO(), basicRes, &connection)
@@ -82,7 +82,7 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 func SearchRemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
 	return remoteHelper.GetScopesFromRemote(input,
 		nil,
-		func(basicRes context2.BasicRes, gid string, queryData *plugin.QueryData, connection models.SonarqubeConnection) ([]models.SonarqubeApiProject, errors.Error) {
+		func(basicRes context2.BasicRes, gid string, queryData *api.RemoteQueryData, connection models.SonarqubeConnection) ([]models.SonarqubeApiProject, errors.Error) {
 			query := initialQuery(queryData)
 			query.Set("q", queryData.Search[0])
 			// create api client
@@ -108,7 +108,7 @@ func SearchRemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutp
 		})
 }
 
-func initialQuery(queryData *plugin.QueryData) url.Values {
+func initialQuery(queryData *api.RemoteQueryData) url.Values {
 	query := url.Values{}
 	query.Set("p", fmt.Sprintf("%v", queryData.Page))
 	query.Set("ps", fmt.Sprintf("%v", queryData.PerPage))

--- a/backend/plugins/trello/api/scope.go
+++ b/backend/plugins/trello/api/scope.go
@@ -102,7 +102,7 @@ func UpdateScope(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, err
 	if err != nil {
 		return nil, errors.Default.Wrap(err, "getting TrelloBoard error")
 	}
-	err = api.DecodeMapStruct(input.Body, &board)
+	err = api.DecodeMapStruct(input.Body, &board, true)
 	if err != nil {
 		return nil, errors.Default.Wrap(err, "patch trello board error")
 	}

--- a/backend/plugins/trello/api/transformation_rule.go
+++ b/backend/plugins/trello/api/transformation_rule.go
@@ -74,7 +74,7 @@ func UpdateTransformationRule(input *plugin.ApiResourceInput) (*plugin.ApiResour
 	if err != nil {
 		return nil, errors.Default.Wrap(err, "error on saving TransformationRule")
 	}
-	err = api.DecodeMapStruct(input.Body, &old)
+	err = api.DecodeMapStruct(input.Body, &old, true)
 	if err != nil {
 		return nil, errors.Default.Wrap(err, "error decoding map into transformationRule")
 	}

--- a/backend/plugins/webhook/api/cicd_pipeline.go
+++ b/backend/plugins/webhook/api/cicd_pipeline.go
@@ -76,7 +76,7 @@ func PostCicdTask(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 	}
 	// get request
 	request := &WebhookTaskRequest{}
-	err = api.DecodeMapStruct(input.Body, request)
+	err = api.DecodeMapStruct(input.Body, request, true)
 	if err != nil {
 		return &plugin.ApiResourceOutput{Body: err.Error(), Status: http.StatusBadRequest}, nil
 	}
@@ -287,7 +287,7 @@ func PostDeploymentCicdTask(input *plugin.ApiResourceInput) (*plugin.ApiResource
 	}
 	// get request
 	request := &WebhookDeployTaskRequest{}
-	err = api.DecodeMapStruct(input.Body, request)
+	err = api.DecodeMapStruct(input.Body, request, true)
 	if err != nil {
 		return &plugin.ApiResourceOutput{Body: err.Error(), Status: http.StatusBadRequest}, nil
 	}

--- a/backend/plugins/webhook/api/issue.go
+++ b/backend/plugins/webhook/api/issue.go
@@ -79,7 +79,7 @@ func PostIssue(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, error
 	}
 	// get request
 	request := &WebhookIssueRequest{}
-	err = helper.DecodeMapStruct(input.Body, request)
+	err = helper.DecodeMapStruct(input.Body, request, true)
 	if err != nil {
 		return &plugin.ApiResourceOutput{Body: err.Error(), Status: http.StatusBadRequest}, nil
 	}

--- a/backend/plugins/zentao/api/remote.go
+++ b/backend/plugins/zentao/api/remote.go
@@ -43,7 +43,7 @@ type ProjectResponse struct {
 	Values []models.ZentaoProject `json:"projects"`
 }
 
-func getGroup(basicRes context2.BasicRes, gid string, queryData *plugin.QueryData, connection models.ZentaoConnection) ([]api.BaseRemoteGroupResponse, errors.Error) {
+func getGroup(basicRes context2.BasicRes, gid string, queryData *api.RemoteQueryData, connection models.ZentaoConnection) ([]api.BaseRemoteGroupResponse, errors.Error) {
 	return []api.BaseRemoteGroupResponse{
 		{
 			Id:   `products`,
@@ -79,7 +79,7 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 	} else if gid == `products` {
 		return productRemoteHelper.GetScopesFromRemote(input,
 			nil,
-			func(basicRes context2.BasicRes, gid string, queryData *plugin.QueryData, connection models.ZentaoConnection) ([]models.ZentaoProductRes, errors.Error) {
+			func(basicRes context2.BasicRes, gid string, queryData *api.RemoteQueryData, connection models.ZentaoConnection) ([]models.ZentaoProductRes, errors.Error) {
 				query := initialQuery(queryData)
 				// create api client
 				apiClient, err := api.NewApiClientFromConnection(context.TODO(), basicRes, &connection)
@@ -104,7 +104,7 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 	} else if gid == `projects` {
 		return projectRemoteHelper.GetScopesFromRemote(input,
 			nil,
-			func(basicRes context2.BasicRes, gid string, queryData *plugin.QueryData, connection models.ZentaoConnection) ([]models.ZentaoProject, errors.Error) {
+			func(basicRes context2.BasicRes, gid string, queryData *api.RemoteQueryData, connection models.ZentaoConnection) ([]models.ZentaoProject, errors.Error) {
 				query := initialQuery(queryData)
 				// create api client
 				apiClient, err := api.NewApiClientFromConnection(context.TODO(), basicRes, &connection)
@@ -130,7 +130,7 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 	return nil, nil
 }
 
-func initialQuery(queryData *plugin.QueryData) url.Values {
+func initialQuery(queryData *api.RemoteQueryData) url.Values {
 	query := url.Values{}
 	query.Set("page", fmt.Sprintf("%v", queryData.Page))
 	query.Set("limit", fmt.Sprintf("%v", queryData.PerPage))

--- a/backend/server/services/blueprint.go
+++ b/backend/server/services/blueprint.go
@@ -200,7 +200,7 @@ func PatchBlueprint(id uint64, body map[string]interface{}) (*models.Blueprint, 
 	}
 
 	originMode := blueprint.Mode
-	err = helper.DecodeMapStruct(body, blueprint)
+	err = helper.DecodeMapStruct(body, blueprint, true)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/server/services/project.go
+++ b/backend/server/services/project.go
@@ -133,7 +133,7 @@ func PatchProject(name string, body map[string]interface{}) (*models.ApiOutputPr
 	projectInput := &models.ApiInputProject{}
 
 	// load input
-	err := helper.DecodeMapStruct(body, projectInput)
+	err := helper.DecodeMapStruct(body, projectInput, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Summary
1. add prepareFirstToken api. Sometimes we have custom params to query remote scope, like tapd company id.
2. update tr helper decode type. To avoid difficult decode like jira.

### Does this close any open issues?
Related to #4566 
