### PR TITLE
[feat-4864] Support for deleting blueprints

### DIFF
--- a/backend/helpers/pluginhelper/services/blueprint_helper.go
+++ b/backend/helpers/pluginhelper/services/blueprint_helper.go
@@ -22,6 +22,7 @@ import (
 	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/models"
+	"github.com/apache/incubator-devlake/core/models/common"
 	"github.com/apache/incubator-devlake/core/plugin"
 )
 
@@ -189,6 +190,16 @@ func (b *BlueprintManager) GetDbBlueprintByProjectName(projectName string) (*mod
 		return nil, err
 	}
 	return dbBlueprint, nil
+}
+
+// DeleteBlueprint deletes a blueprint by its id
+func (b *BlueprintManager) DeleteBlueprint(id uint64) errors.Error {
+	dbBlueprint := &models.Blueprint{
+		Model: common.Model{
+			ID: id,
+		},
+	}
+	return b.db.Delete(&dbBlueprint)
 }
 
 func (b *BlueprintManager) fillBlueprintDetail(blueprint *models.Blueprint) errors.Error {

--- a/backend/server/api/blueprints/blueprints.go
+++ b/backend/server/api/blueprints/blueprints.go
@@ -216,3 +216,27 @@ func GetBlueprintPipelines(c *gin.Context) {
 	}
 	shared.ApiOutputSuccess(c, shared.ResponsePipelines{Pipelines: pipelines, Count: count}, http.StatusOK)
 }
+
+// @Summary delete blueprint by id
+// @Description delete blueprint by id
+// @Tags framework/blueprints
+// @Accept application/json
+// @Param blueprintId path int true "blueprint id"
+// @Success 200
+// @Failure 400  {object} shared.ApiBody "Bad Request"
+// @Failure 500  {object} shared.ApiBody "Internal Error"
+// @Router /blueprints/{blueprintId} [delete]
+func Delete(c *gin.Context) {
+	blueprintId := c.Param("blueprintId")
+	id, err := strconv.ParseUint(blueprintId, 10, 64)
+	if err != nil {
+		shared.ApiOutputError(c, errors.BadInput.Wrap(err, "bad blueprintId format supplied"))
+		return
+	}
+	err = services.DeleteBlueprint(id)
+	if err != nil {
+		shared.ApiOutputError(c, errors.Default.Wrap(err, "error deleting blueprint"))
+		return
+	}
+	shared.ApiOutputSuccess(c, nil, http.StatusOK)
+}

--- a/backend/server/api/router.go
+++ b/backend/server/api/router.go
@@ -42,7 +42,7 @@ func RegisterRouter(r *gin.Engine) {
 	r.GET("/pipelines/:pipelineId", pipelines.Get)
 	r.PATCH("/blueprints/:blueprintId", blueprints.Patch)
 	r.POST("/blueprints/:blueprintId/trigger", blueprints.Trigger)
-	// r.DELETE("/blueprints/:blueprintId", blueprints.Delete)
+	r.DELETE("/blueprints/:blueprintId", blueprints.Delete)
 
 	r.GET("/blueprints", blueprints.Index)
 	r.POST("/blueprints", blueprints.Post)

--- a/backend/server/services/blueprint.go
+++ b/backend/server/services/blueprint.go
@@ -224,6 +224,19 @@ func PatchBlueprint(id uint64, body map[string]interface{}) (*models.Blueprint, 
 	return blueprint, nil
 }
 
+// DeleteBlueprint FIXME ...
+func DeleteBlueprint(id uint64) errors.Error {
+	bp, err := bpManager.GetDbBlueprint(id)
+	if err != nil {
+		return err
+	}
+	err = bpManager.DeleteBlueprint(bp.ID)
+	if err != nil {
+		return errors.Default.Wrap(err, "Failed to delete the blueprint")
+	}
+	return nil
+}
+
 // ReloadBlueprints FIXME ...
 func ReloadBlueprints(c *cron.Cron) errors.Error {
 	enable := true

--- a/backend/test/helper/api.go
+++ b/backend/test/helper/api.go
@@ -101,7 +101,14 @@ func (d *DevlakeClient) GetBlueprint(blueprintId uint64) models.Blueprint {
 	return sendHttpRequest[models.Blueprint](d.testCtx, d.timeout, debugInfo{
 		print:      true,
 		inlineJson: false,
-	}, http.MethodGet, fmt.Sprintf("%s/blueprint/%d", d.Endpoint, blueprintId), nil, nil)
+	}, http.MethodGet, fmt.Sprintf("%s/blueprints/%d", d.Endpoint, blueprintId), nil, nil)
+}
+
+func (d *DevlakeClient) DeleteBlueprint(blueprintId uint64) {
+	sendHttpRequest[any](d.testCtx, d.timeout, debugInfo{
+		print:      true,
+		inlineJson: false,
+	}, http.MethodDelete, fmt.Sprintf("%s/blueprints/%d", d.Endpoint, blueprintId), nil, nil)
 }
 
 func (d *DevlakeClient) CreateProject(project *ProjectConfig) models.ApiOutputProject {


### PR DESCRIPTION
### Summary
Blueprints may now be deleted. The new endpoint is:
`DELETE http://devlake-endpoint/blueprints/[1]`
where `[1] = blueprintId`.

This returns nothing and only deletes the blueprint from the backend. This does not impact scopes or blueprint data.

### Does this close any open issues?
Part of #4864 

### Testing
Manually verified against PagerDuty (using two scopes/services), and Python via an integration test.

### Other Information
Any other information that is important to this PR.
