### PR TITLE
fix: the overflow error of _tool_jira_remotelinks.self

### DIFF
--- a/backend/plugins/jira/models/migrationscripts/20230510_expand_remotelink_selfurl.go
+++ b/backend/plugins/jira/models/migrationscripts/20230510_expand_remotelink_selfurl.go
@@ -1,0 +1,69 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/dal"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/helpers/migrationhelper"
+)
+
+var _ plugin.MigrationScript = (*expandRemotelinkUrl)(nil)
+
+type jiraRemotelink20230510 struct {
+	Self string
+}
+
+func (jiraRemotelink20230510) TableName() string {
+	return "_tool_jira_remotelinks"
+}
+
+type expandRemotelinkSelfUrl struct{}
+
+func (script *expandRemotelinkSelfUrl) Up(basicRes context.BasicRes) errors.Error {
+	db := basicRes.GetDal()
+	// expand _tool_jira_remotelinks.url to LONGTEXT
+	err := migrationhelper.ChangeColumnsType[jiraRemotelink20230510](
+		basicRes,
+		script,
+		jiraRemotelink20230510{}.TableName(),
+		[]string{"self"},
+		func(tmpColumnParams []interface{}) errors.Error {
+			return db.UpdateColumn(
+				&jiraRemotelink20230510{},
+				"self",
+				dal.DalClause{Expr: " ? ", Params: tmpColumnParams},
+				dal.Where("? is not null ", tmpColumnParams...),
+			)
+		},
+	)
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+func (*expandRemotelinkSelfUrl) Version() uint64 {
+	return 20230510110029
+}
+
+func (*expandRemotelinkSelfUrl) Name() string {
+	return "expand _tool_jira_remotelinks.self to LONGTEXT"
+}

--- a/backend/plugins/jira/models/migrationscripts/register.go
+++ b/backend/plugins/jira/models/migrationscripts/register.go
@@ -35,5 +35,6 @@ func All() []plugin.MigrationScript {
 		new(expandRemotelinkUrl),
 		new(addConnectionIdToTransformationRule),
 		new(addChangeTotal20230412),
+		new(expandRemotelinkSelfUrl),
 	}
 }


### PR DESCRIPTION
### Summary
Fix the DB overflow error by changing the type of `_tool_jira_remotelinks.self` from `VARCHAR(255)` to `LONGTEXT`
Now the schema looks like:
```SQL
CREATE TABLE _tool_jira_remotelinks (
    created_at timestamp with time zone,
    updated_at timestamp with time zone,
    _raw_data_params character varying(255),
    _raw_data_table character varying(255),
    _raw_data_id bigint,
    _raw_data_remark text,
    connection_id bigint,
    remotelink_id bigint,
    issue_id bigint,
    raw_json jsonb,
    title text,
    issue_updated timestamp with time zone,
    url text,
    self text,
    CONSTRAINT _tool_jira_remotelinks_pkey PRIMARY KEY (connection_id, remotelink_id)
);
```
### Does this close any open issues?
Closes #5146 

