### PR TITLE
fix: no pagination is used in the collectionAccounts of gitlab

### DIFF
--- a/backend/plugins/gitlab/tasks/account_collector.go
+++ b/backend/plugins/gitlab/tasks/account_collector.go
@@ -19,6 +19,7 @@ package tasks
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 
@@ -54,12 +55,11 @@ func CollectAccounts(taskCtx plugin.SubTaskContext) errors.Error {
 		RawDataSubTaskArgs: *rawDataSubTaskArgs,
 		ApiClient:          data.ApiClient,
 		UrlTemplate:        urlTemplate,
-		//PageSize:           100,
+		PageSize:           100,
 		Query: func(reqData *api.RequestData) (url.Values, errors.Error) {
 			query := url.Values{}
-			// query.Set("sort", "asc")
-			// query.Set("page", fmt.Sprintf("%v", reqData.Pager.Page))
-			// query.Set("per_page", fmt.Sprintf("%v", reqData.Pager.Size))
+			query.Set("page", fmt.Sprintf("%v", reqData.Pager.Page))
+			query.Set("per_page", fmt.Sprintf("%v", reqData.Pager.Size))
 			return query, nil
 		},
 


### PR DESCRIPTION
### Summary

It seems like the pagination code has always been commented out since day one.
I checked the API reference, nothing strange, and tried to uncomment the related code and ran it locally, all seems fine...

### Does this close any open issues?
Closes #5126

### Screenshots
![gitlab-collect-account](https://user-images.githubusercontent.com/61080/237018000-1c5673b9-8f35-43a0-998c-9c27c18875ef.png)
![gitlab-collect-account-db](https://user-images.githubusercontent.com/61080/237018005-ea88a3a3-d823-421c-afab-d0a0125b72c5.png)
