### PR TITLE
chore: change version to a input instead of select

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -75,28 +75,13 @@ body:
       description: Anything else we need to know?
       placeholder: >
         Eg. How often does this problem occur? (Once? Every time? Only when certain conditions are met?)
-  - type: dropdown
+  - type: input
     id: version
     attributes:
       label: Version
       description: >
-        Which version of Apache DevLake are you running?
-      options:
-        - main
-        - v0.16.0
-        - v0.15.0
-        - v0.14.2
-        - v0.14.1
-        - v0.14.0
-        - v0.13.0
-        - v0.12.0
-        - v0.11.0
-        - v0.10.1
-        - v0.10.0
-        - v0.9.3
-        - v0.9.2
-        - v0.9.1
-        - v0.9.0
+        Which version or commit sha of Apache DevLake are you running, e.g. `v0.17.0-beta2` or `2b190844de47d343d84dcf351c6ac57aed826298` (if you were running devlake from the source code directly)?
+      placeholder: v0.17.0-beta2 or 2b190844de47d343d84dcf351c6ac57aed826298
     validations:
       required: true
 


### PR DESCRIPTION
### Summary
chore: change version to a input instead of select


### Does this close any open issues?
Closes #5128
