### PR TITLE
fix: create table _tool_gitlab_issue_assignees

### DIFF
--- a/backend/plugins/gitlab/models/migrationscripts/20230606_add_issue_assignee.go
+++ b/backend/plugins/gitlab/models/migrationscripts/20230606_add_issue_assignee.go
@@ -18,24 +18,30 @@ limitations under the License.
 package migrationscripts
 
 import (
-	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/helpers/migrationhelper"
+	"github.com/apache/incubator-devlake/plugins/gitlab/models/migrationscripts/archived"
 )
 
-// All return all the migration scripts
-func All() []plugin.MigrationScript {
-	return []plugin.MigrationScript{
-		new(addInitTables),
-		new(addGitlabCI),
-		new(addPipelineID),
-		new(addPipelineProjects),
-		new(fixDurationToFloat8),
-		new(addTransformationRule20221125),
-		new(addStdTypeToIssue221230),
-		new(addIsDetailRequired20230210),
-		new(addConnectionIdToTransformationRule),
-		new(addGitlabCommitAuthorInfo),
-		new(addTypeEnvToPipeline),
-		new(renameTr2ScopeConfig),
-		new(addGitlabIssueAssignee),
+type addGitlabIssueAssignee struct{}
+
+func (*addGitlabIssueAssignee) Up(baseRes context.BasicRes) errors.Error {
+	err := migrationhelper.AutoMigrateTables(
+		baseRes,
+		&archived.GitlabIssueAssignee{},
+	)
+	if err != nil {
+		return err
 	}
+
+	return nil
+}
+
+func (*addGitlabIssueAssignee) Version() uint64 {
+	return 20230606110339
+}
+
+func (*addGitlabIssueAssignee) Name() string {
+	return "add _tool_gitlab_issue_assignees table"
 }

--- a/backend/plugins/gitlab/models/migrationscripts/archived/issue_assignee.go
+++ b/backend/plugins/gitlab/models/migrationscripts/archived/issue_assignee.go
@@ -15,27 +15,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package migrationscripts
+package archived
 
 import (
-	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/core/models/migrationscripts/archived"
 )
 
-// All return all the migration scripts
-func All() []plugin.MigrationScript {
-	return []plugin.MigrationScript{
-		new(addInitTables),
-		new(addGitlabCI),
-		new(addPipelineID),
-		new(addPipelineProjects),
-		new(fixDurationToFloat8),
-		new(addTransformationRule20221125),
-		new(addStdTypeToIssue221230),
-		new(addIsDetailRequired20230210),
-		new(addConnectionIdToTransformationRule),
-		new(addGitlabCommitAuthorInfo),
-		new(addTypeEnvToPipeline),
-		new(renameTr2ScopeConfig),
-		new(addGitlabIssueAssignee),
-	}
+type GitlabIssueAssignee struct {
+	archived.NoPKModel
+	ConnectionId uint64 `gorm:"primaryKey"`
+	GitlabId     int    `gorm:"primaryKey"`
+	ProjectId    int    `gorm:"primaryKey"`
+	AssigneeId   int    `gorm:"primaryKey"`
+	AssigneeName string `gorm:"type:varchar(255)"`
+}
+
+func (GitlabIssueAssignee) TableName() string {
+	return "_tool_gitlab_issue_assignees"
 }


### PR DESCRIPTION
### Summary
- Fix #5368 
- provide migration script to create the table `_tool_gitlab_issue_assignees`

### Does this close any open issues?
Closes #5368 

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/8455907/af38e1a9-0cea-44db-835b-6e5155f2fc47)

### Other Information
Any other information that is important to this PR.
