### PR TITLE
fix: Make PR.merge_commit_sha optional

### DIFF
--- a/backend/python/plugins/azuredevops/azuredevops/models.py
+++ b/backend/python/plugins/azuredevops/azuredevops/models.py
@@ -60,7 +60,7 @@ class GitPullRequest(ToolModel, table=True):
     closed_date: Optional[datetime.datetime]
     source_commit_sha: str = Field(source='/lastMergeSourceCommit/commitId')
     target_commit_sha: str = Field(source='/lastMergeTargetCommit/commitId')
-    merge_commit_sha: str = Field(source='/lastMergeCommit/commitId')
+    merge_commit_sha: Optional[str] = Field(source='/lastMergeCommit/commitId')
     url: Optional[str]
     type: Optional[str] = Field(source='/labels/0/name') # TODO: get this off transformation rules regex
     title: Optional[str]


### PR DESCRIPTION
### Summary
Fix collection of abandonned PRs that don't have the lastMergeCommit property.

### Does this close any open issues?
Closes #5108 
