### PR TITLE
fix: sonar issue collector time range split 

### DIFF
--- a/backend/plugins/sonarqube/tasks/issues_collector.go
+++ b/backend/plugins/sonarqube/tasks/issues_collector.go
@@ -119,8 +119,8 @@ func CollectIssues(taskCtx plugin.SubTaskContext) (err errors.Error) {
 				}
 
 				// can not split it any more
-				if createdBeforeUnix-createdAfterUnix < 1 {
-					return 100, nil
+				if createdBeforeUnix-createdAfterUnix <= 10 {
+					return pages, nil
 				}
 
 				// split it


### PR DESCRIPTION
### Summary

Sonarqube issue collector will split result of issues/search by using createdBefore & createdAfter filter params, if the result exceed 100 pages. 

The split end when createdBefore - createdAfter less than 1 second, which is createdBefore == createdAfter, and sonarqube api do not allow createdBefore and createdAfter to be equal. In some case sonar scanner failed to do backdating, all issues have same createdTime, the split will end up createdBefore == createdAfter, and fail with sonarqube api error.

This time range spliting don't need to be so acurate, this PR change the end condition to 10 seconds.

### Does this close any open issues?
Closes #5442

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
