### PR TITLE
fix: unauthorized return 400 instead of 401

### DIFF
--- a/backend/plugins/ae/api/connection.go
+++ b/backend/plugins/ae/api/connection.go
@@ -60,7 +60,7 @@ func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, 
 	case 200: // right StatusCode
 		return &plugin.ApiResourceOutput{Body: true, Status: 200}, nil
 	case 401: // error secretKey or nonceStr
-		return &plugin.ApiResourceOutput{Body: false, Status: res.StatusCode}, nil
+		return &plugin.ApiResourceOutput{Body: false, Status: http.StatusBadRequest}, nil
 	default: // unknow what happen , back to user
 		return &plugin.ApiResourceOutput{Body: res.Body, Status: res.StatusCode}, nil
 	}

--- a/backend/plugins/azure/api/connection.go
+++ b/backend/plugins/azure/api/connection.go
@@ -19,8 +19,9 @@ package api
 
 import (
 	"context"
-	"github.com/apache/incubator-devlake/server/api/shared"
 	"net/http"
+
+	"github.com/apache/incubator-devlake/server/api/shared"
 
 	"github.com/apache/incubator-devlake/core/errors"
 	plugin "github.com/apache/incubator-devlake/core/plugin"
@@ -58,6 +59,9 @@ func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, 
 		return nil, err
 	}
 
+	if res.StatusCode == http.StatusUnauthorized {
+		return nil, errors.HttpStatus(http.StatusBadRequest).New("StatusUnauthorized error while testing connection")
+	}
 	if res.StatusCode != http.StatusOK {
 		return nil, errors.HttpStatus(res.StatusCode).New("unexpected status code while testing connection")
 	}

