### PR TITLE
fix(config-ui): project name not encode in blueprint connection page

### DIFF
--- a/config-ui/src/pages/blueprint/detail/blueprint-detail.tsx
+++ b/config-ui/src/pages/blueprint/detail/blueprint-detail.tsx
@@ -41,7 +41,10 @@ export const BlueprintDetail = ({ from = FromEnum.project, pname, id }: Props) =
   const paths = useMemo(
     () =>
       from === FromEnum.project
-        ? [`/projects/${pname}/${id}/connection-add`, `/projects/${pname}/${id}/`]
+        ? [
+            `/projects/${window.encodeURIComponent(pname ?? '')}/${id}/connection-add`,
+            `/projects/${window.encodeURIComponent(pname ?? '')}/${id}/`,
+          ]
         : [`/blueprints/${id}/connection-add`, `/blueprints/${id}/`],
     [from, pname],
   );


### PR DESCRIPTION
### Summary
Project name not encode in blueprint connection page.
