### PR TITLE
chore: update bug report template to include v0.16.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -83,6 +83,7 @@ body:
         Which version of Apache DevLake are you running?
       options:
         - main
+        - v0.16.0
         - v0.15.0
         - v0.14.2
         - v0.14.1


### PR DESCRIPTION
### Summary
Update the bug report template to include v0.16.0

### Does this close any open issues?
No
