### PR TITLE
[fix-5233]: Pagerduty MTTR computation fix

### DIFF
--- a/backend/plugins/pagerduty/impl/impl.go
+++ b/backend/plugins/pagerduty/impl/impl.go
@@ -57,6 +57,7 @@ func (p PagerDuty) SubTaskMetas() []plugin.SubTaskMeta {
 		tasks.CollectIncidentsMeta,
 		tasks.ExtractIncidentsMeta,
 		tasks.ConvertIncidentsMeta,
+		tasks.ConvertServicesMeta,
 	}
 }
 

--- a/backend/plugins/pagerduty/tasks/incidents_converter.go
+++ b/backend/plugins/pagerduty/tasks/incidents_converter.go
@@ -66,6 +66,7 @@ func ConvertIncidents(taskCtx plugin.SubTaskContext) errors.Error {
 	defer cursor.Close()
 	seenIncidents := map[int]*IncidentWithUser{}
 	idGen := didgen.NewDomainIdGenerator(&models.Incident{})
+	serviceIdGen := didgen.NewDomainIdGenerator(&models.Service{})
 	converter, err := api.NewDataConverter(api.DataConverterArgs{
 		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
 			Ctx:     taskCtx,
@@ -105,7 +106,12 @@ func ConvertIncidents(taskCtx plugin.SubTaskContext) errors.Error {
 				AssigneeName:    user.Name,
 			}
 			seenIncidents[incident.Number] = combined
+			boardIssue := &ticket.BoardIssue{
+				BoardId: serviceIdGen.Generate(data.Options.ConnectionId, data.Options.ServiceId),
+				IssueId: domainIssue.Id,
+			}
 			return []interface{}{
+				boardIssue,
 				domainIssue,
 			}, nil
 		},

--- a/backend/plugins/pagerduty/tasks/service_converter.go
+++ b/backend/plugins/pagerduty/tasks/service_converter.go
@@ -21,7 +21,6 @@ import (
 	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/models/domainlayer"
-	"github.com/apache/incubator-devlake/core/models/domainlayer/devops"
 	"github.com/apache/incubator-devlake/core/models/domainlayer/didgen"
 	"github.com/apache/incubator-devlake/core/models/domainlayer/ticket"
 	"github.com/apache/incubator-devlake/core/plugin"
@@ -62,15 +61,7 @@ func ConvertServices(taskCtx plugin.SubTaskContext) errors.Error {
 				Name: service.Name,
 				Url:  service.Url,
 			}
-			domainCicdScope := &devops.CicdScope{
-				DomainEntity: domainlayer.DomainEntity{
-					Id: didgen.NewDomainIdGenerator(service).Generate(service.ConnectionId, service.Id),
-				},
-				Name: service.Name,
-				Url:  service.Url,
-			}
 			return []interface{}{
-				domainCicdScope,
 				domainBoard,
 			}, nil
 		},

--- a/backend/plugins/pagerduty/tasks/service_converter.go
+++ b/backend/plugins/pagerduty/tasks/service_converter.go
@@ -1,0 +1,90 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"github.com/apache/incubator-devlake/core/dal"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/models/domainlayer"
+	"github.com/apache/incubator-devlake/core/models/domainlayer/devops"
+	"github.com/apache/incubator-devlake/core/models/domainlayer/didgen"
+	"github.com/apache/incubator-devlake/core/models/domainlayer/ticket"
+	"github.com/apache/incubator-devlake/core/plugin"
+	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/plugins/pagerduty/models"
+	"reflect"
+)
+
+func ConvertServices(taskCtx plugin.SubTaskContext) errors.Error {
+	db := taskCtx.GetDal()
+	data := taskCtx.GetData().(*PagerDutyTaskData)
+	rawDataSubTaskArgs := &helper.RawDataSubTaskArgs{
+		Ctx:     taskCtx,
+		Options: data.Options,
+		Table:   "pagerduty_services",
+	}
+	clauses := []dal.Clause{
+		dal.Select("services.*"),
+		dal.From("_tool_pagerduty_services services"),
+		dal.Where("id = ? and connection_id = ?", data.Options.ServiceId, data.Options.ConnectionId),
+	}
+	cursor, err := db.Cursor(clauses...)
+	if err != nil {
+		return err
+	}
+	defer cursor.Close()
+
+	converter, err := helper.NewDataConverter(helper.DataConverterArgs{
+		RawDataSubTaskArgs: *rawDataSubTaskArgs,
+		InputRowType:       reflect.TypeOf(models.Service{}),
+		Input:              cursor,
+		Convert: func(inputRow interface{}) ([]interface{}, errors.Error) {
+			service := inputRow.(*models.Service)
+			domainBoard := &ticket.Board{
+				DomainEntity: domainlayer.DomainEntity{
+					Id: didgen.NewDomainIdGenerator(service).Generate(service.ConnectionId, service.Id),
+				},
+				Name: service.Name,
+				Url:  service.Url,
+			}
+			domainCicdScope := &devops.CicdScope{
+				DomainEntity: domainlayer.DomainEntity{
+					Id: didgen.NewDomainIdGenerator(service).Generate(service.ConnectionId, service.Id),
+				},
+				Name: service.Name,
+				Url:  service.Url,
+			}
+			return []interface{}{
+				domainCicdScope,
+				domainBoard,
+			}, nil
+		},
+	})
+	if err != nil {
+		return err
+	}
+	return converter.Execute()
+}
+
+var ConvertServicesMeta = plugin.SubTaskMeta{
+	Name:             "convertServices",
+	EntryPoint:       ConvertServices,
+	EnabledByDefault: true,
+	Description:      "Convert PagerDuty services",
+	DomainTypes:      []string{plugin.DOMAIN_TYPE_TICKET},
+}


### PR DESCRIPTION
### Summary
What does this PR do?
PagerDuty now emits board domain models as required for correct DORA metric computation.

### Does this close any open issues?
Closes #5233 

### Screenshots
MTTR was n/a before despite having an incident that was resolved. With this fix it's now calculated in the dashboard.

![image](https://github.com/apache/incubator-devlake/assets/25063936/30a54c0f-24ad-4223-8959-d2e85dbd6b87)
![image](https://github.com/apache/incubator-devlake/assets/25063936/2b4d3640-3633-49cc-8eb8-afae94b3b29a)

### Other Information
Any other information that is important to this PR.
