### PR TITLE
fix: the jql time zone issue

### DIFF
--- a/backend/plugins/jira/tasks/issue_collector_test.go
+++ b/backend/plugins/jira/tasks/issue_collector_test.go
@@ -1,0 +1,93 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"testing"
+	"time"
+)
+
+func Test_buildJQL(t *testing.T) {
+	base := time.Date(2021, 2, 3, 4, 5, 6, 7, time.UTC)
+	timeAfter := base
+	add48 := base.Add(48 * time.Hour)
+	minus48 := base.Add(-48 * time.Hour)
+	type args struct {
+		timeAfter          *time.Time
+		latestSuccessStart *time.Time
+		isIncremental      bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test incremental",
+			args: args{
+				timeAfter:          nil,
+				latestSuccessStart: nil,
+				isIncremental:      false,
+			},
+			want: "ORDER BY created ASC"},
+		{
+			name: "test incremental",
+			args: args{
+				timeAfter:          nil,
+				latestSuccessStart: &add48,
+				isIncremental:      true,
+			},
+			want: "updated >= '2021/02/04 04:05' ORDER BY created ASC",
+		},
+		{
+			name: "test incremental",
+			args: args{
+				timeAfter:          &base,
+				latestSuccessStart: nil,
+				isIncremental:      false,
+			},
+			want: "updated >= '2021/02/03 04:05' ORDER BY created ASC",
+		},
+		{
+			name: "test incremental",
+			args: args{
+				timeAfter:          &timeAfter,
+				latestSuccessStart: &add48,
+				isIncremental:      true,
+			},
+			want: "updated >= '2021/02/04 04:05' ORDER BY created ASC",
+		},
+		{
+			name: "test incremental",
+			args: args{
+				timeAfter:          &timeAfter,
+				latestSuccessStart: &minus48,
+				isIncremental:      true,
+			},
+			want: "updated >= '2021/02/03 04:05' ORDER BY created ASC",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildJQL(tt.args.timeAfter, tt.args.latestSuccessStart, tt.args.isIncremental); got != tt.want {
+				t.Errorf("buildJQL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary
## Problem:
A user reported a timezone-related issue with a Jira plugin: https://github.com/apache/incubator-devlake/issues/4902. The most important information is a log that the user provided, which includes a timestamp and some debug information.
```text
time="2023-04-11 13:51:26" level=debug msg=" [pipeline service] [pipeline #2] [task #2] [collectIssues] fetchAsync >>> done for agile/1.0/board/1302/issue map[expand:[changelog] jql:[updated >= '2023/04/11 20:20' AND updated >= '2022/10/11 00:00' AND created is not null ORDER BY created ASC] maxResults:[100] startAt:[0]] <nil>"
```
## Reason:
There are two issues with the log: 
1.  the "updated" field appears twice in the JQL query
2.  the log timestamp is earlier than the "updated" timestamp

```go
if data.TimeAfter != nil {
   jql = fmt.Sprintf("updated >= '%v' AND %v", data.TimeAfter.Format("2006/01/02 15:04"), jql)
}

incremental := collectorWithState.IsIncremental()
if incremental {
   jql = fmt.Sprintf("updated >= '%v' AND %v", collectorWithState.LatestState.LatestSuccessStart.Format("2006/01/02 15:04"), jql)
}
```
Regarding the first issue, the root cause can be found in the code: the "updated" field is included twice because of some conditional logic that checks if a certain variable is not nil.

The second issue is a bit more complex. The timestamp in the log comes from the variable "collectorWithState.LatestState.LatestSuccessStart", which is written to a database in UTC format by the GORM library. However, when this timestamp is read from the database and formatted into a string, the timezone information is lost. This can result in a timestamp that is different from the actual time, especially if the user is in a different timezone.

## Solution:
For the first issue, the solution is to add a condition that checks which of the two "updated" fields is later and use that one.

For the second issue, there are several possible solutions, but each has some drawbacks. One solution is to convert the timestamp to the user's local time before formatting it. However, this can lead to delays or data loss if the user's timezone is different from Jira's timezone. Another solution is to subtract a day from the timestamp before formatting it, but this can result in some data being collected twice. In this PR, we take the second one as our final solution.




### Does this close any open issues?
Closes #4902 
