### PR TITLE
fix: deployment_commit_generator produced unwanted records

### DIFF
--- a/backend/plugins/dora/tasks/deployment_commits_generator.go
+++ b/backend/plugins/dora/tasks/deployment_commits_generator.go
@@ -59,22 +59,27 @@ func GenerateDeploymentCommits(taskCtx plugin.SubTaskContext) errors.Error {
 	// select all cicd_pipeline_commits from all "Deployments" in the project
 	// Note that failed records shall be included as well
 	cursor, err := db.Cursor(
-		dal.Select(`
-			pc.*, p.name as pipeline_name,
-			p.result,
-			p.status,
-			p.duration_sec,
-			p.created_date,
-			p.finished_date,
-			p.environment,
-			p.cicd_scope_id,
-			EXISTS(SELECT 1 FROM cicd_tasks t WHERE t.pipeline_id = p.id AND t.environment = ?)
-			 as has_testing_tasks,
-			EXISTS(SELECT 1 FROM cicd_tasks t WHERE t.pipeline_id = p.id AND t.environment = ?)
-			 as has_staging_tasks,
-			EXISTS( SELECT 1 FROM cicd_tasks t WHERE t.pipeline_id = p.id AND t.environment = ?)
-			 as has_production_tasks
-		`),
+		dal.Select(
+			`
+				pc.*, p.name as pipeline_name,
+				p.result,
+				p.status,
+				p.duration_sec,
+				p.created_date,
+				p.finished_date,
+				p.environment,
+				p.cicd_scope_id,
+				EXISTS(SELECT 1 FROM cicd_tasks t WHERE t.pipeline_id = p.id AND t.environment = ?)
+				as has_testing_tasks,
+				EXISTS(SELECT 1 FROM cicd_tasks t WHERE t.pipeline_id = p.id AND t.environment = ?)
+				as has_staging_tasks,
+				EXISTS( SELECT 1 FROM cicd_tasks t WHERE t.pipeline_id = p.id AND t.environment = ?)
+				as has_production_tasks
+			`,
+			devops.TESTING,
+			devops.STAGING,
+			devops.PRODUCTION,
+		),
 		dal.From("cicd_pipeline_commits pc"),
 		dal.Join("LEFT JOIN cicd_pipelines p ON (p.id = pc.pipeline_id)"),
 		dal.Join("LEFT JOIN project_mapping pm ON (pm.table = 'cicd_scopes' AND pm.row_id = p.cicd_scope_id)"),
@@ -82,10 +87,13 @@ func GenerateDeploymentCommits(taskCtx plugin.SubTaskContext) errors.Error {
 			`
 			pm.project_name = ? AND (
 				p.type = ? OR EXISTS(
-					SELECT 1 FROM cicd_tasks t WHERE t.pipeline_id = p.id AND t.type = p.type
+					SELECT 1 FROM cicd_tasks t WHERE t.pipeline_id = p.id AND t.type = ?
 				)
 			)
-			`, devops.TESTING, devops.STAGING, devops.PRODUCTION, data.Options.ProjectName, devops.DEPLOYMENT,
+			`,
+			data.Options.ProjectName,
+			devops.DEPLOYMENT,
+			devops.DEPLOYMENT,
 		),
 	)
 	if err != nil {


### PR DESCRIPTION
### Summary

Problem: the record in the following screenshot was produced by the `dora.deployment_commit_generator` which is incorrect because it doesn't meet the criteria
![image](https://user-images.githubusercontent.com/61080/234209343-bc27c6e6-bda8-4071-b56b-95a85bdb8d24.png)

Why: this is caused by the incorrect SQL condition:
![image](https://user-images.githubusercontent.com/61080/234210072-0db374b4-a0ad-4afc-a1a5-3840d8f9b49c.png)
The `t.type = p.type` and the `OR` operator are used in conjunction which is incorrect
