### PR TITLE
Use text instead of varchar(255) for GitHubRun's name

### DIFF
--- a/backend/plugins/github/models/migrationscripts/20230518_fix_run_name_to_text.go
+++ b/backend/plugins/github/models/migrationscripts/20230518_fix_run_name_to_text.go
@@ -1,0 +1,69 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/helpers/migrationhelper"
+)
+
+type fixRunNameToText struct{}
+
+type githubRun20230518_old struct {
+	ConnectionId uint64 `gorm:"primaryKey"`
+	RepoId       int    `gorm:"primaryKey"`
+
+	Name string `gorm:"type:varchar(255)"`
+}
+type githubRun20230518 struct {
+	ConnectionId uint64 `gorm:"primaryKey"`
+	RepoId       int    `gorm:"primaryKey"`
+
+	Name string `gorm:"type:text"`
+}
+
+func (*fixRunNameToText) Up(baseRes context.BasicRes) errors.Error {
+	err := migrationhelper.TransformColumns(
+		baseRes,
+		&fixRunNameToText{},
+		"_tool_github_runs",
+		[]string{"name"},
+		func(src *githubRun20230518_old) (*githubRun20230518, errors.Error) {
+			return &githubRun20230518{
+				ConnectionId: src.ConnectionId,
+				RepoId:       src.RepoId,
+				Name:         src.Name,
+			}, nil
+		},
+	)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (*fixRunNameToText) Version() uint64 {
+	return 20230518000001
+}
+
+func (*fixRunNameToText) Name() string {
+	return "UpdateSchemas for fixRunNameToText"
+}

--- a/backend/plugins/github/models/migrationscripts/register.go
+++ b/backend/plugins/github/models/migrationscripts/register.go
@@ -37,5 +37,6 @@ func All() []plugin.MigrationScript {
 		new(addConnectionIdToTransformationRule),
 		new(addEnvToRunAndJob),
 		new(addGithubCommitAuthorInfo),
+		new(fixRunNameToText),
 	}
 }

--- a/backend/plugins/github/models/run.go
+++ b/backend/plugins/github/models/run.go
@@ -27,7 +27,7 @@ type GithubRun struct {
 	ConnectionId     uint64     `gorm:"primaryKey"`
 	RepoId           int        `gorm:"primaryKey"`
 	ID               int        `json:"id" gorm:"primaryKey;autoIncrement:false"`
-	Name             string     `json:"name" gorm:"type:varchar(255)"`
+	Name             string     `json:"name" gorm:"type:text"`
 	NodeID           string     `json:"node_id" gorm:"type:varchar(255)"`
 	HeadBranch       string     `json:"head_branch" gorm:"type:varchar(255)"`
 	HeadSha          string     `json:"head_sha" gorm:"type:varchar(255)"`


### PR DESCRIPTION
I do not have rights to add labels.

### Summary
Github workflows may have longer than 255 characters long names. In order to sync it I changed gorm type from `varchar(255)` to `text` for `GithubRun` type `Name` field. 


### Other Information
Error received while syncing github repository:
```
time="2023-05-09 08:37:03" level=error msg=" [pipeline service] [pipeline #3] [task #25] subtask extractRuns ended unexpectedly
	Wraps: (2) error adding result to batch
	Wraps: (3) Error 1406: Data too long for column 'name' at row 17
	Wraps: (4) Error 1406: Data too long for column 'name' at row 17
	Error types: (1) *hintdetail.withDetail (2) *hintdetail.withDetail (3) *hintdetail.withDetail (4) *mysql.MySQLError"
```