--- a/backend/plugins/bamboo/models/connection.go
+++ b/backend/plugins/bamboo/models/connection.go
@@ -19,9 +19,10 @@ package models
 
 import (
 	"fmt"
-	"github.com/apache/incubator-devlake/core/plugin"
 	"net/http"
 	"time"
+
+	"github.com/apache/incubator-devlake/core/plugin"
 
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
@@ -53,6 +54,10 @@ func (conn *BambooConn) PrepareApiClient(apiClient apihelperabstract.ApiClientAb
 		return errors.HttpStatus(400).New(fmt.Sprintf("Get failed %s", err.Error()))
 	}
 	repo := &ApiBambooServerInfo{}
+
+	if res.StatusCode == http.StatusUnauthorized {
+		return errors.HttpStatus(http.StatusBadRequest).New("StatusUnauthorized error")
+	}
 
 	if res.StatusCode != http.StatusOK {
 		return errors.HttpStatus(res.StatusCode).New(fmt.Sprintf("unexpected status code: %d", res.StatusCode))

--- a/backend/plugins/bitbucket/api/connection.go
+++ b/backend/plugins/bitbucket/api/connection.go
@@ -19,8 +19,9 @@ package api
 
 import (
 	"context"
-	"github.com/apache/incubator-devlake/server/api/shared"
 	"net/http"
+
+	"github.com/apache/incubator-devlake/server/api/shared"
 
 	"github.com/apache/incubator-devlake/core/errors"
 	plugin "github.com/apache/incubator-devlake/core/plugin"
@@ -56,6 +57,10 @@ func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, 
 	res, err := apiClient.Get("user", nil, nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if res.StatusCode == http.StatusUnauthorized {
+		return nil, errors.HttpStatus(http.StatusBadRequest).New("StatusUnauthorized error when testing connection")
 	}
 
 	if res.StatusCode != http.StatusOK {

--- a/backend/plugins/feishu/models/connection.go
+++ b/backend/plugins/feishu/models/connection.go
@@ -19,6 +19,7 @@ package models
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/apache/incubator-devlake/core/errors"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
@@ -42,6 +43,11 @@ func (conn *FeishuConn) PrepareApiClient(apiClient apihelperabstract.ApiClientAb
 	if err != nil {
 		return err
 	}
+
+	if tokenRes.StatusCode == http.StatusUnauthorized {
+		return errors.HttpStatus(http.StatusBadRequest).New("StatusUnauthorized error when get tenant_access_token")
+	}
+
 	tokenResBody := &apimodels.ApiAccessTokenResponse{}
 	err = helper.UnmarshalResponse(tokenRes, tokenResBody)
 	if err != nil {

--- a/backend/plugins/gitee/api/connection.go
+++ b/backend/plugins/gitee/api/connection.go
@@ -19,8 +19,9 @@ package api
 
 import (
 	"context"
-	"github.com/apache/incubator-devlake/server/api/shared"
 	"net/http"
+
+	"github.com/apache/incubator-devlake/server/api/shared"
 
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
@@ -60,6 +61,10 @@ func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, 
 	err = helper.UnmarshalResponse(res, resBody)
 	if err != nil {
 		return nil, err
+	}
+
+	if res.StatusCode == http.StatusUnauthorized {
+		return nil, errors.HttpStatus(http.StatusBadRequest).New("StatusUnauthorized error when testing connection")
 	}
 
 	if res.StatusCode != http.StatusOK {

--- a/backend/plugins/github/api/connection.go
+++ b/backend/plugins/github/api/connection.go
@@ -60,6 +60,11 @@ func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, 
 	if err != nil {
 		return nil, errors.BadInput.Wrap(err, "verify token failed")
 	}
+
+	if res.StatusCode == http.StatusUnauthorized {
+		return nil, errors.HttpStatus(http.StatusBadRequest).New("StatusUnauthorized error when testing connection")
+	}
+
 	if res.StatusCode != http.StatusOK {
 		return nil, errors.HttpStatus(res.StatusCode).New("unexpected status code while testing connection")
 	}

--- a/backend/plugins/gitlab/api/connection.go
+++ b/backend/plugins/gitlab/api/connection.go
@@ -65,6 +65,10 @@ func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, 
 		return nil, err
 	}
 
+	if res.StatusCode == http.StatusUnauthorized {
+		return nil, errors.HttpStatus(http.StatusBadRequest).New("StatusUnauthorized error when testing api or read_api permissions")
+	}
+
 	if res.StatusCode == http.StatusForbidden {
 		return nil, errors.BadInput.New("token need api or read_api permissions scope")
 	}

--- a/backend/plugins/gitlab/models/connection.go
+++ b/backend/plugins/gitlab/models/connection.go
@@ -19,11 +19,12 @@ package models
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api/apihelperabstract"
-	"net/http"
 )
 
 // GitlabConn holds the essential information to connect to the Gitlab API
@@ -55,7 +56,9 @@ func (conn *GitlabConn) PrepareApiClient(apiClient apihelperabstract.ApiClientAb
 		if err != nil {
 			return errors.Convert(err)
 		}
-
+		if res.StatusCode == http.StatusUnauthorized {
+			return errors.HttpStatus(http.StatusBadRequest).New("StatusUnauthorized error while testing connection")
+		}
 		if res.StatusCode != http.StatusOK {
 			return errors.HttpStatus(res.StatusCode).New("unexpected status code while testing connection")
 		}
@@ -73,7 +76,9 @@ func (conn *GitlabConn) PrepareApiClient(apiClient apihelperabstract.ApiClientAb
 		if err != nil {
 			return errors.Convert(err)
 		}
-
+		if res.StatusCode == http.StatusUnauthorized {
+			return errors.HttpStatus(http.StatusBadRequest).New("StatusUnauthorized error while testing connection[PrivateToken]")
+		}
 		if res.StatusCode != http.StatusOK {
 			return errors.HttpStatus(res.StatusCode).New("unexpected status code while testing connection[PrivateToken]")
 		}

--- a/backend/plugins/jenkins/api/connection.go
+++ b/backend/plugins/jenkins/api/connection.go
@@ -19,8 +19,9 @@ package api
 
 import (
 	"context"
-	"github.com/apache/incubator-devlake/server/api/shared"
 	"net/http"
+
+	"github.com/apache/incubator-devlake/server/api/shared"
 
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
@@ -57,6 +58,10 @@ func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, 
 	res, err := apiClient.Get("", nil, nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if res.StatusCode == http.StatusUnauthorized {
+		return nil, errors.HttpStatus(http.StatusBadRequest).New("StatusUnauthorized error while testing connection")
 	}
 
 	if res.StatusCode != http.StatusOK {

--- a/backend/plugins/jira/api/connection.go
+++ b/backend/plugins/jira/api/connection.go
@@ -20,10 +20,11 @@ package api
 import (
 	"context"
 	"fmt"
-	"github.com/apache/incubator-devlake/server/api/shared"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/apache/incubator-devlake/server/api/shared"
 
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
@@ -82,7 +83,7 @@ func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, 
 		return nil, errors.NotFound.New(fmt.Sprintf("Seems like an invalid Endpoint URL, please try %s", restUrl.String()))
 	}
 	if res.StatusCode == http.StatusUnauthorized {
-		return nil, errors.HttpStatus(res.StatusCode).New("Error username/password")
+		return nil, errors.HttpStatus(http.StatusBadRequest).New("Error username/password")
 	}
 
 	resBody := &models.JiraServerInfo{}
@@ -111,7 +112,7 @@ func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, 
 
 	errMsg := ""
 	if res.StatusCode == http.StatusUnauthorized {
-		return nil, errors.HttpStatus(res.StatusCode).New("it might you use the right token(password) but with the wrong username.please check your username/password")
+		return nil, errors.HttpStatus(http.StatusBadRequest).New("it might you use the right token(password) but with the wrong username.please check your username/password")
 	}
 
 	if res.StatusCode != http.StatusOK {

--- a/backend/plugins/pagerduty/api/connection.go
+++ b/backend/plugins/pagerduty/api/connection.go
@@ -49,6 +49,11 @@ func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, 
 	if err != nil {
 		return nil, err
 	}
+
+	if response.StatusCode == http.StatusUnauthorized {
+		return nil, errors.HttpStatus(http.StatusBadRequest).New("StatusUnauthorized error while testing connection")
+	}
+
 	if response.StatusCode == http.StatusOK {
 		return &plugin.ApiResourceOutput{Body: nil, Status: http.StatusOK}, nil
 	}

--- a/backend/plugins/sonarqube/api/connection.go
+++ b/backend/plugins/sonarqube/api/connection.go
@@ -19,12 +19,13 @@ package api
 
 import (
 	"context"
+	"net/http"
+
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/sonarqube/models"
 	"github.com/apache/incubator-devlake/server/api/shared"
-	"net/http"
 )
 
 type validation struct {
@@ -75,7 +76,7 @@ func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, 
 		}
 		return &plugin.ApiResourceOutput{Body: body, Status: 200}, nil
 	case 401: // error secretKey or nonceStr
-		return &plugin.ApiResourceOutput{Body: false, Status: res.StatusCode}, nil
+		return &plugin.ApiResourceOutput{Body: false, Status: http.StatusBadRequest}, nil
 	default: // unknow what happen , back to user
 		return &plugin.ApiResourceOutput{Body: res.Body, Status: res.StatusCode}, nil
 	}

--- a/backend/plugins/tapd/api/connection.go
+++ b/backend/plugins/tapd/api/connection.go
@@ -20,8 +20,9 @@ package api
 import (
 	"context"
 	"fmt"
-	"github.com/apache/incubator-devlake/server/api/shared"
 	"net/http"
+
+	"github.com/apache/incubator-devlake/server/api/shared"
 
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
@@ -60,7 +61,7 @@ func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, 
 		return nil, err
 	}
 	if res.StatusCode == http.StatusUnauthorized {
-		return nil, errors.Unauthorized.New(fmt.Sprintf("verify token failed for %s", connection.Username))
+		return nil, errors.HttpStatus(http.StatusBadRequest).New(fmt.Sprintf("verify token failed for %s", connection.Username))
 	}
 	if res.StatusCode != http.StatusOK {
 		return nil, errors.HttpStatus(res.StatusCode).New(fmt.Sprintf("unexpected status code: %d", res.StatusCode))

--- a/backend/plugins/teambition/api/connection.go
+++ b/backend/plugins/teambition/api/connection.go
@@ -20,13 +20,14 @@ package api
 import (
 	"context"
 	"fmt"
+	"net/http"
+
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/teambition/models"
 	"github.com/apache/incubator-devlake/plugins/teambition/tasks"
 	"github.com/apache/incubator-devlake/server/api/shared"
-	"net/http"
 )
 
 type TeambitionTestConnResponse struct {
@@ -61,6 +62,9 @@ func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, 
 		return nil, err
 	}
 
+	if res.StatusCode == http.StatusUnauthorized {
+		return nil, errors.HttpStatus(http.StatusBadRequest).New("StatusUnauthorized error while testing connection")
+	}
 	if res.StatusCode != http.StatusOK {
 		return nil, errors.HttpStatus(res.StatusCode).New(fmt.Sprintf("unexpected status code: %d", res.StatusCode))
 	}
@@ -70,7 +74,10 @@ func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, 
 		return nil, err
 	}
 	if resBody.Code != http.StatusOK {
-		return nil, errors.HttpStatus(res.StatusCode).New(fmt.Sprintf("unexpected status code: %d", res.StatusCode))
+		return nil, errors.HttpStatus(http.StatusBadRequest).New("StatusUnauthorized on body while testing connection")
+	}
+	if resBody.Code != http.StatusOK {
+		return nil, errors.HttpStatus(resBody.Code).New(fmt.Sprintf("unexpected body status code: %d", resBody.Code))
 	}
 
 	body := TeambitionTestConnResponse{}

--- a/backend/plugins/trello/api/connection.go
+++ b/backend/plugins/trello/api/connection.go
@@ -19,8 +19,9 @@ package api
 
 import (
 	"context"
-	"github.com/apache/incubator-devlake/server/api/shared"
 	"net/http"
+
+	"github.com/apache/incubator-devlake/server/api/shared"
 
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
@@ -57,6 +58,11 @@ func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, 
 	if err != nil {
 		return nil, errors.BadInput.Wrap(err, "verify token failed")
 	}
+
+	if res.StatusCode == http.StatusUnauthorized {
+		return nil, errors.HttpStatus(http.StatusBadRequest).New("StatusUnauthorized error while testing connection")
+	}
+
 	if res.StatusCode != http.StatusOK {
 		return nil, errors.HttpStatus(res.StatusCode).New("unexpected status code while testing connection")
 	}

--- a/backend/plugins/zentao/models/connection.go
+++ b/backend/plugins/zentao/models/connection.go
@@ -19,6 +19,7 @@ package models
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/apache/incubator-devlake/core/errors"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
@@ -36,6 +37,11 @@ func (connection ZentaoConn) PrepareApiClient(apiClient apihelperabstract.ApiCli
 	if err != nil {
 		return err
 	}
+
+	if tokenRes.StatusCode == http.StatusUnauthorized {
+		return errors.HttpStatus(http.StatusBadRequest).New("StatusUnauthorized error while to request access token")
+	}
+
 	tokenResBody := &ApiAccessTokenResponse{}
 	err = helper.UnmarshalResponse(tokenRes, tokenResBody)
 	if err != nil {


### PR DESCRIPTION
### Summary
Because of the 401 error will reset the config-UI login.
So It changed all 401 to 400.

### Does this close any open issues?
Closes #5068 

### Screenshots
![image](https://user-images.githubusercontent.com/2921251/235118957-e607c2cf-fbbd-4f7f-8a0d-990b8f21d2f5.png)
![image](https://user-images.githubusercontent.com/2921251/235119078-4479f03e-ba60-49fc-af00-cc44a7fae0c7.png)
![image](https://user-images.githubusercontent.com/2921251/235122543-2e0fa38c-d305-4b70-b20c-17c1d5879cc8.png)
![image](https://user-images.githubusercontent.com/2921251/235122717-0163c044-6765-4c2d-972c-e79b8798188c.png)
![image](https://user-images.githubusercontent.com/2921251/235122822-873a059d-1be9-44d6-b664-f7f19bb69787.png)
![image](https://user-images.githubusercontent.com/2921251/235125148-351bee73-81be-49d6-ac76-94831b15068d.png)
![image](https://user-images.githubusercontent.com/2921251/235125208-ca1b180e-659d-4d7b-b634-d7b149d5fe70.png)
![image](https://user-images.githubusercontent.com/2921251/235125275-b3b65417-2350-4ef9-a7da-009eb3a35f56.png)
![image](https://user-images.githubusercontent.com/2921251/235125523-1265f72e-ada0-411a-af8e-6cd001635da2.png)


