### PR TITLE
Rename CiCDPipelineCommit.repo to repo_url

### DIFF
--- a/backend/python/plugins/azuredevops/azuredevops/streams/builds.py
+++ b/backend/python/plugins/azuredevops/azuredevops/streams/builds.py
@@ -100,5 +100,5 @@ class Builds(Stream):
             commit_sha=b.source_version,
             branch=b.source_branch,
             repo_id=ctx.scope.domain_id(),
-            repo=ctx.scope.url,
+            repo_url=ctx.scope.url,
         )

--- a/backend/python/plugins/azuredevops/tests/streams_test.py
+++ b/backend/python/plugins/azuredevops/tests/streams_test.py
@@ -140,7 +140,7 @@ def test_builds_stream(context):
             commit_sha='40c59264e73fc5e1a6cab192f1622d26b7bd5c2a',
             branch='refs/heads/main',
             repo_id=context.scope.domain_id(),
-            repo='https://github.com/johndoe/test-repo'
+            repo_url='https://github.com/johndoe/test-repo'
         )
     ]
 

--- a/backend/python/pydevlake/pydevlake/domain_layer/devops.py
+++ b/backend/python/pydevlake/pydevlake/domain_layer/devops.py
@@ -67,7 +67,7 @@ class CiCDPipelineCommit(NoPKModel, table=True):
     commit_sha: str = Field(primary_key=True)
     branch: str
     repo_id: str
-    repo: str
+    repo_url: str
 
 
 class CicdScope(DomainScope):


### PR DESCRIPTION
### Summary
Rename the repo field of CiCDPipelineCommit in pydevlake and in azuredevops plugin
to matche recent changes on go-side counterpart struct.

### Does this close any open issues?
Not on its own but is part of #4869.

@klesh 