### PR TITLE
feat: upgrade grafana to v9.5.1

### DIFF
--- a/config-ui/nginx.conf
+++ b/config-ui/nginx.conf
@@ -29,6 +29,7 @@ ${SERVER_CONF}
     resolver_timeout 3s;
     set $target "${GRAFANA_ENDPOINT}";
     rewrite /grafana/(.*) /$1  break;
+    proxy_set_header Host $http_host;
     proxy_set_header Authorization "";
     proxy_set_header X-Forwarded-Access-Token "${cookie_access_token}";
     proxy_send_timeout 60s;

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -23,7 +23,7 @@
 #While incubation status is not necessarily a reflection of the completeness or stability of the code,
 #it does indicate that the project has yet to be fully endorsed by the ASF.
 
-FROM grafana/grafana:8.0.6
+FROM grafana/grafana:9.5.1
 COPY ./provisioning/dashboards /etc/grafana/provisioning/dashboards
 COPY ./provisioning/datasources /etc/grafana/provisioning/datasources
 COPY ./dashboards /etc/grafana/dashboards


### PR DESCRIPTION
### Summary
upgrade grafana to v9.5.1

### Does this close any open issues?
Closes #5017

### Screenshots
Collect 1 month data from `apache/incubator-devlake` and the `Github` dashboard seemed alright.
![github](https://github.com/apache/incubator-devlake/assets/61080/c0040fa3-a71b-4dba-83bb-e5ceef1394f6)



