### PR TITLE
[fix-4772]: Python progress update crashes Go DevLake server

### DIFF
--- a/backend/core/utils/ipc.go
+++ b/backend/core/utils/ipc.go
@@ -243,7 +243,9 @@ func scanOutputPipe(pipe io.ReadCloser, wg *sync.WaitGroup, onReceive func([]byt
 			src := scanner.Bytes()
 			data := make([]byte, len(src))
 			copy(data, src)
-			onReceive(data)
+			if onReceive != nil {
+				onReceive(data)
+			}
 			outboundChannel <- responseCreator(data)
 		}
 		wg.Done()
@@ -259,7 +261,9 @@ func scanErrorPipe(pipe io.ReadCloser, onReceive func([]byte), outboundChannel c
 			src := scanner.Bytes()
 			data := make([]byte, len(src))
 			copy(data, src)
-			onReceive(data)
+			if onReceive != nil {
+				onReceive(data)
+			}
 			outboundChannel <- &ProcessResponse{stderr: data}
 			_, _ = remoteErrorMsg.Write(src)
 			_, _ = remoteErrorMsg.WriteString("\n")

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/go-openapi/swag v0.21.1 // indirect
 	github.com/go-playground/locales v0.14.0 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect
-	github.com/go-sql-driver/mysql v1.6.0
+	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/gogo/status v1.1.0 // indirect

--- a/backend/python/pydevlake/pydevlake/__init__.py
+++ b/backend/python/pydevlake/pydevlake/__init__.py
@@ -22,3 +22,9 @@ from .message import RemoteScopeGroup
 from .plugin import Plugin, ScopeTxRulePair
 from .stream import DomainType, Stream, Substream
 from .context import Context
+
+# the debugger hangs on startup during plugin registration (reason unknown), hence this workaround
+import sys
+if not sys.argv.__contains__('startup'):
+    from pydevlake.helpers import debugger
+    debugger.init()

--- a/backend/python/pydevlake/pydevlake/helpers/debugger.py
+++ b/backend/python/pydevlake/pydevlake/helpers/debugger.py
@@ -18,7 +18,7 @@ import os
 from pydevlake import logger
 
 
-def __start__():
+def init():
     debugger = os.getenv("USE_PYTHON_DEBUGGER", default="").lower()
     if debugger == "":
         return
@@ -32,12 +32,10 @@ def __start__():
             import pydevd_pycharm as pydevd
             try:
                 pydevd.settrace(host=host, port=port, suspend=False, stdoutToServer=True, stderrToServer=True)
+                logger.info("Pycharm remote debugger successfully connected")
             except TimeoutError as e:
                 logger.error(f"Failed to connect to pycharm debugger on {host}:{port}. Make sure it is running")
         except ImportError as e:
             logger.error("Pycharm debugger library is not installed")
     else:
         logger.error(f"Unsupported Python debugger specified: {debugger}")
-
-
-__start__()

--- a/backend/python/pydevlake/pydevlake/ipc.py
+++ b/backend/python/pydevlake/pydevlake/ipc.py
@@ -24,9 +24,6 @@ from pydevlake.message import Message
 
 
 def plugin_method(func):
-    # keep this to enable debugging, and don't move this elsewhere or it can cause crashes if it gets called during the bootstrap process.
-    # noinspection PyUnresolvedReferences
-    from pydevlake.helpers import debugger
 
     def open_send_channel() -> TextIO:
         fd = 3

--- a/backend/python/pydevlake/pydevlake/subtasks.py
+++ b/backend/python/pydevlake/pydevlake/subtasks.py
@@ -4,7 +4,7 @@
 # The ASF licenses this file to You under the Apache License, Version 2.0
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
-
+import time
 #     http://www.apache.org/licenses/LICENSE-2.0
 
 # Unless required by applicable law or agreed to in writing, software
@@ -45,7 +45,7 @@ class Subtask:
     def verb(self) -> str:
         pass
 
-    def run(self, ctx: Context, sync_point_interval=100):
+    def run(self, ctx: Context, sync_point_interval=1):
         with Session(ctx.engine) as session:
             subtask_run = self._start_subtask(session, ctx.connection.id)
             if ctx.incremental:
@@ -57,13 +57,14 @@ class Subtask:
             try:
                 for i, (data, state) in enumerate(self.fetch(state, session, ctx)):
                     self.process(data, session, ctx)
-
+                    # print("yielding python progress")
                     if i % sync_point_interval == 0 and i != 0:
+
                         # Save current state
                         subtask_run.state = json.dumps(state)
                         session.merge(subtask_run)
                         session.commit()
-
+                        time.sleep(1)
                         # Send progress
                         yield RemoteProgress(
                             increment=sync_point_interval,

--- a/backend/server/services/remote/bridge/bridge.go
+++ b/backend/server/services/remote/bridge/bridge.go
@@ -53,7 +53,7 @@ func (b *Bridge) RemoteSubtaskEntrypointHandler(subtaskMeta models.SubtaskMeta) 
 			if err != nil {
 				return err
 			}
-			if progress.Current != 0 {
+			if progress.Total != 0 {
 				ctx.SetProgress(progress.Current, progress.Total)
 			} else if progress.Increment != 0 {
 				ctx.IncProgress(progress.Increment)


### PR DESCRIPTION
### Summary
* Adds a missing nil check on Go side which was causing crashes whenever Python would stream back a "RemoteProgress". This would get triggered if the number of records fetched on Python side was greater than 100 (or the default value of sync_point_interval in general) which is why we hadn't ran into it before in our light-weight tests. Tests updated to use larger datasets.
* Logic fix for progress counter which would always stay at 0 and possibly skip the last update.
* Some fixes to the Python remote debugger as I encountered issues during testing

### Does this close any open issues?
Closes #4772 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
