### PR TITLE
fix: Fix Job.migrate on postgresql

### DIFF
--- a/backend/python/plugins/azuredevops/azuredevops/models.py
+++ b/backend/python/plugins/azuredevops/azuredevops/models.py
@@ -126,5 +126,11 @@ class Job(ToolModel, table=True):
 
     @classmethod
     def migrate(self, session: Session):
-        session.execute(f'ALTER TABLE {self.__tablename__} DROP PRIMARY KEY')
+        dialect = session.bind.dialect.name
+        if dialect == 'mysql':
+            session.execute(f'ALTER TABLE {self.__tablename__} DROP PRIMARY KEY')
+        elif dialect == 'postgresql':
+            session.execute(f'ALTER TABLE {self.__tablename__} DROP CONSTRAINT {self.__tablename__}_pkey')
+        else:
+            raise Exception(f'Unsupported dialect {dialect}')
         session.execute(f'ALTER TABLE {self.__tablename__} ADD PRIMARY KEY (id, build_id)')


### PR DESCRIPTION
### Summary
Fix azuredevops migration for jobs table on postgresql.
MySQL and postgresql don't have the same syntax to remove a primary key constraint.


### Does this close any open issues?
Closes #5187 
