### PR TITLE
fix(release): add skip binlog for mysql

### DIFF
--- a/devops/releases/lake-v0.16.0/docker-compose.yml
+++ b/devops/releases/lake-v0.16.0/docker-compose.yml
@@ -27,8 +27,10 @@ services:
       MYSQL_DATABASE: lake
       MYSQL_USER: merico
       MYSQL_PASSWORD: merico
-    command: --character-set-server=utf8mb4
+    command:
+      --character-set-server=utf8mb4
       --collation-server=utf8mb4_bin
+      --skip-log-bin
 
   grafana:
     image: apache/devlake-dashboard:v0.16.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     command:
       --character-set-server=utf8mb4
       --collation-server=utf8mb4_bin
+      --skip-log-bin
 
 
   # postgres:


### PR DESCRIPTION
### Summary
This PR addresses the issue of rapid MySQL database size growth due to the storage of binlogs. By adding the --skip-log-bin option to the MySQL configuration, we effectively disable the creation and storage of binlogs, thus reducing the rate at which the database size increases.

### Does this close any open issues?
Closes #4797 

### Screenshots
Include any relevant screenshots here.

### Other Information
This change was made by adding the --skip-log-bin option to the mysql section in the configuration file:

```yaml
Copy code
mysql:
  image: mysql:8
  volumes:
    - mysql-storage:/var/lib/mysql
  restart: always
  ports:
    - 3306:3306
  environment:
    MYSQL_ROOT_PASSWORD: admin
    MYSQL_DATABASE: lake
    MYSQL_USER: merico
    MYSQL_PASSWORD: merico
  command:
    --character-set-server=utf8mb4
    --collation-server=utf8mb4_bin
    --skip-log-bin
```
This modification should help in managing the growth of the database size and maintaining optimal performance.





