### PR TITLE
fix: chrome asks user/pass infinitely when basic auth enabled

### DIFF
--- a/config-ui/src/utils/request.ts
+++ b/config-ui/src/utils/request.ts
@@ -38,11 +38,16 @@ export type ReuqestConfig = {
 export const request = (path: string, config?: ReuqestConfig) => {
   const { method = 'get', data, timeout, headers, signal } = config || {};
   const cancelTokenSource = axios.CancelToken.source();
+  const token = localStorage.getItem('accessToken');
+  var h = { ...headers };
+  if (token) {
+    h.Authorization = `Bearer ${token}`;
+  }
   const params: any = {
     url: path,
     method,
     timeout,
-    headers: { ...headers, Authorization: `Bearer ${localStorage.getItem('accessToken')}` },
+    headers: h,
     cancelToken: cancelTokenSource?.token,
   };
 


### PR DESCRIPTION
### Summary
When basic auth is enable, the following dialog from Chrome browser would never go away.
![image](https://user-images.githubusercontent.com/61080/233958354-e1423908-b417-4c1f-aae5-3380455daa07.png)

It was caused by the code overwriting the `Authorization` header set by the Browse, practically defeating the Basic Authentication Mechanism


### Does this close any open issues?
Closes #5021 


