### PR TITLE
fix(Jira): Fix Jira scope reflection field name: BoardID -> BoardId

### DIFF
--- a/backend/plugins/jira/api/init.go
+++ b/backend/plugins/jira/api/init.go
@@ -40,7 +40,7 @@ func Init(br context.BasicRes) {
 		vld,
 	)
 	params := &api.ReflectionParameters{
-		ScopeIdFieldName:  "BoardID",
+		ScopeIdFieldName:  "BoardId",
 		ScopeIdColumnName: "board_id",
 	}
 	scopeHelper = api.NewScopeHelper[models.JiraConnection, models.JiraBoard, models.JiraScopeConfig](


### PR DESCRIPTION
### Summary
Fixes the call to `/plugins/jira/connections/{connectionId}/scopes/?blueprints=true` erroring out with:
![image](https://github.com/apache/incubator-devlake/assets/25063936/cb791446-ea69-47b8-b5ee-b956434993c4)

It errors out because the reflection param value name for Boards doesn't exactly match the name on the struct:
https://github.com/apache/incubator-devlake/blob/f3e23cebde39cea18b618c7c72546eeff938099f/backend/plugins/jira/models/board.go#L29


### Does this close any open issues?
Closes n/a

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
