### PR TITLE
fix: ensure Changelog IDs are numeric

### DIFF
--- a/backend/plugins/jira/tasks/issue_changelog_convertor.go
+++ b/backend/plugins/jira/tasks/issue_changelog_convertor.go
@@ -18,6 +18,12 @@ limitations under the License.
 package tasks
 
 import (
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/models/domainlayer"
@@ -26,11 +32,9 @@ import (
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/jira/models"
-	"reflect"
-	"strconv"
-	"strings"
-	"time"
 )
+
+var validID = regexp.MustCompile(`[0-9]+`)
 
 var ConvertIssueChangelogsMeta = plugin.SubTaskMeta{
 	Name:             "convertIssueChangelogs",
@@ -160,6 +164,7 @@ func convertIds(ids string, connectionId uint64, sprintIdGenerator *didgen.Domai
 	var resultSlice []string
 	for _, item := range ss {
 		item = strings.TrimSpace(item)
+		item := validID.FindString(item)
 		if item != "" {
 			id, err := strconv.ParseUint(item, 10, 64)
 			if err != nil {


### PR DESCRIPTION
**Why**

The current validation in convertIds function only guards against leading/trailing white space. This can cause an issue if other characters such as `[` or `]` are included in the ids input by the caller e.g. 123,[90],65

Resulting in errors such as

```
time="2023-03-30 12:46:45" level=error msg=" [pipeline service] [pipeline #1] run tasks failed
	caused by: Error running task 70.
	Wraps: (2) subtask convertIssueChangelogs ended unexpectedly
	Wraps: (3) error calling Converter plugin implementation
	Wraps: (4) strconv.ParseUint: parsing "[90]": invalid syntax
	Wraps: (5) strconv.ParseUint: parsing "[90]"
	Wraps: (6) invalid syntax
	Error types: (1) *hintdetail.withDetail (2) *hintdetail.withDetail (3) *hintdetail.withDetail (4) *hintdetail.withDetail (5) *strconv.NumError (6) *errors.errorString
```

**How**

- Add a Regular Expression to match any repeated numeric characters
- Return the first match of the regular expression as the item ID

The above will prevent parseUint from returning an error and resolve https://github.com/apache/incubator-devlake/issues/4827

### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [x] I have added relevant documentation.
- [ ] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?

### Does this close any open issues?
Closes https://github.com/apache/incubator-devlake/issues/4827

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
