### PR TITLE
fix(dora): ignore to calculate cycletime if pr has not been deployed

### DIFF
--- a/backend/plugins/dora/e2e/snapshot_tables/project_pr_metrics.csv
+++ b/backend/plugins/dora/e2e/snapshot_tables/project_pr_metrics.csv
@@ -1,7 +1,7 @@
 id,project_name,first_commit_sha,pr_coding_time,first_review_id,pr_pickup_time,pr_review_time,deployment_id,pr_deploy_time,pr_cycle_time
 github:GithubPullRequest:1:1043463302,project1,75ab753225b5b8acf3bc6e40e463b54b6800e7ed,,github:GithubPrComment:1:964527893,8558,2859,task11,93134,104552
 github:GithubPullRequest:1:1048233599,project1,4f8cdefc9a9d53af16dd482c61623312eb9e9b5e,,github:GithubPrComment:1:1239007576,194,4033,task12,76605,80833
-github:GithubPullRequest:1:1049191985,project1,4b71faf666833c0c7b915a512811e2c5e746d3de,1,github:GithubPrComment:1:965369774,156,1712,task13,115026,116896
+github:GithubPullRequest:1:1049191985,project1,4b71faf666833c0c7b915a512811e2c5e746d3de,1,github:GithubPrComment:1:965369774,156,1712,task13,115026,116897
 github:GithubPullRequest:1:1051112182,project1,,,,,,task14,98341,98398
-github:GithubPullRequest:1:1051574863,project1,,,,,,,,108
-github:GithubPullRequest:1:1051637383,project1,9d53fb594958e65456793caa1bfa8d07a7614291,1,github:GithubPrReview:1:1102479199,45,13,,,60
+github:GithubPullRequest:1:1051574863,project1,,,,,,,,
+github:GithubPullRequest:1:1051637383,project1,9d53fb594958e65456793caa1bfa8d07a7614291,1,github:GithubPrReview:1:1102479199,45,13,,,

--- a/backend/plugins/dora/e2e/snapshot_tables/project_pr_metrics.csv
+++ b/backend/plugins/dora/e2e/snapshot_tables/project_pr_metrics.csv
@@ -1,7 +1,7 @@
 id,project_name,first_commit_sha,pr_coding_time,first_review_id,pr_pickup_time,pr_review_time,deployment_id,pr_deploy_time,pr_cycle_time
 github:GithubPullRequest:1:1043463302,project1,75ab753225b5b8acf3bc6e40e463b54b6800e7ed,,github:GithubPrComment:1:964527893,8558,2859,task11,93134,104552
 github:GithubPullRequest:1:1048233599,project1,4f8cdefc9a9d53af16dd482c61623312eb9e9b5e,,github:GithubPrComment:1:1239007576,194,4033,task12,76605,80833
-github:GithubPullRequest:1:1049191985,project1,4b71faf666833c0c7b915a512811e2c5e746d3de,1,github:GithubPrComment:1:965369774,156,1712,task13,115026,116897
+github:GithubPullRequest:1:1049191985,project1,4b71faf666833c0c7b915a512811e2c5e746d3de,1,github:GithubPrComment:1:965369774,156,1712,task13,115026,116896
 github:GithubPullRequest:1:1051112182,project1,,,,,,task14,98341,98398
 github:GithubPullRequest:1:1051574863,project1,,,,,,,,
 github:GithubPullRequest:1:1051637383,project1,9d53fb594958e65456793caa1bfa8d07a7614291,1,github:GithubPrReview:1:1102479199,45,13,,,

