### PR TITLE
fix: github remote api

### DIFF
--- a/backend/plugins/github/api/remote.go
+++ b/backend/plugins/github/api/remote.go
@@ -167,12 +167,12 @@ type repo struct {
 
 func (r repo) ConvertApiScope() plugin.ToolLayerScope {
 	githubRepository := &models.GithubRepo{
-		//ConnectionId: data.Options.ConnectionId,
 		GithubId:    r.ID,
-		Name:        r.Name,
+		Name:        r.FullName,
 		HTMLUrl:     r.HTMLURL,
 		Description: r.Description,
 		OwnerId:     r.Owner.ID,
+		CloneUrl:    r.CloneURL,
 		CreatedDate: r.CreatedAt,
 		UpdatedDate: r.UpdatedAt,
 	}
@@ -194,6 +194,9 @@ func (r repo) ConvertApiScope() plugin.ToolLayerScope {
 func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
 	return remoteHelper.GetScopesFromRemote(input,
 		func(basicRes context2.BasicRes, gid string, queryData *api.RemoteQueryData, connection models.GithubConnection) ([]org, errors.Error) {
+			if gid != "" {
+				return nil, nil
+			}
 			apiClient, err := api.NewApiClientFromConnection(context.TODO(), basicRes, &connection)
 			if err != nil {
 				return nil, errors.BadInput.Wrap(err, "failed to get create apiClient")


### PR DESCRIPTION
### Summary
- only return scope if the groupId is not empty
- set scope name as full name 
- set clone URL for github scope

### Does this close any open issues?
Closes #5430 #5431 

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/8455907/6cfa2c93-0858-4515-858c-07574fdf6f63)
![image](https://github.com/apache/incubator-devlake/assets/8455907/a470bbb7-817c-487a-bbb9-96c7543ce7da)


### Other Information
Any other information that is important to this PR.
