### PR TITLE
misc: add CamilleTeruel as a collaborator

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -76,6 +76,7 @@ github:
   collaborators:
     - mintsweet
     - keon94
+    - CamilleTeruel
 
 notifications:
   commits: commits@devlake.apache.org


### PR DESCRIPTION
This PR adds CamilleTeruel as a collaborator so Camille can approve workflow runs.
