### PR TITLE
Github workflow run/job doesn't end up in cicd_deployment_commits table with correct Regex

### DIFF
--- a/backend/plugins/github/tasks/cicd_run_convertor.go
+++ b/backend/plugins/github/tasks/cicd_run_convertor.go
@@ -18,6 +18,9 @@ limitations under the License.
 package tasks
 
 import (
+	"reflect"
+	"strings"
+
 	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/models/domainlayer"
@@ -26,8 +29,6 @@ import (
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/github/models"
-	"reflect"
-	"strings"
 )
 
 var ConvertRunsMeta = plugin.SubTaskMeta{
@@ -51,7 +52,7 @@ func ConvertRuns(taskCtx plugin.SubTaskContext) errors.Error {
 
 	pipeline := &models.GithubRun{}
 	cursor, err := db.Cursor(
-		dal.Select("id, repo_id, connection_id, name, head_sha, head_branch, status, conclusion, github_created_at, github_updated_at,_raw_data_remark, _raw_data_id, _raw_data_table, _raw_data_params"),
+		dal.Select("*"),
 		dal.From(pipeline),
 		dal.Where("repo_id = ? and connection_id=?", repoId, data.Options.ConnectionId),
 	)

--- a/backend/plugins/github_graphql/tasks/job_collector.go
+++ b/backend/plugins/github_graphql/tasks/job_collector.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/models/domainlayer/devops"
 	"github.com/apache/incubator-devlake/core/plugin"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/github/models"
@@ -190,6 +191,8 @@ func CollectGraphqlJobs(taskCtx plugin.SubTaskContext) errors.Error {
 						CompletedAt:  checkRun.CompletedAt,
 						Name:         checkRun.Name,
 						Steps:        paramsBytes,
+						Type:         data.RegexEnricher.ReturnNameIfMatched(devops.DEPLOYMENT, checkRun.Name),
+						Environment:  data.RegexEnricher.ReturnNameIfMatched(devops.PRODUCTION, checkRun.Name),
 						// these columns can not fill by graphql
 						//HeadSha:       ``,  // use _tool_github_runs
 						//RunURL:        ``,


### PR DESCRIPTION
### Summary
 
for the `apache/incubator-devlake` repo with the following `transformation settings`
![image](https://user-images.githubusercontent.com/61080/234229366-491bbf09-30cb-463e-804f-ab566c1b591f.png)

we are expecting to see [this github action](https://github.com/apache/incubator-devlake/actions/runs/4782906377) to be appear in `cicd_deployment_commits` table.

However, it didn't happen because the essential information for `cicd_deployment_commits` record to be generated was missing.

1. the `type` and `env` fields were not loaded from the database
2. during the investigation, I found out the `github_graphql` doesn't enrich the `type` / `env` as well, it is not the direct cause of the above problem. but it clearly a bug, might fix it as well.


### Screenshots
With this fix, the `cicd_deployment_commits` can be produced correctly:
![image](https://user-images.githubusercontent.com/61080/234230933-be0e1700-d6f1-485d-b9c9-5694b600eb12.png)
