### PR TITLE
fix: missing data in the table issue_assignees

### DIFF
--- a/backend/plugins/github_graphql/impl/impl.go
+++ b/backend/plugins/github_graphql/impl/impl.go
@@ -112,6 +112,7 @@ func (p GithubGraphql) SubTaskMetas() []plugin.SubTaskMeta {
 		githubTasks.ConvertPullRequestReviewsMeta,
 		githubTasks.ConvertPullRequestLabelsMeta,
 		githubTasks.ConvertPullRequestIssuesMeta,
+		githubTasks.ConvertIssueAssigneeMeta,
 		githubTasks.ConvertIssueCommentsMeta,
 		githubTasks.ConvertPullRequestCommentsMeta,
 		githubTasks.ConvertMilestonesMeta,


### PR DESCRIPTION
### Summary
fix #5445 ,  the subtask `convertIssueAssignee` was not added to the plugin `github_graphql`

### Does this close any open issues?
Closes #5445 

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/8455907/205134f0-ffe2-410a-a50f-db62b662842e)

### Other Information
Any other information that is important to this PR.
