### PR TITLE
5383 build not found

### DIFF
--- a/backend/python/plugins/azuredevops/azuredevops/api.py
+++ b/backend/python/plugins/azuredevops/azuredevops/api.py
@@ -70,7 +70,7 @@ class AzureDevOpsAPI(API):
         return self.get(org, project, '_apis/git/repositories', repo_id, 'commits')
 
     def builds(self, org: str, project: str, repository_id: str, provider: str):
-        return self.get(org, project, '_apis/build/builds', repositoryId=repository_id, repositoryType=provider)
+        return self.get(org, project, '_apis/build/builds', repositoryId=repository_id, repositoryType=provider, deletedFilter='excludeDeleted')
 
     def jobs(self, org: str, project: str, build_id: int):
         return self.get(org, project, '_apis/build/builds', build_id, 'timeline')

--- a/backend/python/plugins/azuredevops/azuredevops/streams/jobs.py
+++ b/backend/python/plugins/azuredevops/azuredevops/streams/jobs.py
@@ -21,6 +21,7 @@ from azuredevops.api import AzureDevOpsAPI
 from azuredevops.models import Job, Build, GitRepository
 from azuredevops.streams.builds import Builds
 from pydevlake import Context, Substream, DomainType
+from pydevlake.api import APIException
 import pydevlake.domain_layer.devops as devops
 
 
@@ -32,7 +33,16 @@ class Jobs(Substream):
     def collect(self, state, context, parent: Build) -> Iterable[tuple[object, dict]]:
         repo: GitRepository = context.scope
         api = AzureDevOpsAPI(context.connection)
-        response = api.jobs(repo.org_id, repo.project_id, parent.id)
+        try:
+            response = api.jobs(repo.org_id, repo.project_id, parent.id)
+        except APIException as e:
+            # Asking for the timeline of a deleted build returns a 204.
+            # But a "deleted" build may be "cleaned" (i.e. deleted for real)
+            # after some time. In this case, the timeline endpoint returns a
+            # 404 instead.
+            if e.response.status == HTTPStatus.NOT_FOUND:
+                return
+            raise
         # If a build has failed before any jobs have started, e.g. due to a
         # bad YAML file, then the jobs endpoint will return a 204 NO CONTENT.
         if response.status == HTTPStatus.NO_CONTENT:

--- a/backend/python/pydevlake/pydevlake/subtasks.py
+++ b/backend/python/pydevlake/pydevlake/subtasks.py
@@ -132,6 +132,10 @@ class Subtask:
             "scope_id": ctx.scope.id
         }, separators=(',', ':'))
 
+    @abstractmethod
+    def delete(self, session, ctx):
+        pass
+
 
 class Collector(Subtask):
     @property
@@ -181,7 +185,8 @@ class Extractor(Subtask):
         session.merge(tool_model)
 
     def delete(self, session, ctx):
-        pass
+        model = self.stream.tool_model
+        session.execute(sql.delete(model).where(model.raw_data_params == self._params(ctx)))
 
 class Convertor(Subtask):
     @property


### PR DESCRIPTION
### Summary
Fix a 404 that arise when trying to collect timelines of a deleted build that got "cleaned".
Once the retention policy of an Azure DevOps build expires, this build can be deleted but is still accessible during at least a month. During that time, we can query its timeline in which case we get a 204.
But after that time querying the build timeline returns a 404.
This PR:
- adds a filter to exclude deleted builds from the builds endpoint.
- deletes all previously collected tool level rows when not incremental.
- handles 404 when collecting a build jobs

### Does this close any open issues?
Closes #5383 
