### PR TITLE
5080 Let test_connection report status from tool API

### DIFF
--- a/backend/python/README.md
+++ b/backend/python/README.md
@@ -57,7 +57,7 @@ class MyPlugin(dl.Plugin):
     def remote_scopes(self, connection, group_id: str) -> Iterable[MyPluginToolScope]:
         ...
 
-    def test_connection(self, connection: MyPluginConnection):
+    def test_connection(self, connection: MyPluginConnection) -> dl.TestConnectionResult:
         ...
 
 
@@ -191,19 +191,17 @@ class MyPlugin(dl.Plugin):
 
 The `test_connection` method is used to test if a given connection is valid.
 It should check that the connection credentials are valid.
-If the connection is not valid, it should raise an exception.
+It should make an authenticated request to the API and return a `TestConnectionResult`.
+There is a convenience static method `from_api_response` to create a `TestConnectionResult` object from an API response.
 
 ```python
 class MyPlugin(dl.Plugin):
     ...
 
-    def test_connection(self, connection: MyPluginConnection):
-        api = ...
-        response = ...
-        if response.status != 401:
-            raise Exception("Invalid credentials")
-        if response.status != 200:
-            raise Exception(f"Connection error {response}")
+    def test_connection(self, connection: MyPluginConnection) -> dl.TestConnectionResult:
+        api = ... # Create API client
+        response = ... # Make authenticated request to API
+        return dl.TestConnection.from_api_response(response)
 ```
 
 

--- a/backend/python/pydevlake/pydevlake/__init__.py
+++ b/backend/python/pydevlake/pydevlake/__init__.py
@@ -35,7 +35,7 @@ def Field(*args, primary_key: bool=False, source: Optional[str]=None, **kwargs):
 
 from .model import ToolModel, ToolScope, DomainScope, Connection, ScopeConfig, DomainType, domain_id
 from .logger import logger
-from .message import RemoteScopeGroup
+from .message import RemoteScopeGroup, TestConnectionResult
 from .plugin import Plugin, ScopeConfigPair
 from .stream import Stream, Substream
 from .context import Context

--- a/backend/python/pydevlake/pydevlake/ipc.py
+++ b/backend/python/pydevlake/pydevlake/ipc.py
@@ -26,7 +26,7 @@ from sqlalchemy.engine import Engine
 
 from pydevlake.context import Context
 from pydevlake.message import Message
-from pydevlake.model import DomainType, SubtaskRun
+from pydevlake.model import SubtaskRun
 
 
 def plugin_method(func):
@@ -85,7 +85,7 @@ class PluginCommands:
         if "name" not in connection:
             connection["name"] = "Test connection"
         connection = self._plugin.connection_type(**connection)
-        self._plugin.test_connection(connection)
+        return self._plugin.test_connection(connection)
 
     @plugin_method
     def make_pipeline(self, scope_config_pairs: list[tuple[dict, dict]], connection: dict):

--- a/backend/python/pydevlake/pydevlake/message.py
+++ b/backend/python/pydevlake/pydevlake/message.py
@@ -21,6 +21,7 @@ import jsonref
 
 from pydevlake.model import ToolScope
 from pydevlake.migration import MigrationScript
+from pydevlake.api import Response
 
 
 class Message(BaseModel):
@@ -111,3 +112,20 @@ class RemoteScope(RemoteScopeTreeNode):
 
 class RemoteScopes(Message):
     __root__: list[RemoteScopeTreeNode]
+
+
+class TestConnectionResult(Message):
+    success: bool
+    message: str
+    status: int
+
+    @staticmethod
+    def from_api_response(response: Response, message: str = None):
+        success = response.status == 200
+        if not message:
+            message = "Connection successful" if success else "Connection failed"
+        return TestConnectionResult(
+            success=success,
+            message=message,
+            status=response.status
+        )

--- a/backend/python/pydevlake/pydevlake/plugin.py
+++ b/backend/python/pydevlake/pydevlake/plugin.py
@@ -22,6 +22,7 @@ import sys
 import fire
 
 import pydevlake.message as msg
+from pydevlake.api import APIException
 from pydevlake.subtasks import Subtask
 from pydevlake.logger import logger
 from pydevlake.ipc import PluginCommands
@@ -68,7 +69,7 @@ class Plugin(ABC):
         return None
 
     @abstractmethod
-    def test_connection(self, connection: Connection):
+    def test_connection(self, connection: Connection) -> msg.TestConnectionResult:
         """
         Test if the the connection with the datasource can be established with the given connection.
         Must raise an exception if the connection can't be established.

--- a/backend/python/test/fakeplugin/fakeplugin/main.py
+++ b/backend/python/test/fakeplugin/fakeplugin/main.py
@@ -20,7 +20,7 @@ import json
 
 from pydantic import SecretStr
 
-from pydevlake import Plugin, Connection, Stream, ToolModel, ToolScope, ScopeConfig, RemoteScopeGroup, DomainType, Field
+from pydevlake import Plugin, Connection, Stream, ToolModel, ToolScope, ScopeConfig, RemoteScopeGroup, DomainType, Field, TestConnectionResult
 from pydevlake.domain_layer.devops import CicdScope, CICDPipeline, CICDStatus, CICDResult, CICDType
 
 VALID_TOKEN = "this_is_a_valid_token"
@@ -147,7 +147,16 @@ class FakePlugin(Plugin):
 
     def test_connection(self, connection: FakeConnection):
         if connection.token.get_secret_value() != VALID_TOKEN:
-            raise Exception("Invalid token")
+            return TestConnectionResult(
+                success=False,
+                message="Invalid token",
+                status=401
+            )
+        return TestConnectionResult(
+            success=True,
+            message="Connection successful",
+            status=200
+        )
 
     @property
     def streams(self):


### PR DESCRIPTION
### Summary
Change test_connection to return a TestConnectionResult that contains a message and a status code
that are used on go-side to build responses to GET 'plugins/<plugin>/test-connection'.

### Does this close any open issues?
Closes #5080 