### PR TITLE
fix: sonarqube issue collector data split error

### DIFF
--- a/backend/plugins/sonarqube/tasks/issues_collector.go
+++ b/backend/plugins/sonarqube/tasks/issues_collector.go
@@ -120,7 +120,7 @@ func CollectIssues(taskCtx plugin.SubTaskContext) (err errors.Error) {
 
 				// can not split it any more
 				if createdBeforeUnix-createdAfterUnix <= 10 {
-					return pages, nil
+					return 100, nil
 				}
 
 				// split it


### PR DESCRIPTION
### Summary

Previous PR #5443 didn't fix the problem, returning page count over 100 will get splited again.

### Does this close any open issues?
Closes #5442

### Screenshots

Include any relevant screenshots here.

### Other Information

Any other information that is important to this PR.
