### PR TITLE
[Feature][Connection]: make sure the connection endpoint ends with "/"

### DIFF
--- a/backend/helpers/pluginhelper/api/connection.go
+++ b/backend/helpers/pluginhelper/api/connection.go
@@ -18,6 +18,8 @@ limitations under the License.
 package api
 
 import (
+	"strings"
+
 	"github.com/apache/incubator-devlake/core/models/common"
 )
 
@@ -34,9 +36,13 @@ type RestConnection struct {
 	RateLimitPerHour int    `comment:"api request rate limit per hour" json:"rateLimitPerHour"`
 }
 
-// GetEndpoint returns the API endpoint of the connection
+// GetEndpoint returns the API endpoint of the connection, which always ends with "/"
 func (rc RestConnection) GetEndpoint() string {
-	return rc.Endpoint
+	// make sure the endpoint ends with "/"
+	if rc.Endpoint == "" || strings.HasSuffix(rc.Endpoint, "/") {
+		return rc.Endpoint
+	}
+	return rc.Endpoint + "/"
 }
 
 // GetProxy returns the proxy for the connection

--- a/backend/plugins/github/api/connection.go
+++ b/backend/plugins/github/api/connection.go
@@ -23,12 +23,13 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/mitchellh/mapstructure"
+
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/github/models"
 	"github.com/apache/incubator-devlake/server/api/shared"
-	"github.com/mitchellh/mapstructure"
 )
 
 var publicPermissions = []string{"repo:status", "repo_deployment", "read:user", "read:org"}


### PR DESCRIPTION
### Summary
make sure the connection endpoint ends with "/"

### Does this close any open issues?
Closes #4996

### Screenshots
Include any relevant screenshots here.

### Other Information

**Please review carefully, I'm not sure it is the best way.**

I noticed that currently, after receiving JSON information from the frontend, the decoding, validation, and saving to the database **are done together**, making it difficult to implement custom logic here.

<img width="1029" alt="image" src="https://github.com/apache/incubator-devlake/assets/36830265/81451d38-aca9-40a3-8db6-72951941b7ca">

I also observed that all connections call the NewApiClientFromConnection function and pass connection.GetEndpoint() as the base URL. So, instead of modifying the records in the database, I'm trying to automatically add a / when the endpoint is needed on the backend.


<img width="993" alt="image" src="https://github.com/apache/incubator-devlake/assets/36830265/2e55cc26-f1f8-473b-a501-40279f35063e">
<img width="880" alt="image" src="https://github.com/apache/incubator-devlake/assets/36830265/0018d803-83de-4cdd-8d23-f78093634add">

