### PR TITLE
fix: cherry pick #5037

### DIFF
--- a/backend/plugins/gitlab/api/remote.go
+++ b/backend/plugins/gitlab/api/remote.go
@@ -109,6 +109,11 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 
 	// get gid and pageData
 	gid := groupId[0]
+	if len(gid) >= 6 {
+		if gid[:6] == "group:" {
+			gid = gid[6:]
+		}
+	}
 	pageData, err := GetPageDataFromPageToken(pageToken[0])
 	if err != nil {
 		return nil, errors.BadInput.New("failed to get paget token")
@@ -150,7 +155,7 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 		for _, group := range resBody {
 			child := RemoteScopesChild{
 				Type: TypeGroup,
-				Id:   strconv.Itoa(group.Id),
+				Id:   "group:" + strconv.Itoa(group.Id),
 				Name: group.Name,
 				// don't need to save group into data
 				Data: nil,

--- a/backend/plugins/gitlab/api/remote.go
+++ b/backend/plugins/gitlab/api/remote.go
@@ -109,9 +109,10 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 
 	// get gid and pageData
 	gid := groupId[0]
-	if len(gid) >= 6 {
-		if gid[:6] == "group:" {
-			gid = gid[6:]
+	rgid := gid
+	if len(rgid) >= 6 {
+		if rgid[:6] == "group:" {
+			rgid = rgid[6:]
 		}
 	}
 	pageData, err := GetPageDataFromPageToken(pageToken[0])
@@ -139,7 +140,7 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 			query.Set("top_level_only", "true")
 			res, err = apiClient.Get("groups", query, nil)
 		} else {
-			res, err = apiClient.Get(fmt.Sprintf("groups/%s/subgroups", gid), query, nil)
+			res, err = apiClient.Get(fmt.Sprintf("groups/%s/subgroups", rgid), query, nil)
 		}
 		if err != nil {
 			return nil, err
@@ -203,7 +204,7 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 			res, err = apiClient.Get(fmt.Sprintf("users/%d/projects", apiClient.GetData(models.GitlabApiClientData_UserId)), query, nil)
 		} else {
 			query.Set("with_shared", "false")
-			res, err = apiClient.Get(fmt.Sprintf("/groups/%s/projects", gid), query, nil)
+			res, err = apiClient.Get(fmt.Sprintf("/groups/%s/projects", rgid), query, nil)
 		}
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
### Summary
Add `group:` before group id.
Because the config-ui does not support the same group id and project id.
![image](https://user-images.githubusercontent.com/2921251/234859980-91f75a04-9c52-45a1-aafc-3074cbb8b696.png)
![image](https://user-images.githubusercontent.com/2921251/234909095-b57379c1-22e6-46cf-9e0d-de616af3580e.png)
![image](https://user-images.githubusercontent.com/2921251/234909323-fc4c7eaa-95bd-4034-8fd1-9e5b55a20437.png)
