### PR TITLE
fix(config-ui): missed margin between DORA link and wording

### DIFF
--- a/config-ui/src/pages/project/home/index.tsx
+++ b/config-ui/src/pages/project/home/index.tsx
@@ -128,8 +128,10 @@ export const ProjectHomePage = () => {
               <p>
                 <a href="https://devlake.apache.org/docs/UserManuals/DORA/" rel="noreferrer" target="_blank">
                   DORA metrics
-                </a>{' '}
-                <span>are four widely-adopted metrics for measuring software delivery performance.</span>
+                </a>
+                <span style={{ marginLeft: 4 }}>
+                  are four widely-adopted metrics for measuring software delivery performance.
+                </span>
               </p>
             </div>
           </div>


### PR DESCRIPTION
### Summary
missed margin between DORA link and wording.

### Screenshots
![screenshot-20230421-105812](https://user-images.githubusercontent.com/37237996/233530273-d4f74667-e6c3-4aa1-8f53-fc862e5ca089.png)

