### PR TITLE
fix: tasks name fixed

### DIFF
--- a/backend/plugins/bitbucket/api/blueprint_V200_test.go
+++ b/backend/plugins/bitbucket/api/blueprint_V200_test.go
@@ -88,6 +88,7 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 				Options: map[string]interface{}{
 					"proxy":  "",
 					"repoId": "bitbucket:BitbucketRepo:1:likyh/likyhphp",
+					"name":   "likyh/likyhphp",
 					"url":    "https://Username:Password@this_is_cloneUrl",
 				},
 			},

--- a/backend/plugins/bitbucket/api/blueprint_v200.go
+++ b/backend/plugins/bitbucket/api/blueprint_v200.go
@@ -127,6 +127,7 @@ func makeDataSourcePipelinePlanV200(
 				Plugin: "gitextractor",
 				Options: map[string]interface{}{
 					"url":    cloneUrl.String(),
+					"name":   repo.BitbucketId,
 					"repoId": didgen.NewDomainIdGenerator(&models.BitbucketRepo{}).Generate(connection.ID, repo.BitbucketId),
 					"proxy":  connection.Proxy,
 				},

--- a/backend/plugins/gitextractor/tasks/git_repo_collector.go
+++ b/backend/plugins/gitextractor/tasks/git_repo_collector.go
@@ -18,14 +18,16 @@ limitations under the License.
 package tasks
 
 import (
+	"strings"
+
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/plugins/gitextractor/parser"
-	"strings"
 )
 
 type GitExtractorOptions struct {
 	RepoId     string `json:"repoId"`
+	Name       string `jsno:"name"`
 	Url        string `json:"url"`
 	User       string `json:"user"`
 	Password   string `json:"password"`

--- a/backend/plugins/github/api/blueprint_V200_test.go
+++ b/backend/plugins/github/api/blueprint_V200_test.go
@@ -90,6 +90,7 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 				Options: map[string]interface{}{
 					"proxy":  "",
 					"repoId": "github:GithubRepo:1:12345",
+					"name":   "test/testRepo",
 					"url":    "https://git:123@this_is_cloneUrl",
 				},
 			},

--- a/backend/plugins/github/api/blueprint_v200.go
+++ b/backend/plugins/github/api/blueprint_v200.go
@@ -135,6 +135,7 @@ func makeDataSourcePipelinePlanV200(
 				Plugin: "gitextractor",
 				Options: map[string]interface{}{
 					"url":    cloneUrl.String(),
+					"name":   githubRepo.Name,
 					"repoId": didgen.NewDomainIdGenerator(&models.GithubRepo{}).Generate(connection.ID, githubRepo.GithubId),
 					"proxy":  connection.Proxy,
 				},

--- a/backend/plugins/gitlab/api/blueprint_V200_test.go
+++ b/backend/plugins/gitlab/api/blueprint_V200_test.go
@@ -143,6 +143,7 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 				Options: map[string]interface{}{
 					"proxy":  "",
 					"repoId": expectRepoId,
+					"name":   testName,
 					"url":    "https://git:nddtf@this_is_cloneUrl",
 				},
 			},

--- a/backend/plugins/gitlab/api/blueprint_v200.go
+++ b/backend/plugins/gitlab/api/blueprint_v200.go
@@ -165,6 +165,7 @@ func makePipelinePlanV200(
 				Plugin: "gitextractor",
 				Options: map[string]interface{}{
 					"url":    cloneUrl.String(),
+					"name":   gitlabProject.Name,
 					"repoId": didgen.NewDomainIdGenerator(&models.GitlabProject{}).Generate(connection.ID, gitlabProject.GitlabId),
 					"proxy":  connection.Proxy,
 				},

--- a/config-ui/src/pages/pipeline/components/task/index.tsx
+++ b/config-ui/src/pages/pipeline/components/task/index.tsx
@@ -48,7 +48,7 @@ export const PipelineTask = ({ task }: Props) => {
         name = `${name}:${options.name}`;
         break;
       case ['gitextractor'].includes(config.plugin):
-        name = `${name}:${options.repoId}`;
+        name = `${name}:${options.name}`;
         break;
       case ['dora'].includes(config.plugin):
         name = `${name}:${options.projectName}`;


### PR DESCRIPTION
### Summary
Fix the gitextractor tasks names displayed.
Add the name to the gitextractor on GitHub, GitLab, and Bitbucket on the blueprint.


### Does this close any open issues?
Closes #5088

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/2921251/596234c9-cd5d-49b5-9a91-01be32bdafc1)
![image](https://github.com/apache/incubator-devlake/assets/2921251/a02213c2-a415-472d-9fad-add6bbecb235)