### PR TITLE
fix: resolution_date is earlier than created_date

### DIFF
--- a/backend/helpers/pluginhelper/api/graphql_collector.go
+++ b/backend/helpers/pluginhelper/api/graphql_collector.go
@@ -305,9 +305,6 @@ func (collector *GraphqlCollector) ExtractExistRawData(divider *BatchSaveDivider
 	defer cursor.Close()
 	row := &RawData{}
 
-	// get the type of query and variables
-	query, variables, _ := collector.args.BuildQuery(nil)
-
 	// prgress
 	collector.args.Ctx.SetProgress(0, -1)
 	ctx := collector.args.Ctx.GetContext()
@@ -318,6 +315,8 @@ func (collector *GraphqlCollector) ExtractExistRawData(divider *BatchSaveDivider
 			return errors.Convert(ctx.Err())
 		default:
 		}
+		// get the type of query and variables. For each iteration, the query should be a different object
+		query, variables, _ := collector.args.BuildQuery(nil)
 		err = db.Fetch(cursor, row)
 		if err != nil {
 			return errors.Default.Wrap(err, "error fetching row")


### PR DESCRIPTION
### Summary

Before going any further, let's take a look at an example.
```go
var f struct {
    I int     `json:"i"`
    A *string `json:"a"`
}
blob1 := `{"i": 42, "a": "hello"}`
json.Unmarshal([]byte(blob1), &f)
blob2 := `{"i": 42}`
json.Unmarshal([]byte(blob2), &f)
fmt.Println(*f.A)
```
The output of this piece of code would be "hello", because the `blob2` has no "a" key, the field `f.A` would keep the value set at the last time. 
The `ExtractExistRawData` function in the `GraphqlCollector` suffers from the same issue. During each iteration of the loop, the same query object is being populated by a call to `json.Unmarshal`, causing the previous field values to persist. To fix this issue, we propose creating a new query object during each iteration of the loop.
Here's the relevant code:
```go
query, variables, _ := collector.args.BuildQuery(nil)
for cursor.Next() {
    err = db.Fetch(cursor, row)
    err = errors.Convert(json.Unmarshal(row.Data, &query))
}
```
### Does this close any open issues?
Closes #4988 
Closes #4989 

