### PR TITLE
Skip empty blueprint

### DIFF
--- a/backend/core/plugin/plugin_blueprint.go
+++ b/backend/core/plugin/plugin_blueprint.go
@@ -38,6 +38,19 @@ type PipelineStage []*PipelineTask
 // PipelinePlan consist of multiple PipelineStages, they will be executed in sequential order
 type PipelinePlan []PipelineStage
 
+// IsEmpty checks if a PipelinePlan is empty
+func (plan PipelinePlan) IsEmpty() bool {
+	if len(plan) == 0 {
+		return true
+	}
+	for _, stage := range plan {
+		if len(stage) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // PluginBlueprintV100 is used to support Blueprint Normal model, for Plugin and Blueprint to
 // collaboarte and generate a sophisticated Pipeline Plan based on User Settings.
 // V100 doesn't support Project, and being deprecated, please use PluginBlueprintV200 instead

--- a/backend/core/plugin/plugin_blueprint_test.go
+++ b/backend/core/plugin/plugin_blueprint_test.go
@@ -1,0 +1,53 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestPipelinePlan_IsEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		plan PipelinePlan
+		want bool
+	}{
+		{
+			name: "empty",
+			plan: PipelinePlan{},
+			want: true,
+		},
+		{
+			name: "empty",
+			plan: []PipelineStage{{}, {}},
+			want: true,
+		},
+		{
+			name: "empty",
+			plan: []PipelineStage{{}, {&PipelineTask{}}},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("length of plan is", len(tt.plan))
+			assert.Equalf(t, tt.want, tt.plan.IsEmpty(), "IsEmpty()")
+		})
+	}
+}

--- a/backend/server/services/blueprint.go
+++ b/backend/server/services/blueprint.go
@@ -166,10 +166,6 @@ func validateBlueprintAndMakePlan(blueprint *models.Blueprint) errors.Error {
 		if err != nil {
 			return errors.Default.Wrap(err, "invalid plan")
 		}
-		// tasks should not be empty
-		if len(plan) == 0 || len(plan[0]) == 0 {
-			return errors.Default.New("empty plan")
-		}
 	} else if blueprint.Mode == models.BLUEPRINT_MODE_NORMAL {
 		plan, err := MakePlanForBlueprint(blueprint)
 		if err != nil {
@@ -299,13 +295,16 @@ func createPipelineByBlueprint(blueprint *models.Blueprint) (*models.Pipeline, e
 	newPipeline.Labels = blueprint.Labels
 	newPipeline.SkipOnFail = blueprint.SkipOnFail
 
+	// if the plan is empty, we should not create the pipeline
 	var shouldCreatePipeline bool
 	for _, stage := range plan {
 		for _, task := range stage {
 			switch task.Plugin {
 			case "org", "refdiff", "dora":
 			default:
-				shouldCreatePipeline = true
+				if !plan.IsEmpty() {
+					shouldCreatePipeline = true
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Summary
- Not run the blueprints which do not contain any plugin other than `org`, `dora` and `refdiff`
- Not run the blueprints if all of the plans are empty
- Allow creating empty blueprints in advanced mode

### Does this close any open issues?
Closes #5307 

