### PR TITLE
feat: save board as kanban type

### DIFF
--- a/backend/plugins/customize/service/service.go
+++ b/backend/plugins/customize/service/service.go
@@ -167,6 +167,7 @@ func (s *Service) SaveBoard(boardId, boardName string) errors.Error {
 			Id: boardId,
 		},
 		Name: boardName,
+		Type: "kanban",
 	})
 }
 


### PR DESCRIPTION
### Summary
This pull request adds functionality to insert or update a new record into the `boards` table with the type set to kanban, upon uploading the issues.csv file. 

### Does this close any open issues?
Closes #5086 

