### PR TITLE
fix: fix missing id in tapd transformationRule migration

### DIFF
--- a/backend/plugins/tapd/models/migrationscripts/20230323_add_transformation.go
+++ b/backend/plugins/tapd/models/migrationscripts/20230323_add_transformation.go
@@ -131,5 +131,5 @@ func (*addTransformation) Version() uint64 {
 }
 
 func (*addTransformation) Name() string {
-	return "Tapd add transformation"
+	return "Tapd add transformation, update _raw_data_params"
 }

--- a/backend/plugins/tapd/models/migrationscripts/archived/transformation_rule.go
+++ b/backend/plugins/tapd/models/migrationscripts/archived/transformation_rule.go
@@ -23,7 +23,7 @@ import (
 )
 
 type TapdTransformationRule struct {
-	archived.NoPKModel
+	archived.Model
 	ConnectionId   uint64          `mapstructure:"connectionId" json:"connectionId"`
 	Name           string          `gorm:"type:varchar(255);index:idx_name_tapd,unique" validate:"required" mapstructure:"name" json:"name"`
 	TypeMappings   json.RawMessage `mapstructure:"typeMappings,omitempty" json:"typeMappings"`


### PR DESCRIPTION
### Summary
fix missing id in tapd transformationRule migration.

### Screenshots
The bug:
![img_v2_089ce6c0-8859-46db-9218-680d70e86f3g](https://user-images.githubusercontent.com/3294100/234613297-5bdd8a7a-99fa-42e2-9906-90f6e1f4181e.jpg)

After fix, migration can run~
![image](https://user-images.githubusercontent.com/3294100/234613386-efbb3d04-a536-43dd-bfca-4c94ee7463c4.png)

After run:
![image](https://user-images.githubusercontent.com/3294100/234614071-3e2cfaf6-41d5-4236-aec2-7ebc96e9415f.png)
Although id is not primary key if the table transformation rule exist, I think it's no matter. Because this script haven't publish to users.
