### PR TITLE
fix: the unit of Y-axis for change failure rate is incorrect

### DIFF
--- a/grafana/dashboards/DORA.json
+++ b/grafana/dashboards/DORA.json
@@ -15,8 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 27,
-  "iteration": 1680142836842,
+  "id": 28,
+  "iteration": 1681113037519,
   "links": [],
   "panels": [
     {
@@ -892,6 +892,8 @@
             "lineWidth": 1
           },
           "mappings": [],
+          "max": 1,
+          "min": 0,
           "thresholds": {
             "mode": "percentage",
             "steps": [
@@ -938,7 +940,9 @@
         },
         "orientation": "auto",
         "showValue": "auto",
-        "text": {},
+        "text": {
+          "valueSize": 1
+        },
         "tooltip": {
           "mode": "single"
         }
@@ -1025,5 +1029,5 @@
   "timezone": "",
   "title": "DORA",
   "uid": "qNo8_0M4z",
-  "version": 3
+  "version": 5
 }


### PR DESCRIPTION
### Summary
fix: the unit of Y-axis for change failure rate is incorrect

### Does this close any open issues?
Closes #4882 

### Screenshots
![image](https://user-images.githubusercontent.com/101256042/230856088-8d04fda0-4289-4f06-989a-50b0117fffca.png)
![image](https://user-images.githubusercontent.com/101256042/230856208-43b9a286-0507-4271-81f7-db54953652e3.png)


### Other Information
Any other information that is important to this PR.
