### PR TITLE
fix: invalid endpoint URLs should not pass connection test

### DIFF
--- a/backend/plugins/jenkins/api/connection.go
+++ b/backend/plugins/jenkins/api/connection.go
@@ -20,6 +20,7 @@ package api
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/apache/incubator-devlake/server/api/shared"
 
@@ -49,6 +50,10 @@ func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, 
 	err = api.Decode(input.Body, &connection, vld)
 	if err != nil {
 		return nil, err
+	}
+	// Check if the URL contains "/api"
+	if strings.Contains(connection.Endpoint, "/api") {
+		return nil, errors.HttpStatus(http.StatusBadRequest).New("Invalid URL. Please use the base URL without /api")
 	}
 	// test connection
 	apiClient, err := api.NewApiClientFromConnection(context.TODO(), basicRes, &connection)


### PR DESCRIPTION
### Summary
fix: invalid endpoint URLs should not pass connection test

### Does this close any open issues?
Closes #5272 

### Screenshots
old:
![b89c95c6-9a5b-452b-82c3-ce2ae983315b](https://github.com/apache/incubator-devlake/assets/101256042/46213146-9422-435d-aa48-bd266ceedd26)
new:
![38795619-a52b-4def-9013-8c2c8f9a57d9](https://github.com/apache/incubator-devlake/assets/101256042/d665a237-dcbf-4fdf-b8e9-df72ff3efd2f)


### Other Information
Any other information that is important to this PR.
