### PR TITLE
fix: build and push devlake base failed when push a new tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,6 @@ jobs:
           push: true
           target: builder
           tags: ${{ secrets.DOCKERHUB_OWNER }}/devlake:amd64-builder
-          file: ./backend/Dockerfile
           platforms: linux/amd64
           cache-from: ${{ secrets.DOCKERHUB_OWNER }}/devlake:amd64-builder
           cache-to: ${{ secrets.DOCKERHUB_OWNER }}/devlake:amd64-builder
@@ -70,7 +69,6 @@ jobs:
           push: true
           target: base
           tags: ${{ secrets.DOCKERHUB_OWNER }}/devlake:base
-          file: ./backend/Dockerfile
           platforms: linux/amd64,linux/arm64
           cache-from: ${{ secrets.DOCKERHUB_OWNER }}/devlake:base
           cache-to: ${{ secrets.DOCKERHUB_OWNER }}/devlake:base
@@ -106,7 +104,6 @@ jobs:
           push: false
           target: build
           tags: ${{ secrets.DOCKERHUB_OWNER }}/devlake:build-cache-${{ matrix.platform }}
-          file: ./backend/Dockerfile
           platforms: linux/${{ matrix.platform }}
           cache-from: ${{ secrets.DOCKERHUB_OWNER }}/devlake:amd64-builder
           cache-to: type=local,mode=min,dest=/tmp/devlake-build-cache-${{ matrix.platform }}
@@ -155,7 +152,6 @@ jobs:
           push: true
           tags: ${{ steps.get_push_tags.outputs.TAGS }}
           platforms: linux/amd64,linux/arm64
-          file: ./backend/Dockerfile
           cache-from: |
             ${{ secrets.DOCKERHUB_OWNER }}/devlake:amd64-builder
             ${{ secrets.DOCKERHUB_OWNER }}/devlake:base

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build and push lake image
         uses: docker/build-push-action@v3
         with:
-          context: .
+          context: ./backend
           push: true
           target: builder
           tags: ${{ secrets.DOCKERHUB_OWNER }}/devlake:amd64-builder
@@ -66,7 +66,7 @@ jobs:
       - name: Build and push lake image
         uses: docker/build-push-action@v3
         with:
-          context: .
+          context: ./backend
           push: true
           target: base
           tags: ${{ secrets.DOCKERHUB_OWNER }}/devlake:base
@@ -102,7 +102,7 @@ jobs:
       - name: Build and cache lake build
         uses: docker/build-push-action@v3
         with:
-          context: .
+          context: ./backend
           push: false
           target: build
           tags: ${{ secrets.DOCKERHUB_OWNER }}/devlake:build-cache-${{ matrix.platform }}
@@ -151,7 +151,7 @@ jobs:
       - name: Build and push lake image
         uses: docker/build-push-action@v3
         with:
-          context: .
+          context: ./backend
           push: true
           tags: ${{ steps.get_push_tags.outputs.TAGS }}
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
### Summary
fix: build and push devlake base failed when push a new tag
add backend path to context.

### Does this close any open issues?
related to #4763 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
