### PR TITLE
fix: jenkins build collectUnfinishedDetails add filter condition

### DIFF
--- a/backend/plugins/jenkins/tasks/build_collector.go
+++ b/backend/plugins/jenkins/tasks/build_collector.go
@@ -108,7 +108,7 @@ func CollectApiBuilds(taskCtx plugin.SubTaskContext) errors.Error {
 					dal.Select("number"),
 					dal.From(&models.JenkinsBuild{}),
 					dal.Where(
-						"full_name = ? AND connection_id = ?",
+						"full_name = ? AND connection_id = ? AND result != 'SUCCESS'",
 						data.Options.JobFullName, data.Options.ConnectionId,
 					),
 				)

--- a/backend/plugins/jenkins/tasks/build_collector.go
+++ b/backend/plugins/jenkins/tasks/build_collector.go
@@ -108,7 +108,7 @@ func CollectApiBuilds(taskCtx plugin.SubTaskContext) errors.Error {
 					dal.Select("number"),
 					dal.From(&models.JenkinsBuild{}),
 					dal.Where(
-						"full_name = ? AND connection_id = ? AND result != 'SUCCESS'",
+						"full_name = ? AND connection_id = ? AND result != 'SUCCESS' AND result != 'FAILURE'",
 						data.Options.JobFullName, data.Options.ConnectionId,
 					),
 				)


### PR DESCRIPTION
### Summary
fix: jenkins build collectUnfinishedDetails add filter condition.
CollectUnfinishedDetails.BuildInputIterator This function should only return "builds that have not yet finished running"

### Does this close any open issues?
reletad to #4535 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
