### PR TITLE
cherrypick(v0.17.0-beta9): #5311

### DIFF
--- a/backend/plugins/pagerduty/tasks/incidents_collector.go
+++ b/backend/plugins/pagerduty/tasks/incidents_collector.go
@@ -64,6 +64,7 @@ func CollectIncidents(taskCtx plugin.SubTaskContext) errors.Error {
 		Ctx: taskCtx,
 		Params: PagerDutyParams{
 			ConnectionId: data.Options.ConnectionId,
+			ServiceId:    data.Options.ServiceId,
 		},
 		Table: RAW_INCIDENTS_TABLE,
 	}

--- a/backend/plugins/pagerduty/tasks/task_data.go
+++ b/backend/plugins/pagerduty/tasks/task_data.go
@@ -41,6 +41,7 @@ type PagerDutyTaskData struct {
 
 type PagerDutyParams struct {
 	ConnectionId uint64
+	ServiceId    string
 }
 
 func DecodeAndValidateTaskOptions(options map[string]interface{}) (*PagerDutyOptions, errors.Error) {


### PR DESCRIPTION
### Summary
PagerDuty API params was missing the service ID reference. This is already fixed in main/v0.18, but wasn't back-ported to v0.17.

### Does this close any open issues?
Closes #5311
