### PR TITLE
Exclude all non-job timeline entries from collection

### DIFF
--- a/backend/python/plugins/azuredevops/azuredevops/streams/jobs.py
+++ b/backend/python/plugins/azuredevops/azuredevops/streams/jobs.py
@@ -32,8 +32,9 @@ class Jobs(Substream):
         api = AzureDevOpsAPI(context.connection)
         response = api.jobs(repo.org_id, repo.project_id, parent.id)
         for raw_job in response.json["records"]:
-            raw_job["build_id"] = parent.domain_id()
-            yield raw_job, state
+            if raw_job["type"] == "Job":
+                raw_job["build_id"] = parent.domain_id()
+                yield raw_job, state
 
     def convert(self, j: Job, ctx: Context) -> Iterable[devops.CICDPipeline]:
         result = None


### PR DESCRIPTION
### Summary

Exclude all timeline entries that are not jobs from the Jobs stream of AzureDevops plugin.
@hezyin 

### Does this close any open issues?
Closes #5070