### PR TITLE
[fix-5107]: PagerDuty data collection limit with service filtering

### DIFF
--- a/backend/helpers/pluginhelper/api/api_async_client.go
+++ b/backend/helpers/pluginhelper/api/api_async_client.go
@@ -181,13 +181,14 @@ func (apiClient *ApiAsyncClient) DoAsync(
 
 		// check
 		needRetry := false
+		errMessage := "unknown"
 		if err != nil {
 			needRetry = true
+			errMessage = err.Error()
 		} else if res.StatusCode >= HttpMinStatusRetryCode {
 			needRetry = true
-			err = errors.HttpStatus(res.StatusCode).New(
-				fmt.Sprintf("Http DoAsync error calling [%s %s]. Response: %s", method, path, string(respBody)),
-			)
+			errMessage = fmt.Sprintf("Http DoAsync error calling [%s %s]. Response: %s", method, path, string(respBody))
+			err = errors.HttpStatus(res.StatusCode).New(errMessage)
 		}
 
 		//  if it needs retry, check and retry
@@ -205,7 +206,7 @@ func (apiClient *ApiAsyncClient) DoAsync(
 		}
 
 		if err != nil {
-			err = errors.Default.Wrap(err, fmt.Sprintf("retry exceeded %d times calling %s", retry, path))
+			err = errors.Default.Wrap(err, fmt.Sprintf("Retry exceeded %d times calling %s. The last error was: %s", retry, path, errMessage))
 			apiClient.logger.Error(err, "")
 			return errors.Convert(err)
 		}

--- a/backend/plugins/pagerduty/tasks/incidents_collector.go
+++ b/backend/plugins/pagerduty/tasks/incidents_collector.go
@@ -71,13 +71,12 @@ func CollectIncidents(taskCtx plugin.SubTaskContext) errors.Error {
 		TimeAfter:          data.TimeAfter,
 		CollectNewRecordsByList: api.FinalizableApiCollectorListArgs{
 			PageSize: 100,
-			GetTotalPages: func(res *http.Response, args *api.ApiCollectorArgs) (int, errors.Error) {
-				paging := pagingInfo{}
-				err := api.UnmarshalResponse(res, &paging)
-				if err != nil {
-					return 0, errors.BadInput.Wrap(err, "failed to determined paging count")
+			GetNextPageCustomData: func(prevReqData *api.RequestData, prevPageResponse *http.Response) (interface{}, errors.Error) {
+				pager := prevReqData.Pager
+				if pager.Skip+pager.Size >= 10_000 { // API limit. Can't exceed this or it'll error out
+					return nil, api.ErrFinishCollect
 				}
-				return *paging.Total, nil
+				return nil, nil
 			},
 			FinalizableApiCollectorCommonArgs: api.FinalizableApiCollectorCommonArgs{
 				UrlTemplate: "incidents",
@@ -95,7 +94,8 @@ func CollectIncidents(taskCtx plugin.SubTaskContext) errors.Error {
 					} else {
 						query.Set("date_range", "all")
 					}
-					query.Set("sort_by", "created_at:desc")
+					query.Set("service_ids[]", data.Options.ServiceId)
+					query.Set("sort_by", "created_at:desc") // the newest entries will be fetched first
 					query.Set("limit", fmt.Sprintf("%d", reqData.Pager.Size))
 					query.Set("offset", fmt.Sprintf("%d", reqData.Pager.Skip))
 					query.Set("total", "true")


### PR DESCRIPTION
### Does this close any open issues?
Closes #5107

### Screenshots
Wrote a script to generate a little over 10k incidents on my account. The reported error was reproduced with the original code, and resolved by the fix. Exactly up to 10k latest incidents will now get returned.
![image](https://github.com/apache/incubator-devlake/assets/25063936/14186849-ba9d-48e1-a37a-e0ac6183821b)
![image](https://github.com/apache/incubator-devlake/assets/25063936/e4ce7750-8c95-43ab-85ed-b2b88a0a862b)


### Other Information
Any other information that is important to this PR.
