### PR TITLE
Support token limited to single organization

### DIFF
--- a/backend/python/plugins/azuredevops/azuredevops/models.py
+++ b/backend/python/plugins/azuredevops/azuredevops/models.py
@@ -27,6 +27,7 @@ from pydevlake.pipeline_tasks import RefDiffOptions
 
 class AzureDevOpsConnection(Connection):
     token: str
+    organization: Optional[str]
 
 
 class AzureDevOpsTransformationRule(TransformationRule):

--- a/backend/python/pydevlake/pydevlake/__init__.py
+++ b/backend/python/pydevlake/pydevlake/__init__.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+pytest.register_assert_rewrite('pydevlake.testing')
 
 from .model import ToolModel, ToolScope, DomainScope, Connection, TransformationRule
 from .logger import logger

--- a/backend/python/pydevlake/pydevlake/message.py
+++ b/backend/python/pydevlake/pydevlake/message.py
@@ -112,7 +112,7 @@ class RemoteScopeGroup(RemoteScopeTreeNode):
 class RemoteScope(RemoteScopeTreeNode):
     type: str = Field("scope", const=True)
     parent_id: str = Field(..., alias="parentId")
-    scope: ToolScope
+    data: ToolScope
 
 
 class RemoteScopes(Message):

--- a/backend/python/pydevlake/pydevlake/plugin.py
+++ b/backend/python/pydevlake/pydevlake/plugin.py
@@ -116,7 +116,7 @@ class Plugin(ABC):
                         id=tool_scope.id,
                         parent_id=group_id,
                         name=tool_scope.name,
-                        scope=tool_scope
+                        data=tool_scope
                     )
                 )
         else:

--- a/backend/python/pydevlake/pydevlake/testing/__init__.py
+++ b/backend/python/pydevlake/pydevlake/testing/__init__.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-pytest.register_assert_rewrite('pydevlake.testing')
-
 from .testing import (
     assert_stream_convert,
     assert_stream_run,

--- a/backend/server/services/remote/plugin/remote_scope_api.go
+++ b/backend/server/services/remote/plugin/remote_scope_api.go
@@ -32,7 +32,7 @@ type RemoteScopesOutput struct {
 
 type RemoteScopesTreeNode struct {
 	Type     string      `json:"type"`
-	ParentId string      `json:"parentId"`
+	ParentId *string     `json:"parentId"`
 	Id       string      `json:"id"`
 	Name     string      `json:"name"`
 	Data     interface{} `json:"data"`

--- a/backend/test/integration/helper/models.go
+++ b/backend/test/integration/helper/models.go
@@ -51,7 +51,7 @@ type BlueprintV2Config struct {
 }
 type RemoteScopesChild struct {
 	Type     string      `json:"type"`
-	ParentId string      `json:"parentId"`
+	ParentId *string     `json:"parentId"`
 	Id       string      `json:"id"`
 	Name     string      `json:"name"`
 	Data     interface{} `json:"data"`

--- a/backend/test/integration/remote/python_plugin_test.go
+++ b/backend/test/integration/remote/python_plugin_test.go
@@ -52,6 +52,7 @@ func TestRemoteScopeGroups(t *testing.T) {
 	require.Equal(t, "group1", scope.Id)
 	require.Equal(t, "", scope.ParentId)
 	require.Equal(t, "group", scope.Type)
+	require.Nil(t, scope.Data)
 }
 
 func TestRemoteScopes(t *testing.T) {
@@ -71,6 +72,7 @@ func TestRemoteScopes(t *testing.T) {
 	require.Equal(t, "p1", scope.Id)
 	require.Equal(t, "group1", scope.ParentId)
 	require.Equal(t, "scope", scope.Type)
+	require.NotNil(t, scope.Data)
 }
 
 func TestCreateScope(t *testing.T) {

--- a/backend/test/integration/remote/python_plugin_test.go
+++ b/backend/test/integration/remote/python_plugin_test.go
@@ -50,8 +50,8 @@ func TestRemoteScopeGroups(t *testing.T) {
 	scope := scopeGroups[0]
 	require.Equal(t, "Group 1", scope.Name)
 	require.Equal(t, "group1", scope.Id)
-	require.Equal(t, "", scope.ParentId)
 	require.Equal(t, "group", scope.Type)
+	require.Nil(t, scope.ParentId)
 	require.Nil(t, scope.Data)
 }
 
@@ -70,7 +70,7 @@ func TestRemoteScopes(t *testing.T) {
 	scope := scopes[0]
 	require.Equal(t, "Project 1", scope.Name)
 	require.Equal(t, "p1", scope.Id)
-	require.Equal(t, "group1", scope.ParentId)
+	require.Equal(t, "group1", *scope.ParentId)
 	require.Equal(t, "scope", scope.Type)
 	require.NotNil(t, scope.Data)
 }


### PR DESCRIPTION
### ⚠️ Pre Checklist

- [ ] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

### Summary
- Add support for azure devops API tokens limited to a single organization
- Fix missing data in remote scopes responses
- Remote test warning