### PR TITLE
fix: fix config ui do not support same group and project id

### DIFF
--- a/backend/plugins/gitlab/api/remote.go
+++ b/backend/plugins/gitlab/api/remote.go
@@ -20,13 +20,14 @@ package api
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/url"
+
 	context2 "github.com/apache/incubator-devlake/core/context"
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/gitlab/models"
-	"net/http"
-	"net/url"
 )
 
 // RemoteScopes list all available scope for users
@@ -57,6 +58,9 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 					return nil, err
 				}
 			} else {
+				if gid[:6] == "group:" {
+					gid = gid[6:]
+				}
 				res, err = apiClient.Get(fmt.Sprintf("groups/%s/subgroups", gid), query, nil)
 				if err != nil {
 					return nil, err
@@ -67,6 +71,7 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 			if err != nil {
 				return nil, err
 			}
+
 			return resBody, err
 		},
 		func(basicRes context2.BasicRes, gid string, queryData *api.RemoteQueryData, connection models.GitlabConnection) ([]models.GitlabApiProject, errors.Error) {
@@ -83,6 +88,9 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 				}
 			} else {
 				query.Set("with_shared", "false")
+				if gid[:6] == "group:" {
+					gid = gid[6:]
+				}
 				res, err = apiClient.Get(fmt.Sprintf("/groups/%s/projects", gid), query, nil)
 				if err != nil {
 					return nil, err

--- a/backend/plugins/gitlab/models/project.go
+++ b/backend/plugins/gitlab/models/project.go
@@ -18,10 +18,11 @@ limitations under the License.
 package models
 
 import (
-	"github.com/apache/incubator-devlake/core/plugin"
-	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"strconv"
 	"time"
+
+	"github.com/apache/incubator-devlake/core/plugin"
+	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 
 	"github.com/apache/incubator-devlake/core/models/common"
 )
@@ -118,7 +119,7 @@ type GroupResponse struct {
 }
 
 func (p GroupResponse) GroupId() string {
-	return strconv.Itoa(p.Id)
+	return "group:" + strconv.Itoa(p.Id)
 }
 
 func (p GroupResponse) GroupName() string {


### PR DESCRIPTION
### Summary
Because the request was changed
The fix #4307 on config-ui does not work.
So it needs to be fixed on the backend.
Rename the group id, and add `group:` before the id

### Does this close any open issues?
related #4296 

### Screenshots
![image](https://user-images.githubusercontent.com/2921251/234530520-dda9bd8b-562c-4d00-9eaf-9e7fff8f5efb.png)
![image](https://user-images.githubusercontent.com/2921251/234530640-5084b63c-078f-4cf4-96d7-295c3bb2a8db.png)


