### PR TITLE
fix: Set type of description column to TEXT

### DIFF
--- a/backend/python/plugins/azuredevops/azuredevops/models.py
+++ b/backend/python/plugins/azuredevops/azuredevops/models.py
@@ -60,7 +60,7 @@ class GitPullRequest(ToolModel, table=True):
     closed_date: Optional[datetime.datetime]
     source_commit_sha: str = Field(source='/lastMergeSourceCommit/commitId')
     target_commit_sha: str = Field(source='/lastMergeTargetCommit/commitId')
-    merge_commit_sha: str = Field(source='/lastMergeCommit/commitId')
+    merge_commit_sha: Optional[str] = Field(source='/lastMergeCommit/commitId')
     url: Optional[str]
     type: Optional[str] = Field(source='/labels/0/name') # TODO: get this off transformation rules regex
     title: Optional[str]
@@ -70,7 +70,11 @@ class GitPullRequest(ToolModel, table=True):
 
     @classmethod
     def migrate(self, session: Session):
-        session.execute(f'ALTER TABLE {self.__tablename__} MODIFY COLUMN description TEXT')
+        dialect = session.bind.dialect.name
+        if dialect == 'mysql':
+            session.execute(f'ALTER TABLE {self.__tablename__} MODIFY COLUMN description TEXT')
+        elif dialect == 'postgresql':
+            session.execute(f'ALTER TABLE {self.__tablename__} ALTER COLUMN description TYPE TEXT')
 
 
 class GitPullRequestCommit(ToolModel, table=True):

--- a/backend/python/plugins/azuredevops/azuredevops/models.py
+++ b/backend/python/plugins/azuredevops/azuredevops/models.py
@@ -18,7 +18,7 @@ from enum import Enum
 from typing import Optional
 import re
 
-from sqlmodel import Session
+from sqlmodel import Session, Column, Text
 
 from pydevlake import Field, Connection, TransformationRule
 from pydevlake.model import ToolModel, ToolScope
@@ -52,7 +52,7 @@ class GitPullRequest(ToolModel, table=True):
         Completed = "completed"
 
     pull_request_id: int = Field(primary_key=True)
-    description: Optional[str]
+    description: Optional[str] = Field(sa_column=Column(Text))
     status: PRStatus
     created_by_id: str = Field(source='/createdBy/id')
     created_by_name: str = Field(source='/createdBy/displayName')
@@ -67,6 +67,10 @@ class GitPullRequest(ToolModel, table=True):
     target_ref_name: Optional[str]
     source_ref_name: Optional[str]
     fork_repo_id: Optional[str] = Field(source='/forkSource/repository/id')
+
+    @classmethod
+    def migrate(self, session: Session):
+        session.execute(f'ALTER TABLE {self.__tablename__} MODIFY COLUMN description TEXT')
 
 
 class GitPullRequestCommit(ToolModel, table=True):


### PR DESCRIPTION
### Summary

Change the type of azure devops pull request description from `var(255)` to `text`.

### Does this close any open issues?
Closes #5151 