### PR TITLE
fix: /grafana being redirected to a wrong URL

### DIFF
--- a/config-ui/nginx.conf
+++ b/config-ui/nginx.conf
@@ -1,6 +1,7 @@
 server {
   listen 4000;
   server_name localhost;
+  absolute_redirect off;
 ${SERVER_CONF}
 
   location / {


### PR DESCRIPTION
### Summary

When trying to access `/grafana` , nginx would redirect users to `/grafana/` due to 404.
However, for whatever reason, nginx produces a Full Qaulified URL which is undesirable, especially for modern DevOps practice.
This PR fixes the problem by turning `absolute_redirect` off



### Does this close any open issues?
Closes #5048 


### Screenshots
![image](https://user-images.githubusercontent.com/61080/234837429-abc36bbd-bf9e-4a0c-9f15-c83716a4e09c.png)
