### PR TITLE
fix: missing `_raw_jira_api_issue_comments` table

### DIFF
--- a/backend/plugins/jira/tasks/issue_comment_extractor.go
+++ b/backend/plugins/jira/tasks/issue_comment_extractor.go
@@ -29,7 +29,7 @@ import (
 var _ plugin.SubTaskEntryPoint = ExtractIssueComments
 
 var ExtractIssueCommentsMeta = plugin.SubTaskMeta{
-	Name:             "extractIssueChangelogs",
+	Name:             "extractIssueComments",
 	EntryPoint:       ExtractIssueComments,
 	EnabledByDefault: false,
 	Description:      "extract Jira Issue comments",


### PR DESCRIPTION
### Summary
Fix #5223, the name of the subtask `ExtractIssueComments` was wrongly set to `extractIssueChangelogs`, in this PR, the name is set to the correct value.

### Does this close any open issues?
Closes #5223 

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/8455907/c83ae3d1-b321-4666-ba58-2083859180cc)