--- a/backend/plugins/dora/tasks/change_lead_time_calculator.go
+++ b/backend/plugins/dora/tasks/change_lead_time_calculator.go
@@ -81,6 +81,9 @@ func CalculateChangeLeadTime(taskCtx plugin.SubTaskContext) errors.Error {
 			projectPrMetric.Id = pr.Id
 			projectPrMetric.ProjectName = data.Options.ProjectName
 
+			// will be the very beginning of the pr
+			earlistDate := pr.CreatedDate
+
 			// Calculate PR coding time
 			if firstCommit != nil {
 				codingTime := int64(pr.CreatedDate.Sub(firstCommit.AuthoredDate).Seconds())
@@ -91,6 +94,10 @@ func CalculateChangeLeadTime(taskCtx plugin.SubTaskContext) errors.Error {
 				}
 				projectPrMetric.PrCodingTime = processNegativeValue(codingTime)
 				projectPrMetric.FirstCommitSha = firstCommit.Sha
+				// update the earlist date if the first commit is earlier than the pr created date
+				if earlistDate.After(firstCommit.AuthoredDate) {
+					earlistDate = firstCommit.AuthoredDate
+				}
 			}
 
 			// Get the first review for the PR
@@ -100,7 +107,6 @@ func CalculateChangeLeadTime(taskCtx plugin.SubTaskContext) errors.Error {
 			}
 
 			// Calculate PR pickup time and PR review time
-			prDuring := processNegativeValue(int64(pr.MergedDate.Sub(pr.CreatedDate).Minutes()))
 			if firstReview != nil {
 				projectPrMetric.PrPickupTime = processNegativeValue(int64(firstReview.CreatedDate.Sub(pr.CreatedDate).Minutes()))
 				projectPrMetric.PrReviewTime = processNegativeValue(int64(pr.MergedDate.Sub(firstReview.CreatedDate).Minutes()))
@@ -118,24 +124,13 @@ func CalculateChangeLeadTime(taskCtx plugin.SubTaskContext) errors.Error {
 				timespan := deployment.TaskFinishedDate.Sub(*pr.MergedDate)
 				projectPrMetric.PrDeployTime = processNegativeValue(int64(timespan.Minutes()))
 				projectPrMetric.DeploymentId = deployment.TaskId
+
+				// calculate the cycle time by the earliest date and deployment time
+				// if deployment is nil, just let PrCycleTime to be nil
+				cycleTimeInMins := int64(deployment.TaskFinishedDate.Sub(earlistDate).Minutes())
+				projectPrMetric.PrCycleTime = &cycleTimeInMins
 			} else {
 				logger.Debug("deploy time of pr %v is nil\n", pr.PullRequestKey)
-			}
-
-			// Calculate PR cycle time
-			projectPrMetric.PrCycleTime = nil
-			var result int64
-			if projectPrMetric.PrCodingTime != nil {
-				result += *projectPrMetric.PrCodingTime
-			}
-			if prDuring != nil {
-				result += *prDuring
-			}
-			if projectPrMetric.PrDeployTime != nil {
-				result += *projectPrMetric.PrDeployTime
-			}
-			if result > 0 {
-				projectPrMetric.PrCycleTime = &result
 			}
 
 			// Return the projectPrMetric

--- a/backend/plugins/dora/tasks/change_lead_time_calculator.go
+++ b/backend/plugins/dora/tasks/change_lead_time_calculator.go
@@ -123,7 +123,7 @@ func CalculateChangeLeadTime(taskCtx plugin.SubTaskContext) errors.Error {
 			}
 
 			// Calculate PR cycle time
-			if deployment == nil {
+			if deployment == nil || projectPrMetric.PrDeployTime == nil {
 				// Return the projectPrMetric with nill cycle time
 				return []interface{}{projectPrMetric}, nil
 			}


### PR DESCRIPTION
### Summary
This pr refactors the code to improve the calculation of metrics related to pull requests (PRs) in the specified project. The previous implementation had several issues related to incorrect time calculations, which have been resolved in this update.

The main changes made in this pr are:

1. The calculation of the cycle time for a PR now takes into account the earliest date between the PR creation date and the deployment task finished date.

2. If a pr has not been deployed, we will not calculate its cycletime

### Does this close any open issues?
Closes #4853

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
