### PR TITLE
fix: gitlab/bitbucket generate the complete repo name path when creat…

### DIFF
--- a/backend/plugins/bitbucket/api/blueprint_V200_test.go
+++ b/backend/plugins/bitbucket/api/blueprint_V200_test.go
@@ -111,14 +111,14 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 		DomainEntity: domainlayer.DomainEntity{
 			Id: "bitbucket:BitbucketRepo:1:likyh/likyhphp",
 		},
-		Name: "test/testRepo",
+		Name: "likyh/likyhphp",
 	}
 
 	scopeTicket := &ticket.Board{
 		DomainEntity: domainlayer.DomainEntity{
 			Id: "bitbucket:BitbucketRepo:1:likyh/likyhphp",
 		},
-		Name:        "test/testRepo",
+		Name:        "likyh/likyhphp",
 		Description: "",
 		Url:         "",
 		CreatedDate: nil,

--- a/backend/plugins/bitbucket/api/blueprint_v200.go
+++ b/backend/plugins/bitbucket/api/blueprint_v200.go
@@ -154,7 +154,7 @@ func makeScopesV200(bpScopes []*plugin.BlueprintScopeV200, connection *models.Bi
 				DomainEntity: domainlayer.DomainEntity{
 					Id: didgen.NewDomainIdGenerator(&models.BitbucketRepo{}).Generate(connection.ID, repo.BitbucketId),
 				},
-				Name: repo.Name,
+				Name: repo.BitbucketId,
 			}
 			scopes = append(scopes, scopeRepo)
 		}
@@ -164,7 +164,7 @@ func makeScopesV200(bpScopes []*plugin.BlueprintScopeV200, connection *models.Bi
 				DomainEntity: domainlayer.DomainEntity{
 					Id: didgen.NewDomainIdGenerator(&models.BitbucketRepo{}).Generate(connection.ID, repo.BitbucketId),
 				},
-				Name: repo.Name,
+				Name: repo.BitbucketId,
 			}
 			scopes = append(scopes, scopeCICD)
 		}
@@ -174,7 +174,7 @@ func makeScopesV200(bpScopes []*plugin.BlueprintScopeV200, connection *models.Bi
 				DomainEntity: domainlayer.DomainEntity{
 					Id: didgen.NewDomainIdGenerator(&models.BitbucketRepo{}).Generate(connection.ID, repo.BitbucketId),
 				},
-				Name: repo.Name,
+				Name: repo.BitbucketId,
 			}
 			scopes = append(scopes, scopeTicket)
 		}

--- a/backend/plugins/gitlab/api/blueprint_V200_test.go
+++ b/backend/plugins/gitlab/api/blueprint_V200_test.go
@@ -47,6 +47,7 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	const testHttpUrlToRepo string = "https://this_is_cloneUrl"
 	const testToken string = "nddtf"
 	const testName string = "gitlab-test"
+	const pathWithNamespace string = "nddtf/gitlab-test"
 	const testScopeConfigName string = "gitlab scope config"
 	const testProxy string = ""
 
@@ -59,13 +60,13 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	}
 
 	var testGitlabProject = &models.GitlabProject{
-		ConnectionId: testConnectionID,
-		GitlabId:     testID,
-		Name:         testName,
-
-		ScopeConfigId: testScopeConfigId,
-		CreatedDate:   &time.Time{},
-		HttpUrlToRepo: testHttpUrlToRepo,
+		ConnectionId:      testConnectionID,
+		GitlabId:          testID,
+		Name:              testName,
+		PathWithNamespace: pathWithNamespace,
+		ScopeConfigId:     testScopeConfigId,
+		CreatedDate:       &time.Time{},
+		HttpUrlToRepo:     testHttpUrlToRepo,
 	}
 
 	var testScopeConfig = &models.GitlabScopeConfig{
@@ -160,14 +161,14 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 		},
 	}
 
-	expectRepo := code.NewRepo(expectRepoId, testName)
+	expectRepo := code.NewRepo(expectRepoId, pathWithNamespace)
 	expectRepo.ForkedFrom = testGitlabProject.ForkedFromProjectWebUrl
 
-	expectCicdScope := devops.NewCicdScope(expectRepoId, testName)
+	expectCicdScope := devops.NewCicdScope(expectRepoId, pathWithNamespace)
 	expectCicdScope.Description = ""
 	expectCicdScope.Url = ""
 
-	expectBoard := ticket.NewBoard(expectRepoId, testName)
+	expectBoard := ticket.NewBoard(expectRepoId, pathWithNamespace)
 	expectBoard.Description = ""
 	expectBoard.Url = ""
 	expectBoard.Type = ""

--- a/backend/plugins/gitlab/api/blueprint_v200.go
+++ b/backend/plugins/gitlab/api/blueprint_v200.go
@@ -86,7 +86,7 @@ func makeScopeV200(connectionId uint64, scopes []*plugin.BlueprintScopeV200) ([]
 		if utils.StringsContains(scopeConfig.Entities, plugin.DOMAIN_TYPE_CODE_REVIEW) ||
 			utils.StringsContains(scopeConfig.Entities, plugin.DOMAIN_TYPE_CODE) {
 			// if we don't need to collect gitex, we need to add repo to scopes here
-			scopeRepo := code.NewRepo(id, gitlabProject.Name)
+			scopeRepo := code.NewRepo(id, gitlabProject.PathWithNamespace)
 
 			if gitlabProject.ForkedFromProjectWebUrl != "" {
 				scopeRepo.ForkedFrom = gitlabProject.ForkedFromProjectWebUrl
@@ -96,15 +96,13 @@ func makeScopeV200(connectionId uint64, scopes []*plugin.BlueprintScopeV200) ([]
 
 		// add cicd_scope to scopes
 		if utils.StringsContains(scopeConfig.Entities, plugin.DOMAIN_TYPE_CICD) {
-			scopeCICD := devops.NewCicdScope(id, gitlabProject.Name)
-
+			scopeCICD := devops.NewCicdScope(id, gitlabProject.PathWithNamespace)
 			sc = append(sc, scopeCICD)
 		}
 
 		// add board to scopes
 		if utils.StringsContains(scopeConfig.Entities, plugin.DOMAIN_TYPE_TICKET) {
-			scopeTicket := ticket.NewBoard(id, gitlabProject.Name)
-
+			scopeTicket := ticket.NewBoard(id, gitlabProject.PathWithNamespace)
 			sc = append(sc, scopeTicket)
 		}
 	}


### PR DESCRIPTION
### Summary
gitlab/bitbucket generate the complete repo name path when creating blueprint

### Does this close any open issues?
Closes #5193 

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/101256042/05dc546e-3b72-4b24-9522-ced0eb1ad7f3)

### Other Information
Any other information that is important to this PR.
