### PR TITLE
fix: Fix failing tests

### DIFF
--- a/backend/server/services/remote/models/models.go
+++ b/backend/server/services/remote/models/models.go
@@ -69,8 +69,8 @@ type ScopeModel struct {
 }
 
 type TransformationModel struct {
-	ConnectionId uint64    `gorm:"primaryKey" json:"connectionId"`
 	Id           uint64    `gorm:"primaryKey" json:"id"`
+	ConnectionId uint64    `json:"connectionId"`
 	Name         string    `json:"name"`
 	CreatedAt    time.Time `json:"createdAt"`
 	UpdatedAt    time.Time `json:"updatedAt"`

--- a/backend/server/services/remote/plugin/scope_api.go
+++ b/backend/server/services/remote/plugin/scope_api.go
@@ -174,7 +174,7 @@ func (pa *pluginAPI) ListScopes(input *plugin.ApiResourceInput) (*plugin.ApiReso
 	}
 	var ruleIds []uint64
 	for _, scopeModel := range scopeMap {
-		if tid := uint64(scopeModel["transformation_rule_id"].(float64)); tid > 0 {
+		if tid := uint64(scopeModel["transformationRuleId"].(float64)); tid > 0 {
 			ruleIds = append(ruleIds, tid)
 		}
 	}
@@ -197,7 +197,7 @@ func (pa *pluginAPI) ListScopes(input *plugin.ApiResourceInput) (*plugin.ApiReso
 	}
 	var apiScopes []apiScopeResponse
 	for _, scope := range scopeMap {
-		txRuleName, ok := names[uint64(scope["transformation_rule_id"].(float64))]
+		txRuleName, ok := names[uint64(scope["transformationRuleId"].(float64))]
 		if ok {
 			scopeRes := apiScopeResponse{
 				Scope:                  scope,

--- a/backend/test/integration/remote/helper.go
+++ b/backend/test/integration/remote/helper.go
@@ -45,8 +45,8 @@ type (
 	FakeProject struct {
 		Id                   string `json:"id"`
 		Name                 string `json:"name"`
-		ConnectionId         uint64 `json:"connection_id"`
-		TransformationRuleId uint64 `json:"transformation_rule_id"`
+		ConnectionId         uint64 `json:"connectionId"`
+		TransformationRuleId uint64 `json:"transformationRuleId"`
 	}
 	FakeTxRule struct {
 		Id   uint64 `json:"id"`


### PR DESCRIPTION
Commit 4c07a8113 renamed two JSON tags of server/services/remote/models/models.go:ScopeModel fields. 
This made the python_plugin_test.go tests fail for all builds.

### ⚠️ Pre Checklist

- [ ] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.
