### PR TITLE
fix(config-ui): refdiff task name error

### DIFF
--- a/config-ui/src/pages/pipeline/components/task/index.tsx
+++ b/config-ui/src/pages/pipeline/components/task/index.tsx
@@ -50,7 +50,7 @@ export const PipelineTask = ({ task }: Props) => {
       case ['gitextractor'].includes(config.plugin):
         name = `${name}:${options.repoId}`;
         break;
-      case ['dora', 'refdiff'].includes(config.plugin):
+      case ['dora'].includes(config.plugin):
         name = `${name}:${options.projectName}`;
         break;
       case ['gitlab'].includes(config.plugin):
@@ -74,6 +74,9 @@ export const PipelineTask = ({ task }: Props) => {
         } else {
           name = `${name}:product/${options.productId}`;
         }
+        break;
+      case ['refdiff'].includes(config.plugin):
+        name = `${name}:${options.repoId ?? options.projectName}`;
         break;
     }
 


### PR DESCRIPTION
### Summary
fixed refdiff task name error.

### Screenshots
<img width="1181" alt="WeCom20230426-095820@2x" src="https://user-images.githubusercontent.com/37237996/234446651-324950e3-561c-4e1b-825c-f91d212fea53.png">

