### PR TITLE
fix: the swagger error for sonarqube-proxy-endpoint

### DIFF
--- a/backend/plugins/sonarqube/api/proxy.go
+++ b/backend/plugins/sonarqube/api/proxy.go
@@ -36,7 +36,7 @@ import (
 // @Success 200  {object} interface{} "Success"
 // @Failure 400  {string} errcode.Error "Bad Request"
 // @Failure 500  {string} errcode.Error "Internal Error"
-// @Router /plugins/sonarqube/connections/{connectionId}/proxy/rest/{*path} [GET]
+// @Router /plugins/sonarqube/connections/{connectionId}/proxy/rest/{path} [GET]
 func Proxy(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
 	connection := &models.SonarqubeConnection{}
 	err := connectionHelper.First(connection, input.Params)


### PR DESCRIPTION
### Summary
fix #5264, which is caused by a syntax error in the Swagger source file

### Does this close any open issues?
Closes #5264 

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/8455907/73995ae6-ecf5-4031-a89b-64fe63c7210b)


