### PR TITLE
fix: bitbucket repos' url columns are empty

### DIFF
--- a/backend/plugins/bitbucket/api/remote.go
+++ b/backend/plugins/bitbucket/api/remote.go
@@ -20,14 +20,15 @@ package api
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
 	context2 "github.com/apache/incubator-devlake/core/context"
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/bitbucket/models"
-	"net/http"
-	"net/url"
-	"strings"
 )
 
 // RemoteScopes list all available scope for users
@@ -81,7 +82,7 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 				return nil, errors.BadInput.Wrap(err, "failed to get create apiClient")
 			}
 			var res *http.Response
-			query.Set("fields", "values.name,values.full_name,values.language,values.description,values.owner.username,values.created_on,values.updated_on,values.links.clone,values.links.self,pagelen,page,size")
+			query.Set("fields", "values.name,values.full_name,values.language,values.description,values.owner.display_name,values.created_on,values.updated_on,values.links.clone,values.links.html,pagelen,page,size")
 			// list projects part
 			res, err = apiClient.Get(fmt.Sprintf("/repositories/%s", gid), query, nil)
 			if err != nil {

--- a/backend/plugins/bitbucket/e2e/snapshot_tables/_tool_bitbucket_repos.csv
+++ b/backend/plugins/bitbucket/e2e/snapshot_tables/_tool_bitbucket_repos.csv
@@ -1,2 +1,2 @@
 connection_id,bitbucket_id,name,html_url,description,owner,language,clone_url,_raw_data_params,_raw_data_table,_raw_data_id,_raw_data_remark
-1,likyh/likyhphp,likyhphp,https://bitbucket.org/likyh/likyhphp,,,,https://likyh@bitbucket.org/likyh/likyhphp.git,,,0,
+1,likyh/likyhphp,likyhphp,https://bitbucket.org/likyh/likyhphp,,teoiaoe,,https://likyh@bitbucket.org/likyh/likyhphp.git,,,0,

--- a/backend/plugins/bitbucket/models/repo.go
+++ b/backend/plugins/bitbucket/models/repo.go
@@ -18,9 +18,10 @@ limitations under the License.
 package models
 
 import (
+	"time"
+
 	"github.com/apache/incubator-devlake/core/models/common"
 	"github.com/apache/incubator-devlake/core/plugin"
-	"time"
 )
 
 var _ plugin.ToolLayerScope = (*BitbucketRepo)(nil)
@@ -66,7 +67,7 @@ type BitbucketApiRepo struct {
 	Language    string `json:"language"`
 	Description string `json:"description"`
 	Owner       struct {
-		Username string `json:"username"`
+		Displayname string `json:"display_name"`
 	} `json:"owner"`
 	CreatedAt *time.Time `json:"created_on"`
 	UpdatedAt *time.Time `json:"updated_on"`
@@ -89,7 +90,7 @@ func (b BitbucketApiRepo) ConvertApiScope() plugin.ToolLayerScope {
 	scope.Language = b.Language
 	scope.Description = b.Description
 	scope.Name = b.Name
-	scope.Owner = b.Owner.Username
+	scope.Owner = b.Owner.Displayname
 	scope.HTMLUrl = b.Links.Html.Href
 
 	scope.CloneUrl = ""


### PR DESCRIPTION
### Summary
fix: bitbucket repos' url columns are empty

### Does this close any open issues?
Closes #5100 

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/101256042/a34710b2-0026-4e17-9fdc-3cbfdcc5f413)
![image](https://github.com/apache/incubator-devlake/assets/101256042/d390638f-47cc-4527-b9dd-79f00fd1b375)


### Other Information
Any other information that is important to this PR.
