### PR TITLE
Fix empty tx rules patterns

### DIFF
--- a/backend/python/plugins/azuredevops/azuredevops/streams/pull_request_commits.py
+++ b/backend/python/plugins/azuredevops/azuredevops/streams/pull_request_commits.py
@@ -30,7 +30,7 @@ class GitPullRequestCommits(Substream):
     def collect(self, state, context, parent: GitPullRequest) -> Iterable[tuple[object, dict]]:
         repo: GitRepository = context.scope
         azuredevops_api = AzureDevOpsAPI(context.connection)
-        response = azuredevops_api.git_repo_pull_request_commits(repo.org_id, repo.project_id, parent.repo_id, parent.id)
+        response = azuredevops_api.git_repo_pull_request_commits(repo.org_id, repo.project_id, repo.id, parent.pull_request_id)
         for raw_commit in response:
             raw_commit["pull_request_id"] = parent.domain_id()
             yield raw_commit, state

--- a/backend/python/pydevlake/pydevlake/model.py
+++ b/backend/python/pydevlake/pydevlake/model.py
@@ -46,6 +46,16 @@ class ToolTable(SQLModel):
         plural_entity = inflect_engine.plural_noun(cls.__name__.lower())
         return f'_tool_{plugin_name}_{plural_entity}'
 
+    class Config:
+        allow_population_by_field_name = True
+
+        @classmethod
+        def alias_generator(cls, attr_name: str) -> str:
+            # Allow to set snake_cased attributes with camelCased keyword args.
+            # Useful for extractors dealing with raw data that has camelCased attributes.
+            parts = attr_name.split('_')
+            return parts[0] + ''.join(word.capitalize() for word in parts[1:])
+
 
 class Connection(ToolTable, Model):
     name: str
@@ -117,16 +127,6 @@ class ToolModel(ToolTable, NoPKModel):
             if prop.key == 'connection_id':
                 continue
             yield getattr(self, prop.key)
-
-    class Config:
-        allow_population_by_field_name = True
-
-        @classmethod
-        def alias_generator(cls, attr_name: str) -> str:
-            # Allow to set snake_cased attributes with camelCased keyword args.
-            # Useful for extractors dealing with raw data that has camelCased attributes.
-            parts = attr_name.split('_')
-            return parts[0] + ''.join(word.capitalize() for word in parts[1:])
 
 
 class DomainModel(NoPKModel):


### PR DESCRIPTION
### Summary

Fix empty transformation rule fields in db caused by a casing mismatch.
@hezyin 

### Does this close any open issues?
Closes #5072 
