### PR TITLE
fix: Build.result must be optional

### DIFF
--- a/backend/python/plugins/azuredevops/azuredevops/models.py
+++ b/backend/python/plugins/azuredevops/azuredevops/models.py
@@ -98,7 +98,7 @@ class Build(ToolModel, table=True):
     start_time: Optional[datetime.datetime]
     finish_time: Optional[datetime.datetime]
     status: BuildStatus
-    result: BuildResult
+    result: Optional[BuildResult]
     source_branch: str
     source_version: str
 


### PR DESCRIPTION
### Summary
Fixes an error while extracting running builds.

### Does this close any open issues?
Closes #5336 