### PR TITLE
fix: Assign proper value to the column `type`  of table `boards`

### DIFF
--- a/backend/plugins/customize/service/service.go
+++ b/backend/plugins/customize/service/service.go
@@ -167,7 +167,7 @@ func (s *Service) SaveBoard(boardId, boardName string) errors.Error {
 			Id: boardId,
 		},
 		Name: boardName,
-		Type: "kanban",
+		Type: "csv",
 	})
 }
 

--- a/backend/plugins/tapd/api/blueprint_v200.go
+++ b/backend/plugins/tapd/api/blueprint_v200.go
@@ -109,6 +109,7 @@ func makeScopesV200(
 					Id: didgen.NewDomainIdGenerator(&models.TapdWorkspace{}).Generate(tapdWorkspace.ConnectionId, tapdWorkspace.Id),
 				},
 				Name: tapdWorkspace.Name,
+				Type: "scrum",
 			}
 			scopes = append(scopes, domainBoard)
 		}

--- a/backend/plugins/tapd/api/blueprint_v200_test.go
+++ b/backend/plugins/tapd/api/blueprint_v200_test.go
@@ -70,6 +70,7 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 			Id: "tapd:TapdWorkspace:1:10",
 		},
 		Name: "a",
+		Type: "scrum",
 	}
 
 	expectScopes = append(expectScopes, tapdBoard)

--- a/backend/plugins/tapd/tasks/workspace_converter.go
+++ b/backend/plugins/tapd/tasks/workspace_converter.go
@@ -42,6 +42,7 @@ func ConvertWorkspace(taskCtx plugin.SubTaskContext) errors.Error {
 			Id: getWorkspaceIdGen().Generate(workspace.ConnectionId, workspace.Id),
 		},
 		Name: workspace.Name,
+		Type: "scrum",
 		Url:  fmt.Sprintf("%s/%d", "https://tapd.cn", workspace.Id),
 	}
 


### PR DESCRIPTION
### Summary
Fix #5157 ([Bug][Tapd] Tapd board type not set to scrum in domain layer's boards table)

### Does this close any open issues?
Closes #5157 

