### PR TITLE
fix: log the panic errors

### DIFF
--- a/backend/core/runner/run_task.go
+++ b/backend/core/runner/run_task.go
@@ -67,9 +67,8 @@ func RunTask(
 			default:
 				e = fmt.Errorf("%v", et)
 			}
-			if !dbPipeline.SkipOnFail {
-				err = errors.Default.Wrap(e, fmt.Sprintf("run task failed with panic (%s)", utils.GatherCallFrames(0)))
-			}
+			err = errors.Default.Wrap(e, fmt.Sprintf("run task failed with panic (%s)", utils.GatherCallFrames(0)))
+			logger.Error(err, "run task failed with panic")
 		}
 		finishedAt := time.Now()
 		spentSeconds := finishedAt.Unix() - beganAt.Unix()
@@ -113,6 +112,10 @@ func RunTask(
 		)
 		if dbe != nil {
 			logger.Error(dbe, "update pipeline state failed")
+		}
+		// not return err if the `SkipOnFail` is true
+		if dbPipeline.SkipOnFail {
+			err = nil
 		}
 	}()
 

--- a/backend/helpers/pluginhelper/api/worker_scheduler.go
+++ b/backend/helpers/pluginhelper/api/worker_scheduler.go
@@ -136,11 +136,11 @@ func (s *WorkerScheduler) checkError(err interface{}) {
 	if err == nil {
 		return
 	}
-	switch err.(type) {
+	switch e := err.(type) {
 	case error:
-		s.appendError(err.(error))
+		s.appendError(e)
 	default:
-		s.appendError(fmt.Errorf("%v", err))
+		s.appendError(fmt.Errorf("%v", e))
 	}
 }
 

--- a/backend/helpers/pluginhelper/api/worker_scheduler.go
+++ b/backend/helpers/pluginhelper/api/worker_scheduler.go
@@ -19,6 +19,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -135,7 +136,12 @@ func (s *WorkerScheduler) checkError(err interface{}) {
 	if err == nil {
 		return
 	}
-	s.appendError(err.(error))
+	switch err.(type) {
+	case error:
+		s.appendError(err.(error))
+	default:
+		s.appendError(fmt.Errorf("%v", err))
+	}
 }
 
 // HasError return if any error occurred


### PR DESCRIPTION
### Summary
fix #5018 [Bug][Framework] Recovered errors from panics are not logged when SkipOnFail flag is set to true

### Does this close any open issues?
Closes #5018 

### Screenshots
![image](https://user-images.githubusercontent.com/8455907/233998266-50631a9f-67c5-41c9-9bd4-38e65f9672e3.png)

