### PR TITLE
fix: missing raw layer tables

### DIFF
--- a/backend/helpers/pluginhelper/api/api_extractor.go
+++ b/backend/helpers/pluginhelper/api/api_extractor.go
@@ -64,7 +64,9 @@ func (extractor *ApiExtractor) Execute() errors.Error {
 	// load data from database
 	db := extractor.args.Ctx.GetDal()
 	logger := extractor.args.Ctx.GetLogger()
-
+	if !db.HasTable(extractor.table) {
+		return nil
+	}
 	clauses := []dal.Clause{
 		dal.From(extractor.table),
 		dal.Where("params = ?", extractor.params),


### PR DESCRIPTION
### Summary
- Fix #5490 
- Collectors are supposed to create the raw layer tables, if the collector never got executed, the tables are missing, and the extractors could not find the tables. In this PR, the extractors would return without any error, if they found the table is missing

### Does this close any open issues?
Closes #5490 

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/8455907/b7c649e3-6d24-4968-a66b-1c198ca6dbd5)

### Other Information
Any other information that is important to this PR.
