### PR TITLE
fix: cached plan must not change result type in customize

### DIFF
--- a/backend/plugins/starrocks/tasks/tasks.go
+++ b/backend/plugins/starrocks/tasks/tasks.go
@@ -247,7 +247,19 @@ func copyDataToDst(dc *DataConfigParams, columnMap map[string]string, orderBy st
 		dal.Orderby(orderBy),
 	)
 	if err != nil {
-		return err
+		if strings.Contains(err.Error(), "cached plan must not change result type") {
+			logger.Warn(err, "skip err: cached plan must not change result type")
+			rows, err = db.Cursor(
+				dal.From(table),
+				dal.Orderby(orderBy),
+			)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+
 	}
 	defer rows.Close()
 


### PR DESCRIPTION
### Summary
fix cached plan must not change result type in customize 

### Does this close any open issues?
Closes #4867 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
