### PR TITLE
[feat-5513]: Scope check before deleting connections + various small fixes

### DIFF
--- a/backend/core/models/dynamic_tabler.go
+++ b/backend/core/models/dynamic_tabler.go
@@ -29,41 +29,54 @@ import (
 // DynamicTabler is a core.Tabler that wraps a runtime (anonymously) generated data-model. Due to limitations of
 // reflection in Go and the GORM framework, the underlying model and the table have to be explicitly passed into dal.Dal's API
 // via Unwrap() and TableName()
-type DynamicTabler struct {
+type DynamicTabler interface {
+	dal.Tabler
+	NewValue() any
+	New() DynamicTabler
+	NewSlice() DynamicTabler
+	From(src any) errors.Error
+	To(target any) errors.Error
+	Unwrap() any
+	UnwrapPtr() *any
+	UnwrapSlice() []any
+}
+
+// DynamicTablerImpl the implementation of DynamicTabler
+type DynamicTablerImpl struct {
 	objType reflect.Type
 	wrapped any
 	table   string
 }
 
-func NewDynamicTabler(tableName string, objType reflect.Type) *DynamicTabler {
-	return &DynamicTabler{
+func NewDynamicTabler(tableName string, objType reflect.Type) DynamicTabler {
+	return &DynamicTablerImpl{
 		objType: objType,
 		table:   tableName,
 	}
 }
 
-func (d *DynamicTabler) NewValue() any {
+func (d *DynamicTablerImpl) NewValue() any {
 	return reflect.New(d.objType).Interface()
 }
 
-func (d *DynamicTabler) New() *DynamicTabler {
-	return &DynamicTabler{
+func (d *DynamicTablerImpl) New() DynamicTabler {
+	return &DynamicTablerImpl{
 		objType: d.objType,
 		wrapped: d.NewValue(),
 		table:   d.table,
 	}
 }
 
-func (d *DynamicTabler) NewSlice() *DynamicTabler {
+func (d *DynamicTablerImpl) NewSlice() DynamicTabler {
 	sliceType := reflect.SliceOf(d.objType)
-	return &DynamicTabler{
+	return &DynamicTablerImpl{
 		objType: sliceType,
 		wrapped: reflect.New(sliceType).Interface(),
 		table:   d.table,
 	}
 }
 
-func (d *DynamicTabler) From(src any) errors.Error {
+func (d *DynamicTablerImpl) From(src any) errors.Error {
 	b, err := json.Marshal(src)
 	if err != nil {
 		return errors.Convert(err)
@@ -71,7 +84,7 @@ func (d *DynamicTabler) From(src any) errors.Error {
 	return errors.Convert(json.Unmarshal(b, d.wrapped))
 }
 
-func (d *DynamicTabler) To(target any) errors.Error {
+func (d *DynamicTablerImpl) To(target any) errors.Error {
 	b, err := json.Marshal(d.wrapped)
 	if err != nil {
 		return errors.Convert(err)
@@ -79,19 +92,15 @@ func (d *DynamicTabler) To(target any) errors.Error {
 	return errors.Convert(json.Unmarshal(b, target))
 }
 
-func (d *DynamicTabler) Set(x any) {
-	d.wrapped = x
-}
-
-func (d *DynamicTabler) Unwrap() any {
+func (d *DynamicTablerImpl) Unwrap() any {
 	return d.wrapped
 }
 
-func (d *DynamicTabler) UnwrapPtr() *any {
+func (d *DynamicTablerImpl) UnwrapPtr() *any {
 	return &d.wrapped
 }
 
-func (d *DynamicTabler) UnwrapSlice() []any {
+func (d *DynamicTablerImpl) UnwrapSlice() []any {
 	var arr []any
 	slice := reflect.ValueOf(d.wrapped).Elem()
 	for i := 0; i < slice.Len(); i++ {
@@ -100,15 +109,15 @@ func (d *DynamicTabler) UnwrapSlice() []any {
 	return arr
 }
 
-func (d *DynamicTabler) TableName() string {
+func (d *DynamicTablerImpl) TableName() string {
 	return d.table
 }
 
-var _ dal.Tabler = (*DynamicTabler)(nil)
+var _ DynamicTabler = (*DynamicTablerImpl)(nil)
 
 // UnwrapObject if the actual object is wrapped in some proxy, it unwinds and returns it, otherwise this is idempotent
 func UnwrapObject(ifc any) any {
-	if dynamic, ok := ifc.(*DynamicTabler); ok {
+	if dynamic, ok := ifc.(DynamicTabler); ok {
 		return dynamic.Unwrap()
 	}
 	return ifc

--- a/backend/core/plugin/hub_test.go
+++ b/backend/core/plugin/hub_test.go
@@ -28,6 +28,10 @@ var _ PluginMeta = (*Bar)(nil)
 
 type Foo string
 
+func (f *Foo) Name() string {
+	return "foo"
+}
+
 func (f *Foo) Description() string {
 	return "foo"
 }
@@ -37,6 +41,10 @@ func (f *Foo) RootPkgPath() string {
 }
 
 type Bar string
+
+func (b *Bar) Name() string {
+	return "bar"
+}
 
 func (b *Bar) Description() string {
 	return "foo"

--- a/backend/core/plugin/plugin_meta.go
+++ b/backend/core/plugin/plugin_meta.go
@@ -47,6 +47,6 @@ type PluginIcon interface {
 // PluginSource abstracts data sources
 type PluginSource interface {
 	Connection() dal.Tabler
-	Scopes() []ToolLayerScope
+	Scope() ToolLayerScope
 	ScopeConfig() dal.Tabler
 }

--- a/backend/core/plugin/plugin_meta.go
+++ b/backend/core/plugin/plugin_meta.go
@@ -47,6 +47,6 @@ type PluginIcon interface {
 // PluginSource abstracts data sources
 type PluginSource interface {
 	Connection() dal.Tabler
-	Scopes() []dal.Tabler
+	Scopes() []ToolLayerScope
 	ScopeConfig() dal.Tabler
 }

--- a/backend/core/plugin/plugin_meta.go
+++ b/backend/core/plugin/plugin_meta.go
@@ -17,11 +17,14 @@ limitations under the License.
 
 package plugin
 
+import "github.com/apache/incubator-devlake/core/dal"
+
 // PluginMeta is the Minimal features a plugin should comply, should be implemented by all plugins
 type PluginMeta interface {
 	Description() string
 	// PkgPath information lost when compiled as plugin(.so)
 	RootPkgPath() string
+	Name() string
 }
 
 type GrafanaDashboard struct {
@@ -42,9 +45,8 @@ type PluginIcon interface {
 }
 
 // PluginSource abstracts data sources
-// type PluginSource interface {
-// 	Connection() interface{}
-// 	Scope() interface{}
-// Deprecated: rename to ScopeConfig
-// ScopeConfig() interface{}
-// }
+type PluginSource interface {
+	Connection() dal.Tabler
+	Scopes() []dal.Tabler
+	ScopeConfig() dal.Tabler
+}

--- a/backend/core/utils/json_test.go
+++ b/backend/core/utils/json_test.go
@@ -42,7 +42,7 @@ func TestMissingProperty(t *testing.T) {
 	_, err := GetProperty[int](object, "name")
 
 	assert.Error(t, err)
-	assert.Equal(t, "Missing property \"name\"", err.Error())
+	assert.Contains(t, err.Error(), "Missing property \"name\"")
 }
 
 func TestInvalidPropertyType(t *testing.T) {
@@ -53,7 +53,7 @@ func TestInvalidPropertyType(t *testing.T) {
 	_, err := GetProperty[string](object, "id")
 
 	assert.Error(t, err)
-	assert.Equal(t, "Value is not of type string", err.Error())
+	assert.Contains(t, err.Error(), "Value is not of type string")
 }
 
 func TestGetItemInRange(t *testing.T) {
@@ -71,7 +71,7 @@ func TestGetItemOutOfRange(t *testing.T) {
 	_, err := GetItem[int](array, 3)
 
 	assert.Error(t, err)
-	assert.Equal(t, "Index 3 out of range", err.Error())
+	assert.Contains(t, err.Error(), "Index 3 out of range")
 }
 
 func TestConvertSlice(t *testing.T) {
@@ -89,7 +89,7 @@ func TestConvertSliceInvalidType(t *testing.T) {
 	val, err := Convert[[]string](value)
 	_ = val
 	assert.Error(t, err)
-	assert.Equal(t, "Element 0 is not of type string", err.Error())
+	assert.Contains(t, err.Error(), "Element 0 is not of type string")
 }
 
 func TestConvertSliceInvalidValue(t *testing.T) {
@@ -98,7 +98,7 @@ func TestConvertSliceInvalidValue(t *testing.T) {
 	_, err := Convert[[]int](value)
 
 	assert.Error(t, err)
-	assert.Equal(t, "Element 1 is not of type int", err.Error())
+	assert.Contains(t, err.Error(), "Element 1 is not of type int")
 }
 
 func TestConvertSliceInvalidSlice(t *testing.T) {
@@ -107,5 +107,5 @@ func TestConvertSliceInvalidSlice(t *testing.T) {
 	_, err := Convert[[]int](value)
 
 	assert.Error(t, err)
-	assert.Equal(t, "Value is not a slice", err.Error())
+	assert.Contains(t, err.Error(), "Value is not a slice")
 }

--- a/backend/helpers/pluginhelper/api/connection_helper.go
+++ b/backend/helpers/pluginhelper/api/connection_helper.go
@@ -154,7 +154,7 @@ func (c *ConnectionApiHelper) save(connection interface{}, method func(entity in
 	return nil
 }
 
-func (c *ConnectionApiHelper) getScopeModels() []dal.Tabler {
+func (c *ConnectionApiHelper) getScopeModels() []plugin.ToolLayerScope {
 	pluginMeta, _ := plugin.GetPlugin(c.pluginName)
 	pluginSrc, ok := pluginMeta.(plugin.PluginSource)
 	if !ok {

--- a/backend/helpers/pluginhelper/api/misc_helpers.go
+++ b/backend/helpers/pluginhelper/api/misc_helpers.go
@@ -25,7 +25,7 @@ import (
 
 // CallDB wraps DB calls with this signature, and handles the case if the struct is wrapped in a models.DynamicTabler.
 func CallDB(f func(any, ...dal.Clause) errors.Error, x any, clauses ...dal.Clause) errors.Error {
-	if dynamic, ok := x.(*models.DynamicTabler); ok {
+	if dynamic, ok := x.(models.DynamicTabler); ok {
 		clauses = append(clauses, dal.From(dynamic.TableName()))
 		x = dynamic.Unwrap()
 	}

--- a/backend/helpers/pluginhelper/api/scope_generic_helper.go
+++ b/backend/helpers/pluginhelper/api/scope_generic_helper.go
@@ -679,8 +679,6 @@ func (gs *GenericScopeApiHelper[Conn, Scope, ScopeConfig]) getAffectedTables(plu
 }
 
 func isScopeModel(obj dal.Tabler) bool {
-	if _, ok := obj.(plugin.ToolLayerScope); ok {
-		return true
-	}
-	return reflectField(obj, "ScopeConfigId").IsValid()
+	_, ok := obj.(plugin.ToolLayerScope)
+	return ok
 }

--- a/backend/helpers/pluginhelper/api/scope_helper_test.go
+++ b/backend/helpers/pluginhelper/api/scope_helper_test.go
@@ -305,7 +305,7 @@ func createMockScopeHelper[Repo any](scopeIdFieldName string) *ScopeApiHelper[Te
 	mockDal.On("All", mock.Anything, mock.Anything).Return(nil)
 	mockDal.On("AllTables").Return(nil, nil)
 
-	connHelper := NewConnectionHelper(mockRes, nil)
+	connHelper := NewConnectionHelper(mockRes, nil, "dummy_plugin")
 
 	params := &ReflectionParameters{
 		ScopeIdFieldName:  scopeIdFieldName,

--- a/backend/plugins/ae/api/connection.go
+++ b/backend/plugins/ae/api/connection.go
@@ -145,7 +145,7 @@ func DeleteConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput
 		return nil, err
 	}
 	var refs *services.BlueprintProjectPairs
-	refs, err = connectionHelper.Delete(input.GetPlugin(), connection)
+	refs, err = connectionHelper.Delete(connection)
 	if err != nil {
 		return &plugin.ApiResourceOutput{Body: refs, Status: err.GetType().GetHttpCode()}, err
 	}

--- a/backend/plugins/ae/api/init.go
+++ b/backend/plugins/ae/api/init.go
@@ -19,6 +19,7 @@ package api
 
 import (
 	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/go-playground/validator/v10"
 )
@@ -27,11 +28,13 @@ var vld *validator.Validate
 var connectionHelper *api.ConnectionApiHelper
 var basicRes context.BasicRes
 
-func Init(br context.BasicRes) {
+func Init(br context.BasicRes, p plugin.PluginMeta) {
+
 	basicRes = br
 	vld = validator.New()
 	connectionHelper = api.NewConnectionHelper(
 		basicRes,
 		vld,
+		p.Name(),
 	)
 }

--- a/backend/plugins/ae/impl/impl.go
+++ b/backend/plugins/ae/impl/impl.go
@@ -54,7 +54,7 @@ func (p AE) Connection() dal.Tabler {
 	return &models.AeConnection{}
 }
 
-func (p AE) Scopes() []plugin.ToolLayerScope {
+func (p AE) Scope() plugin.ToolLayerScope {
 	return nil
 }
 

--- a/backend/plugins/ae/impl/impl.go
+++ b/backend/plugins/ae/impl/impl.go
@@ -31,18 +31,34 @@ import (
 	"github.com/apache/incubator-devlake/plugins/ae/tasks"
 )
 
-var _ plugin.PluginMeta = (*AE)(nil)
-var _ plugin.PluginInit = (*AE)(nil)
-var _ plugin.PluginTask = (*AE)(nil)
-var _ plugin.PluginApi = (*AE)(nil)
-var _ plugin.PluginModel = (*AE)(nil)
-var _ plugin.PluginMigration = (*AE)(nil)
-var _ plugin.CloseablePluginTask = (*AE)(nil)
+var _ interface {
+	plugin.PluginMeta
+	plugin.PluginInit
+	plugin.PluginTask
+	plugin.PluginApi
+	plugin.PluginModel
+	plugin.PluginMigration
+	plugin.CloseablePluginTask
+	plugin.PluginSource
+} = (*AE)(nil)
 
 type AE struct{}
 
 func (p AE) Init(basicRes context.BasicRes) errors.Error {
-	api.Init(basicRes)
+	api.Init(basicRes, p)
+
+	return nil
+}
+
+func (p AE) Connection() dal.Tabler {
+	return &models.AeConnection{}
+}
+
+func (p AE) Scopes() []dal.Tabler {
+	return nil
+}
+
+func (p AE) ScopeConfig() dal.Tabler {
 	return nil
 }
 
@@ -56,6 +72,10 @@ func (p AE) GetTablesInfo() []dal.Tabler {
 
 func (p AE) Description() string {
 	return "To collect and enrich data from AE"
+}
+
+func (p AE) Name() string {
+	return "ae"
 }
 
 func (p AE) SubTaskMetas() []plugin.SubTaskMeta {
@@ -81,6 +101,7 @@ func (p AE) PrepareTaskData(taskCtx plugin.TaskContext, options map[string]inter
 	connectionHelper := helper.NewConnectionHelper(
 		taskCtx,
 		nil,
+		p.Name(),
 	)
 	err = connectionHelper.FirstById(connection, op.ConnectionId)
 	if err != nil {

--- a/backend/plugins/ae/impl/impl.go
+++ b/backend/plugins/ae/impl/impl.go
@@ -54,7 +54,7 @@ func (p AE) Connection() dal.Tabler {
 	return &models.AeConnection{}
 }
 
-func (p AE) Scopes() []dal.Tabler {
+func (p AE) Scopes() []plugin.ToolLayerScope {
 	return nil
 }
 

--- a/backend/plugins/bamboo/api/blueprint_V200_test.go
+++ b/backend/plugins/bamboo/api/blueprint_V200_test.go
@@ -124,6 +124,7 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 
 	// register bamboo plugin for NewDomainIdGenerator
 	mockMeta := mockplugin.NewPluginMeta(t)
+	mockMeta.On("Name").Return("bamboo").Maybe()
 	mockMeta.On("RootPkgPath").Return("github.com/apache/incubator-devlake/plugins/bamboo")
 	err = plugin.RegisterPlugin("bamboo", mockMeta)
 	assert.Equal(t, err, nil)
@@ -145,7 +146,7 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 			*dst = *testScopeConfig
 		}).Return(nil)
 	})
-	Init(basicRes)
+	Init(basicRes, mockMeta)
 
 	plans, scopes, err := MakePipelinePlanV200(testSubTaskMeta, testConnectionID, bpScopes, syncPolicy)
 	assert.Equal(t, err, nil)

--- a/backend/plugins/bamboo/api/connection.go
+++ b/backend/plugins/bamboo/api/connection.go
@@ -118,7 +118,7 @@ func DeleteConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput
 		return nil, err
 	}
 	var refs *services.BlueprintProjectPairs
-	refs, err = connectionHelper.Delete(input.GetPlugin(), connection)
+	refs, err = connectionHelper.Delete(connection)
 	if err != nil {
 		return &plugin.ApiResourceOutput{Body: refs, Status: err.GetType().GetHttpCode()}, err
 	}

--- a/backend/plugins/bamboo/api/init.go
+++ b/backend/plugins/bamboo/api/init.go
@@ -19,6 +19,7 @@ package api
 
 import (
 	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/bamboo/models"
 	"github.com/go-playground/validator/v10"
@@ -32,12 +33,14 @@ var scopeConfigHelper *api.ScopeConfigHelper[models.BambooScopeConfig]
 
 var basicRes context.BasicRes
 
-func Init(br context.BasicRes) {
+func Init(br context.BasicRes, p plugin.PluginMeta) {
+
 	basicRes = br
 	vld = validator.New()
 	connectionHelper = api.NewConnectionHelper(
 		basicRes,
 		vld,
+		p.Name(),
 	)
 	params := &api.ReflectionParameters{
 		ScopeIdFieldName:  "ProjectKey",

--- a/backend/plugins/bamboo/impl/impl.go
+++ b/backend/plugins/bamboo/impl/impl.go
@@ -56,8 +56,8 @@ func (p Bamboo) Connection() dal.Tabler {
 	return &models.BambooConnection{}
 }
 
-func (p Bamboo) Scopes() []plugin.ToolLayerScope {
-	return []plugin.ToolLayerScope{&models.BambooProject{}}
+func (p Bamboo) Scope() plugin.ToolLayerScope {
+	return &models.BambooProject{}
 }
 
 func (p Bamboo) ScopeConfig() dal.Tabler {

--- a/backend/plugins/bamboo/impl/impl.go
+++ b/backend/plugins/bamboo/impl/impl.go
@@ -56,8 +56,8 @@ func (p Bamboo) Connection() dal.Tabler {
 	return &models.BambooConnection{}
 }
 
-func (p Bamboo) Scopes() []dal.Tabler {
-	return []dal.Tabler{&models.BambooProject{}}
+func (p Bamboo) Scopes() []plugin.ToolLayerScope {
+	return []plugin.ToolLayerScope{&models.BambooProject{}}
 }
 
 func (p Bamboo) ScopeConfig() dal.Tabler {

--- a/backend/plugins/bamboo/impl/impl.go
+++ b/backend/plugins/bamboo/impl/impl.go
@@ -33,33 +33,35 @@ import (
 )
 
 // make sure interface is implemented
-var _ plugin.PluginMeta = (*Bamboo)(nil)
-var _ plugin.PluginInit = (*Bamboo)(nil)
-var _ plugin.PluginTask = (*Bamboo)(nil)
-var _ plugin.PluginModel = (*Bamboo)(nil)
-var _ plugin.PluginMigration = (*Bamboo)(nil)
-var _ plugin.DataSourcePluginBlueprintV200 = (*Bamboo)(nil)
-var _ plugin.CloseablePluginTask = (*Bamboo)(nil)
-
-// var _ plugin.PluginSource = (*Bamboo)(nil)
+var _ interface {
+	plugin.PluginMeta
+	plugin.PluginInit
+	plugin.PluginTask
+	plugin.PluginModel
+	plugin.PluginMigration
+	plugin.DataSourcePluginBlueprintV200
+	plugin.CloseablePluginTask
+	plugin.PluginSource
+} = (*Bamboo)(nil)
 
 type Bamboo struct{}
 
 func (p Bamboo) Init(br context.BasicRes) errors.Error {
-	api.Init(br)
+	api.Init(br, p)
+
 	return nil
 }
 
-func (p Bamboo) Connection() interface{} {
+func (p Bamboo) Connection() dal.Tabler {
 	return &models.BambooConnection{}
 }
 
-func (p Bamboo) Scope() interface{} {
-	return nil
+func (p Bamboo) Scopes() []dal.Tabler {
+	return []dal.Tabler{&models.BambooProject{}}
 }
 
-func (p Bamboo) ScopeConfig() interface{} {
-	return nil
+func (p Bamboo) ScopeConfig() dal.Tabler {
+	return &models.BambooScopeConfig{}
 }
 
 func (p Bamboo) MakeDataSourcePipelinePlanV200(connectionId uint64, scopes []*plugin.BlueprintScopeV200, syncPolicy plugin.BlueprintSyncPolicy) (plugin.PipelinePlan, []plugin.Scope, errors.Error) {
@@ -80,6 +82,10 @@ func (p Bamboo) GetTablesInfo() []dal.Tabler {
 
 func (p Bamboo) Description() string {
 	return "collect some Bamboo data"
+}
+
+func (p Bamboo) Name() string {
+	return "bamboo"
 }
 
 func (p Bamboo) SubTaskMetas() []plugin.SubTaskMeta {
@@ -117,6 +123,7 @@ func (p Bamboo) PrepareTaskData(taskCtx plugin.TaskContext, options map[string]i
 	connectionHelper := helper.NewConnectionHelper(
 		taskCtx,
 		nil,
+		p.Name(),
 	)
 	connection := &models.BambooConnection{}
 	err = connectionHelper.FirstById(connection, op.ConnectionId)

--- a/backend/plugins/bitbucket/api/blueprint_V200_test.go
+++ b/backend/plugins/bitbucket/api/blueprint_V200_test.go
@@ -56,10 +56,12 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	}
 	mockMeta := mockplugin.NewPluginMeta(t)
 	mockMeta.On("RootPkgPath").Return("github.com/apache/incubator-devlake/plugins/bitbucket")
+	mockMeta.On("Name").Return("bitbucket").Maybe()
 	err := plugin.RegisterPlugin("bitbucket", mockMeta)
 	assert.Nil(t, err)
 	// Refresh Global Variables and set the sql mock
-	mockBasicRes()
+	mockBasicRes(t)
+
 	bs := &plugin.BlueprintScopeV200{
 		Id: "1",
 	}
@@ -129,7 +131,7 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	assert.Equal(t, expectScopes, scopes)
 }
 
-func mockBasicRes() {
+func mockBasicRes(t *testing.T) {
 	testBitbucketRepo := &models.BitbucketRepo{
 		ConnectionId:  1,
 		BitbucketId:   "likyh/likyhphp",
@@ -165,5 +167,7 @@ func mockBasicRes() {
 			*dst = *testScopeConfig
 		}).Return(nil)
 	})
-	Init(mockRes)
+	p := mockplugin.NewPluginMeta(t)
+	p.On("Name").Return("dummy").Maybe()
+	Init(mockRes, p)
 }

--- a/backend/plugins/bitbucket/api/connection.go
+++ b/backend/plugins/bitbucket/api/connection.go
@@ -125,7 +125,7 @@ func DeleteConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput
 		return nil, err
 	}
 	var refs *services.BlueprintProjectPairs
-	refs, err = connectionHelper.Delete(input.GetPlugin(), connection)
+	refs, err = connectionHelper.Delete(connection)
 	if err != nil {
 		return &plugin.ApiResourceOutput{Body: refs, Status: err.GetType().GetHttpCode()}, err
 	}

--- a/backend/plugins/bitbucket/api/init.go
+++ b/backend/plugins/bitbucket/api/init.go
@@ -19,6 +19,7 @@ package api
 
 import (
 	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/bitbucket/models"
 	"github.com/go-playground/validator/v10"
@@ -31,12 +32,14 @@ var remoteHelper *api.RemoteApiHelper[models.BitbucketConnection, models.Bitbuck
 var scHelper *api.ScopeConfigHelper[models.BitbucketScopeConfig]
 var basicRes context.BasicRes
 
-func Init(br context.BasicRes) {
+func Init(br context.BasicRes, p plugin.PluginMeta) {
+
 	basicRes = br
 	vld = validator.New()
 	connectionHelper = api.NewConnectionHelper(
 		basicRes,
 		vld,
+		p.Name(),
 	)
 	params := &api.ReflectionParameters{
 		ScopeIdFieldName:  "BitbucketId",

--- a/backend/plugins/bitbucket/impl/impl.go
+++ b/backend/plugins/bitbucket/impl/impl.go
@@ -51,8 +51,8 @@ func (p Bitbucket) Connection() dal.Tabler {
 	return &models.BitbucketConnection{}
 }
 
-func (p Bitbucket) Scopes() []dal.Tabler {
-	return []dal.Tabler{&models.BitbucketRepo{}}
+func (p Bitbucket) Scopes() []plugin.ToolLayerScope {
+	return []plugin.ToolLayerScope{&models.BitbucketRepo{}}
 }
 
 func (p Bitbucket) ScopeConfig() dal.Tabler {

--- a/backend/plugins/bitbucket/impl/impl.go
+++ b/backend/plugins/bitbucket/impl/impl.go
@@ -33,33 +33,35 @@ import (
 	"github.com/apache/incubator-devlake/plugins/bitbucket/tasks"
 )
 
-var _ plugin.PluginMeta = (*Bitbucket)(nil)
-var _ plugin.PluginInit = (*Bitbucket)(nil)
-var _ plugin.PluginTask = (*Bitbucket)(nil)
-var _ plugin.PluginApi = (*Bitbucket)(nil)
-var _ plugin.PluginModel = (*Bitbucket)(nil)
-var _ plugin.PluginMigration = (*Bitbucket)(nil)
-var _ plugin.CloseablePluginTask = (*Bitbucket)(nil)
-var _ plugin.DataSourcePluginBlueprintV200 = (*Bitbucket)(nil)
-
-// var _ plugin.PluginSource = (*Bitbucket)(nil)
+var _ interface {
+	plugin.PluginMeta
+	plugin.PluginInit
+	plugin.PluginTask
+	plugin.PluginApi
+	plugin.PluginModel
+	plugin.PluginMigration
+	plugin.CloseablePluginTask
+	plugin.DataSourcePluginBlueprintV200
+	plugin.PluginSource
+} = (*Bitbucket)(nil)
 
 type Bitbucket string
 
-func (p Bitbucket) Connection() interface{} {
+func (p Bitbucket) Connection() dal.Tabler {
 	return &models.BitbucketConnection{}
 }
 
-func (p Bitbucket) Scope() interface{} {
-	return &models.BitbucketRepo{}
+func (p Bitbucket) Scopes() []dal.Tabler {
+	return []dal.Tabler{&models.BitbucketRepo{}}
 }
 
-func (p Bitbucket) ScopeConfig() interface{} {
+func (p Bitbucket) ScopeConfig() dal.Tabler {
 	return &models.BitbucketScopeConfig{}
 }
 
 func (p Bitbucket) Init(basicRes context.BasicRes) errors.Error {
-	api.Init(basicRes)
+	api.Init(basicRes, p)
+
 	return nil
 }
 
@@ -80,6 +82,10 @@ func (p Bitbucket) GetTablesInfo() []dal.Tabler {
 
 func (p Bitbucket) Description() string {
 	return "To collect and enrich data from Bitbucket"
+}
+
+func (p Bitbucket) Name() string {
+	return "bitbucket"
 }
 
 func (p Bitbucket) SubTaskMetas() []plugin.SubTaskMeta {
@@ -136,6 +142,7 @@ func (p Bitbucket) PrepareTaskData(taskCtx plugin.TaskContext, options map[strin
 	connectionHelper := helper.NewConnectionHelper(
 		taskCtx,
 		nil,
+		p.Name(),
 	)
 	connection := &models.BitbucketConnection{}
 	err = connectionHelper.FirstById(connection, op.ConnectionId)

--- a/backend/plugins/bitbucket/impl/impl.go
+++ b/backend/plugins/bitbucket/impl/impl.go
@@ -51,8 +51,8 @@ func (p Bitbucket) Connection() dal.Tabler {
 	return &models.BitbucketConnection{}
 }
 
-func (p Bitbucket) Scopes() []plugin.ToolLayerScope {
-	return []plugin.ToolLayerScope{&models.BitbucketRepo{}}
+func (p Bitbucket) Scope() plugin.ToolLayerScope {
+	return &models.BitbucketRepo{}
 }
 
 func (p Bitbucket) ScopeConfig() dal.Tabler {

--- a/backend/plugins/customize/impl/impl.go
+++ b/backend/plugins/customize/impl/impl.go
@@ -28,11 +28,13 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-var _ plugin.PluginMeta = (*Customize)(nil)
-var _ plugin.PluginInit = (*Customize)(nil)
-var _ plugin.PluginApi = (*Customize)(nil)
-var _ plugin.PluginModel = (*Customize)(nil)
-var _ plugin.PluginMigration = (*Customize)(nil)
+var _ interface {
+	plugin.PluginMeta
+	plugin.PluginInit
+	plugin.PluginApi
+	plugin.PluginModel
+	plugin.PluginMigration
+} = (*Customize)(nil)
 
 type Customize struct {
 	handlers *api.Handlers
@@ -70,6 +72,10 @@ func (p Customize) PrepareTaskData(taskCtx plugin.TaskContext, options map[strin
 
 func (p Customize) Description() string {
 	return "To customize table fields"
+}
+
+func (p Customize) Name() string {
+	return "customize"
 }
 
 func (p Customize) MigrationScripts() []plugin.MigrationScript {

--- a/backend/plugins/dbt/impl/impl.go
+++ b/backend/plugins/dbt/impl/impl.go
@@ -25,11 +25,11 @@ import (
 	"github.com/apache/incubator-devlake/plugins/dbt/tasks"
 )
 
-var (
-	_ plugin.PluginMeta  = (*Dbt)(nil)
-	_ plugin.PluginTask  = (*Dbt)(nil)
-	_ plugin.PluginModel = (*Dbt)(nil)
-)
+var _ interface {
+	plugin.PluginMeta
+	plugin.PluginTask
+	plugin.PluginModel
+} = (*Dbt)(nil)
 
 type Dbt struct{}
 
@@ -69,4 +69,8 @@ func (p Dbt) PrepareTaskData(taskCtx plugin.TaskContext, options map[string]inte
 
 func (p Dbt) RootPkgPath() string {
 	return "github.com/apache/incubator-devlake/plugins/dbt"
+}
+
+func (p Dbt) Name() string {
+	return "dbt"
 }

--- a/backend/plugins/dora/impl/impl.go
+++ b/backend/plugins/dora/impl/impl.go
@@ -28,12 +28,14 @@ import (
 )
 
 // make sure interface is implemented
-var _ plugin.PluginMeta = (*Dora)(nil)
-var _ plugin.PluginTask = (*Dora)(nil)
-var _ plugin.PluginModel = (*Dora)(nil)
-var _ plugin.PluginMetric = (*Dora)(nil)
-var _ plugin.PluginMigration = (*Dora)(nil)
-var _ plugin.MetricPluginBlueprintV200 = (*Dora)(nil)
+var _ interface {
+	plugin.PluginMeta
+	plugin.PluginTask
+	plugin.PluginModel
+	plugin.PluginMetric
+	plugin.PluginMigration
+	plugin.MetricPluginBlueprintV200
+} = (*Dora)(nil)
 
 type Dora struct{}
 
@@ -66,6 +68,10 @@ func (p Dora) RequiredDataEntities() (data []map[string]interface{}, err errors.
 
 func (p Dora) GetTablesInfo() []dal.Tabler {
 	return []dal.Tabler{}
+}
+
+func (p Dora) Name() string {
+	return "dora"
 }
 
 func (p Dora) IsProjectMetric() bool {

--- a/backend/plugins/feishu/api/connection.go
+++ b/backend/plugins/feishu/api/connection.go
@@ -111,7 +111,7 @@ func DeleteConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput
 		return nil, err
 	}
 	var refs *services.BlueprintProjectPairs
-	refs, err = connectionHelper.Delete(input.GetPlugin(), connection)
+	refs, err = connectionHelper.Delete(connection)
 	if err != nil {
 		return &plugin.ApiResourceOutput{Body: refs, Status: err.GetType().GetHttpCode()}, err
 	}

--- a/backend/plugins/feishu/api/init.go
+++ b/backend/plugins/feishu/api/init.go
@@ -19,6 +19,7 @@ package api
 
 import (
 	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/go-playground/validator/v10"
 )
@@ -27,11 +28,12 @@ var vld *validator.Validate
 var connectionHelper *api.ConnectionApiHelper
 var basicRes context.BasicRes
 
-func Init(br context.BasicRes) {
+func Init(br context.BasicRes, p plugin.PluginMeta) {
 	basicRes = br
 	vld = validator.New()
 	connectionHelper = api.NewConnectionHelper(
 		basicRes,
 		vld,
+		p.Name(),
 	)
 }

--- a/backend/plugins/feishu/impl/impl.go
+++ b/backend/plugins/feishu/impl/impl.go
@@ -31,18 +31,22 @@ import (
 	"github.com/apache/incubator-devlake/plugins/feishu/tasks"
 )
 
-var _ plugin.PluginMeta = (*Feishu)(nil)
-var _ plugin.PluginInit = (*Feishu)(nil)
-var _ plugin.PluginTask = (*Feishu)(nil)
-var _ plugin.PluginApi = (*Feishu)(nil)
-var _ plugin.PluginModel = (*Feishu)(nil)
-var _ plugin.PluginMigration = (*Feishu)(nil)
-var _ plugin.CloseablePluginTask = (*Feishu)(nil)
+var _ interface {
+	plugin.PluginMeta
+	plugin.PluginInit
+	plugin.PluginTask
+	plugin.PluginApi
+	plugin.PluginModel
+	plugin.PluginSource
+	plugin.PluginMigration
+	plugin.CloseablePluginTask
+} = (*Feishu)(nil)
 
 type Feishu struct{}
 
 func (p Feishu) Init(basicRes context.BasicRes) errors.Error {
-	api.Init(basicRes)
+	api.Init(basicRes, p)
+
 	return nil
 }
 
@@ -55,6 +59,22 @@ func (p Feishu) GetTablesInfo() []dal.Tabler {
 
 func (p Feishu) Description() string {
 	return "To collect and enrich data from Feishu"
+}
+
+func (p Feishu) Name() string {
+	return "feishu"
+}
+
+func (p Feishu) Connection() dal.Tabler {
+	return &models.FeishuConnection{}
+}
+
+func (p Feishu) Scopes() []dal.Tabler {
+	return nil
+}
+
+func (p Feishu) ScopeConfig() dal.Tabler {
+	return nil
 }
 
 func (p Feishu) SubTaskMetas() []plugin.SubTaskMeta {
@@ -79,6 +99,7 @@ func (p Feishu) PrepareTaskData(taskCtx plugin.TaskContext, options map[string]i
 	connectionHelper := helper.NewConnectionHelper(
 		taskCtx,
 		nil,
+		p.Name(),
 	)
 	connection := &models.FeishuConnection{}
 	err := connectionHelper.FirstById(connection, op.ConnectionId)

--- a/backend/plugins/feishu/impl/impl.go
+++ b/backend/plugins/feishu/impl/impl.go
@@ -69,7 +69,7 @@ func (p Feishu) Connection() dal.Tabler {
 	return &models.FeishuConnection{}
 }
 
-func (p Feishu) Scopes() []plugin.ToolLayerScope {
+func (p Feishu) Scope() plugin.ToolLayerScope {
 	return nil
 }
 

--- a/backend/plugins/feishu/impl/impl.go
+++ b/backend/plugins/feishu/impl/impl.go
@@ -69,7 +69,7 @@ func (p Feishu) Connection() dal.Tabler {
 	return &models.FeishuConnection{}
 }
 
-func (p Feishu) Scopes() []dal.Tabler {
+func (p Feishu) Scopes() []plugin.ToolLayerScope {
 	return nil
 }
 

--- a/backend/plugins/gitee/api/connection.go
+++ b/backend/plugins/gitee/api/connection.go
@@ -128,7 +128,7 @@ func DeleteConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput
 		return nil, err
 	}
 	var refs *services.BlueprintProjectPairs
-	refs, err = connectionHelper.Delete(input.GetPlugin(), connection)
+	refs, err = connectionHelper.Delete(connection)
 	if err != nil {
 		return &plugin.ApiResourceOutput{Body: refs, Status: err.GetType().GetHttpCode()}, err
 	}

--- a/backend/plugins/gitee/api/init.go
+++ b/backend/plugins/gitee/api/init.go
@@ -19,6 +19,7 @@ package api
 
 import (
 	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/go-playground/validator/v10"
 )
@@ -27,11 +28,13 @@ var vld *validator.Validate
 var connectionHelper *api.ConnectionApiHelper
 var basicRes context.BasicRes
 
-func Init(br context.BasicRes) {
+func Init(br context.BasicRes, p plugin.PluginMeta) {
+
 	basicRes = br
 	vld = validator.New()
 	connectionHelper = api.NewConnectionHelper(
 		basicRes,
 		vld,
+		p.Name(),
 	)
 }

--- a/backend/plugins/gitee/impl/impl.go
+++ b/backend/plugins/gitee/impl/impl.go
@@ -50,8 +50,8 @@ func (p Gitee) Connection() dal.Tabler {
 	return &models.GiteeConnection{}
 }
 
-func (p Gitee) Scopes() []dal.Tabler {
-	return []dal.Tabler{&models.GiteeRepo{}}
+func (p Gitee) Scopes() []plugin.ToolLayerScope {
+	return []plugin.ToolLayerScope{&models.GiteeRepo{}}
 }
 
 func (p Gitee) ScopeConfig() dal.Tabler {

--- a/backend/plugins/gitee/impl/impl.go
+++ b/backend/plugins/gitee/impl/impl.go
@@ -31,23 +31,42 @@ import (
 	"github.com/apache/incubator-devlake/plugins/gitee/tasks"
 )
 
-var _ plugin.PluginMeta = (*Gitee)(nil)
-var _ plugin.PluginInit = (*Gitee)(nil)
-var _ plugin.PluginTask = (*Gitee)(nil)
-var _ plugin.PluginApi = (*Gitee)(nil)
-var _ plugin.PluginModel = (*Gitee)(nil)
-var _ plugin.PluginMigration = (*Gitee)(nil)
-var _ plugin.CloseablePluginTask = (*Gitee)(nil)
+var _ interface {
+	plugin.PluginMeta
+	plugin.PluginInit
+	plugin.PluginTask
+	plugin.PluginApi
+	plugin.PluginModel
+	plugin.PluginSource
+	plugin.PluginMigration
+	plugin.CloseablePluginTask
+} = (*Gitee)(nil)
+
+var _ plugin.PluginSource = (*Gitee)(nil)
 
 type Gitee string
 
+func (p Gitee) Connection() dal.Tabler {
+	return &models.GiteeConnection{}
+}
+
+func (p Gitee) Scopes() []dal.Tabler {
+	return []dal.Tabler{&models.GiteeRepo{}}
+}
+
+func (p Gitee) ScopeConfig() dal.Tabler {
+	return nil
+}
+
 func (p Gitee) Init(basicRes context.BasicRes) errors.Error {
-	api.Init(basicRes)
+	api.Init(basicRes, p)
+
 	return nil
 }
 
 func (p Gitee) GetTablesInfo() []dal.Tabler {
-	return []dal.Tabler{&models.GiteeConnection{},
+	return []dal.Tabler{
+		&models.GiteeConnection{},
 		&models.GiteeAccount{},
 		&models.GiteeCommit{},
 		&models.GiteeCommitStat{},
@@ -67,6 +86,10 @@ func (p Gitee) GetTablesInfo() []dal.Tabler {
 
 func (p Gitee) Description() string {
 	return "To collect and enrich data from Gitee"
+}
+
+func (p Gitee) Name() string {
+	return "gitee"
 }
 
 func (p Gitee) SubTaskMetas() []plugin.SubTaskMeta {
@@ -127,6 +150,7 @@ func (p Gitee) PrepareTaskData(taskCtx plugin.TaskContext, options map[string]in
 	connectionHelper := helper.NewConnectionHelper(
 		taskCtx,
 		nil,
+		p.Name(),
 	)
 
 	if err != nil {

--- a/backend/plugins/gitee/impl/impl.go
+++ b/backend/plugins/gitee/impl/impl.go
@@ -50,8 +50,8 @@ func (p Gitee) Connection() dal.Tabler {
 	return &models.GiteeConnection{}
 }
 
-func (p Gitee) Scopes() []plugin.ToolLayerScope {
-	return []plugin.ToolLayerScope{&models.GiteeRepo{}}
+func (p Gitee) Scope() plugin.ToolLayerScope {
+	return &models.GiteeRepo{}
 }
 
 func (p Gitee) ScopeConfig() dal.Tabler {

--- a/backend/plugins/gitee/models/repo.go
+++ b/backend/plugins/gitee/models/repo.go
@@ -19,6 +19,8 @@ package models
 
 import (
 	"github.com/apache/incubator-devlake/core/models/common"
+	"github.com/apache/incubator-devlake/core/plugin"
+	"strconv"
 	"time"
 )
 
@@ -38,6 +40,16 @@ type GiteeRepo struct {
 	common.NoPKModel
 }
 
+func (r GiteeRepo) ScopeId() string {
+	return strconv.Itoa(r.GiteeId)
+}
+
+func (r GiteeRepo) ScopeName() string {
+	return r.Name
+}
+
 func (GiteeRepo) TableName() string {
 	return "_tool_gitee_repos"
 }
+
+var _ plugin.ToolLayerScope = (*GiteeRepo)(nil)

--- a/backend/plugins/gitextractor/impl/impl.go
+++ b/backend/plugins/gitextractor/impl/impl.go
@@ -31,9 +31,11 @@ import (
 	"strings"
 )
 
-var _ plugin.PluginMeta = (*GitExtractor)(nil)
-var _ plugin.PluginTask = (*GitExtractor)(nil)
-var _ plugin.PluginModel = (*GitExtractor)(nil)
+var _ interface {
+	plugin.PluginMeta
+	plugin.PluginTask
+	plugin.PluginModel
+} = (*GitExtractor)(nil)
 
 type GitExtractor struct{}
 
@@ -43,6 +45,10 @@ func (p GitExtractor) GetTablesInfo() []dal.Tabler {
 
 func (p GitExtractor) Description() string {
 	return "extract infos from git repository"
+}
+
+func (p GitExtractor) Name() string {
+	return "gitextractor"
 }
 
 // return all available subtasks, framework will run them for you in order

--- a/backend/plugins/github/api/blueprint_V200_test.go
+++ b/backend/plugins/github/api/blueprint_V200_test.go
@@ -57,10 +57,12 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	}
 	mockMeta := mockplugin.NewPluginMeta(t)
 	mockMeta.On("RootPkgPath").Return("github.com/apache/incubator-devlake/plugins/github")
+	mockMeta.On("Name").Return("github").Maybe()
 	err := plugin.RegisterPlugin("github", mockMeta)
 	assert.Nil(t, err)
 	// Refresh Global Variables and set the sql mock
-	mockBasicRes()
+	mockBasicRes(t)
+
 	bs := &plugin.BlueprintScopeV200{
 		Id: "1",
 	}
@@ -131,7 +133,7 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	assert.Equal(t, expectScopes, scopes)
 }
 
-func mockBasicRes() {
+func mockBasicRes(t *testing.T) {
 	testGithubRepo := &models.GithubRepo{
 		ConnectionId:  1,
 		GithubId:      12345,
@@ -168,5 +170,7 @@ func mockBasicRes() {
 			*dst = *testScopeConfig
 		}).Return(nil)
 	})
-	Init(mockRes)
+	p := mockplugin.NewPluginMeta(t)
+	p.On("Name").Return("dummy").Maybe()
+	Init(mockRes, p)
 }

--- a/backend/plugins/github/api/connection.go
+++ b/backend/plugins/github/api/connection.go
@@ -253,7 +253,7 @@ func DeleteConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput
 		return nil, err
 	}
 	var refs *services.BlueprintProjectPairs
-	refs, err = connectionHelper.Delete(input.GetPlugin(), connection)
+	refs, err = connectionHelper.Delete(connection)
 	if err != nil {
 		return &plugin.ApiResourceOutput{Body: refs, Status: err.GetType().GetHttpCode()}, err
 	}

--- a/backend/plugins/github/api/init.go
+++ b/backend/plugins/github/api/init.go
@@ -36,12 +36,14 @@ var basicRes context.BasicRes
 var scHelper *api.ScopeConfigHelper[models.GithubScopeConfig]
 var remoteHelper *api.RemoteApiHelper[models.GithubConnection, models.GithubRepo, repo, plugin.ApiGroup]
 
-func Init(br context.BasicRes) {
+func Init(br context.BasicRes, p plugin.PluginMeta) {
+
 	basicRes = br
 	vld = validator.New()
 	connectionHelper = api.NewConnectionHelper(
 		basicRes,
 		vld,
+		p.Name(),
 	)
 	params := &api.ReflectionParameters{
 		ScopeIdFieldName:  "GithubId",

--- a/backend/plugins/github/impl/impl.go
+++ b/backend/plugins/github/impl/impl.go
@@ -51,8 +51,8 @@ func (p Github) Connection() dal.Tabler {
 	return &models.GithubConnection{}
 }
 
-func (p Github) Scopes() []plugin.ToolLayerScope {
-	return []plugin.ToolLayerScope{&models.GithubRepo{}}
+func (p Github) Scope() plugin.ToolLayerScope {
+	return &models.GithubRepo{}
 }
 
 func (p Github) ScopeConfig() dal.Tabler {

--- a/backend/plugins/github/impl/impl.go
+++ b/backend/plugins/github/impl/impl.go
@@ -34,32 +34,34 @@ import (
 	"github.com/apache/incubator-devlake/plugins/github/tasks"
 )
 
-var _ plugin.PluginMeta = (*Github)(nil)
-var _ plugin.PluginInit = (*Github)(nil)
-var _ plugin.PluginTask = (*Github)(nil)
-var _ plugin.PluginApi = (*Github)(nil)
-var _ plugin.PluginModel = (*Github)(nil)
-var _ plugin.DataSourcePluginBlueprintV200 = (*Github)(nil)
-var _ plugin.CloseablePluginTask = (*Github)(nil)
-
-// var _ plugin.PluginSource = (*Github)(nil)
+var _ interface {
+	plugin.PluginMeta
+	plugin.PluginInit
+	plugin.PluginTask
+	plugin.PluginApi
+	plugin.PluginModel
+	plugin.PluginSource
+	plugin.DataSourcePluginBlueprintV200
+	plugin.CloseablePluginTask
+} = (*Github)(nil)
 
 type Github struct{}
 
-func (p Github) Connection() interface{} {
+func (p Github) Connection() dal.Tabler {
 	return &models.GithubConnection{}
 }
 
-func (p Github) Scope() interface{} {
-	return &models.GithubRepo{}
+func (p Github) Scopes() []dal.Tabler {
+	return []dal.Tabler{&models.GithubRepo{}}
 }
 
-func (p Github) ScopeConfig() interface{} {
+func (p Github) ScopeConfig() dal.Tabler {
 	return &models.GithubScopeConfig{}
 }
 
 func (p Github) Init(basicRes context.BasicRes) errors.Error {
-	api.Init(basicRes)
+	api.Init(basicRes, p)
+
 	return nil
 }
 
@@ -92,6 +94,10 @@ func (p Github) GetTablesInfo() []dal.Tabler {
 
 func (p Github) Description() string {
 	return "To collect and enrich data from GitHub"
+}
+
+func (p Github) Name() string {
+	return "github"
 }
 
 func (p Github) SubTaskMetas() []plugin.SubTaskMeta {
@@ -154,6 +160,7 @@ func (p Github) PrepareTaskData(taskCtx plugin.TaskContext, options map[string]i
 	connectionHelper := helper.NewConnectionHelper(
 		taskCtx,
 		nil,
+		p.Name(),
 	)
 	connection := &models.GithubConnection{}
 	err = connectionHelper.FirstById(connection, op.ConnectionId)

--- a/backend/plugins/github/impl/impl.go
+++ b/backend/plugins/github/impl/impl.go
@@ -51,8 +51,8 @@ func (p Github) Connection() dal.Tabler {
 	return &models.GithubConnection{}
 }
 
-func (p Github) Scopes() []dal.Tabler {
-	return []dal.Tabler{&models.GithubRepo{}}
+func (p Github) Scopes() []plugin.ToolLayerScope {
+	return []plugin.ToolLayerScope{&models.GithubRepo{}}
 }
 
 func (p Github) ScopeConfig() dal.Tabler {

--- a/backend/plugins/github_graphql/impl/impl.go
+++ b/backend/plugins/github_graphql/impl/impl.go
@@ -56,8 +56,8 @@ func (p GithubGraphql) Connection() dal.Tabler {
 	return &models.GithubConnection{}
 }
 
-func (p GithubGraphql) Scopes() []plugin.ToolLayerScope {
-	return []plugin.ToolLayerScope{&models.GithubRepo{}}
+func (p GithubGraphql) Scope() plugin.ToolLayerScope {
+	return &models.GithubRepo{}
 }
 
 func (p GithubGraphql) ScopeConfig() dal.Tabler {

--- a/backend/plugins/github_graphql/impl/impl.go
+++ b/backend/plugins/github_graphql/impl/impl.go
@@ -56,8 +56,8 @@ func (p GithubGraphql) Connection() dal.Tabler {
 	return &models.GithubConnection{}
 }
 
-func (p GithubGraphql) Scopes() []dal.Tabler {
-	return []dal.Tabler{&models.GithubRepo{}}
+func (p GithubGraphql) Scopes() []plugin.ToolLayerScope {
+	return []plugin.ToolLayerScope{&models.GithubRepo{}}
 }
 
 func (p GithubGraphql) ScopeConfig() dal.Tabler {

--- a/backend/plugins/github_graphql/impl/impl.go
+++ b/backend/plugins/github_graphql/impl/impl.go
@@ -41,30 +41,35 @@ import (
 )
 
 // make sure interface is implemented
-var _ plugin.PluginMeta = (*GithubGraphql)(nil)
-var _ plugin.PluginTask = (*GithubGraphql)(nil)
-var _ plugin.PluginApi = (*GithubGraphql)(nil)
-var _ plugin.PluginModel = (*GithubGraphql)(nil)
-var _ plugin.CloseablePluginTask = (*GithubGraphql)(nil)
-
-// var _ plugin.PluginSource = (*GithubGraphql)(nil)
+var _ interface {
+	plugin.PluginMeta
+	plugin.PluginTask
+	plugin.PluginApi
+	plugin.PluginModel
+	plugin.PluginSource
+	plugin.CloseablePluginTask
+} = (*GithubGraphql)(nil)
 
 type GithubGraphql struct{}
 
-func (p GithubGraphql) Connection() interface{} {
+func (p GithubGraphql) Connection() dal.Tabler {
 	return &models.GithubConnection{}
 }
 
-func (p GithubGraphql) Scope() interface{} {
-	return &models.GithubRepo{}
+func (p GithubGraphql) Scopes() []dal.Tabler {
+	return []dal.Tabler{&models.GithubRepo{}}
 }
 
-func (p GithubGraphql) ScopeConfig() interface{} {
+func (p GithubGraphql) ScopeConfig() dal.Tabler {
 	return &models.GithubScopeConfig{}
 }
 
 func (p GithubGraphql) Description() string {
 	return "collect some GithubGraphql data"
+}
+
+func (p GithubGraphql) Name() string {
+	return "github_graphql"
 }
 
 func (p GithubGraphql) GetTablesInfo() []dal.Tabler {
@@ -139,6 +144,7 @@ func (p GithubGraphql) PrepareTaskData(taskCtx plugin.TaskContext, options map[s
 	connectionHelper := helper.NewConnectionHelper(
 		taskCtx,
 		nil,
+		p.Name(),
 	)
 	connection := &models.GithubConnection{}
 	err = connectionHelper.FirstById(connection, op.ConnectionId)

--- a/backend/plugins/gitlab/api/blueprint_V200_test.go
+++ b/backend/plugins/gitlab/api/blueprint_V200_test.go
@@ -178,6 +178,7 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	// register gitlab plugin for NewDomainIdGenerator
 	mockMeta := mockplugin.NewPluginMeta(t)
 	mockMeta.On("RootPkgPath").Return("github.com/apache/incubator-devlake/plugins/gitlab")
+	mockMeta.On("Name").Return("dummy").Maybe()
 	err = plugin.RegisterPlugin("gitlab", mockMeta)
 	assert.Equal(t, err, nil)
 
@@ -198,7 +199,7 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 			*dst = *testScopeConfig
 		}).Return(nil)
 	})
-	Init(mockRes)
+	Init(mockRes, mockMeta)
 
 	plans, scopes, err := MakePipelinePlanV200(testSubTaskMeta, testConnectionID, bpScopes, syncPolicy)
 	assert.Equal(t, err, nil)

--- a/backend/plugins/gitlab/api/connection.go
+++ b/backend/plugins/gitlab/api/connection.go
@@ -132,7 +132,7 @@ func DeleteConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput
 		return nil, err
 	}
 	var refs *services.BlueprintProjectPairs
-	refs, err = connectionHelper.Delete(input.GetPlugin(), connection)
+	refs, err = connectionHelper.Delete(connection)
 	if err != nil {
 		return &plugin.ApiResourceOutput{Body: refs, Status: err.GetType().GetHttpCode()}, err
 	}

--- a/backend/plugins/gitlab/api/init.go
+++ b/backend/plugins/gitlab/api/init.go
@@ -19,6 +19,7 @@ package api
 
 import (
 	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/gitlab/models"
 	"github.com/go-playground/validator/v10"
@@ -31,12 +32,14 @@ var remoteHelper *api.RemoteApiHelper[models.GitlabConnection, models.GitlabProj
 var basicRes context.BasicRes
 var scHelper *api.ScopeConfigHelper[models.GitlabScopeConfig]
 
-func Init(br context.BasicRes) {
+func Init(br context.BasicRes, p plugin.PluginMeta) {
+
 	basicRes = br
 	vld = validator.New()
 	connectionHelper = api.NewConnectionHelper(
 		basicRes,
 		vld,
+		p.Name(),
 	)
 	params := &api.ReflectionParameters{
 		ScopeIdFieldName:  "GitlabId",

--- a/backend/plugins/gitlab/impl/impl.go
+++ b/backend/plugins/gitlab/impl/impl.go
@@ -40,9 +40,9 @@ var _ interface {
 	plugin.PluginTask
 	plugin.PluginModel
 	plugin.PluginMigration
+	plugin.PluginSource
 	plugin.DataSourcePluginBlueprintV200
 	plugin.CloseablePluginTask
-	// plugin.PluginSource
 } = (*Gitlab)(nil)
 
 type Gitlab string
@@ -55,19 +55,20 @@ func init() {
 }
 
 func (p Gitlab) Init(basicRes context.BasicRes) errors.Error {
-	api.Init(basicRes)
+	api.Init(basicRes, p)
+
 	return nil
 }
 
-func (p Gitlab) Connection() interface{} {
+func (p Gitlab) Connection() dal.Tabler {
 	return &models.GitlabConnection{}
 }
 
-func (p Gitlab) Scope() interface{} {
-	return &models.GitlabProject{}
+func (p Gitlab) Scopes() []dal.Tabler {
+	return []dal.Tabler{&models.GitlabProject{}}
 }
 
-func (p Gitlab) ScopeConfig() interface{} {
+func (p Gitlab) ScopeConfig() dal.Tabler {
 	return &models.GitlabScopeConfig{}
 }
 
@@ -101,6 +102,10 @@ func (p Gitlab) Description() string {
 	return "To collect and enrich data from Gitlab"
 }
 
+func (p Gitlab) Name() string {
+	return "gitlab"
+}
+
 func (p Gitlab) SubTaskMetas() []plugin.SubTaskMeta {
 	list, err := subtaskmeta_sorter.NewDependencySorter(tasks.SubTaskMetaList).Sort()
 	if err != nil {
@@ -123,6 +128,7 @@ func (p Gitlab) PrepareTaskData(taskCtx plugin.TaskContext, options map[string]i
 	connectionHelper := helper.NewConnectionHelper(
 		taskCtx,
 		nil,
+		p.Name(),
 	)
 	if err != nil {
 		return nil, err

--- a/backend/plugins/gitlab/impl/impl.go
+++ b/backend/plugins/gitlab/impl/impl.go
@@ -64,8 +64,8 @@ func (p Gitlab) Connection() dal.Tabler {
 	return &models.GitlabConnection{}
 }
 
-func (p Gitlab) Scopes() []dal.Tabler {
-	return []dal.Tabler{&models.GitlabProject{}}
+func (p Gitlab) Scopes() []plugin.ToolLayerScope {
+	return []plugin.ToolLayerScope{&models.GitlabProject{}}
 }
 
 func (p Gitlab) ScopeConfig() dal.Tabler {

--- a/backend/plugins/gitlab/impl/impl.go
+++ b/backend/plugins/gitlab/impl/impl.go
@@ -64,8 +64,8 @@ func (p Gitlab) Connection() dal.Tabler {
 	return &models.GitlabConnection{}
 }
 
-func (p Gitlab) Scopes() []plugin.ToolLayerScope {
-	return []plugin.ToolLayerScope{&models.GitlabProject{}}
+func (p Gitlab) Scope() plugin.ToolLayerScope {
+	return &models.GitlabProject{}
 }
 
 func (p Gitlab) ScopeConfig() dal.Tabler {

--- a/backend/plugins/icla/impl/impl.go
+++ b/backend/plugins/icla/impl/impl.go
@@ -30,13 +30,16 @@ import (
 )
 
 // make sure interface is implemented
-var _ plugin.PluginMeta = (*Icla)(nil)
-var _ plugin.PluginInit = (*Icla)(nil)
-var _ plugin.PluginTask = (*Icla)(nil)
-var _ plugin.PluginApi = (*Icla)(nil)
-var _ plugin.PluginModel = (*Icla)(nil)
-var _ plugin.PluginMigration = (*Icla)(nil)
-var _ plugin.CloseablePluginTask = (*Icla)(nil)
+
+var _ interface {
+	plugin.PluginMeta
+	plugin.PluginInit
+	plugin.PluginTask
+	plugin.PluginApi
+	plugin.PluginModel
+	plugin.PluginMigration
+	plugin.CloseablePluginTask
+} = (*Icla)(nil)
 
 type Icla struct{}
 
@@ -82,6 +85,10 @@ func (p Icla) PrepareTaskData(taskCtx plugin.TaskContext, options map[string]int
 // PkgPath information lost when compiled as plugin(.so)
 func (p Icla) RootPkgPath() string {
 	return "github.com/apache/incubator-devlake/plugins/icla"
+}
+
+func (p Icla) Name() string {
+	return "icla"
 }
 
 func (p Icla) MigrationScripts() []plugin.MigrationScript {

--- a/backend/plugins/jenkins/api/blueprint_v200_test.go
+++ b/backend/plugins/jenkins/api/blueprint_v200_test.go
@@ -35,6 +35,7 @@ import (
 func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	mockMeta := mockplugin.NewPluginMeta(t)
 	mockMeta.On("RootPkgPath").Return("github.com/apache/incubator-devlake/plugins/jenkins")
+	mockMeta.On("Name").Return("jenkins").Maybe()
 	err := plugin.RegisterPlugin("jenkins", mockMeta)
 	assert.Nil(t, err)
 	bs := &plugin.BlueprintScopeV200{
@@ -45,7 +46,8 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	bpScopes := make([]*plugin.BlueprintScopeV200, 0)
 	bpScopes = append(bpScopes, bs)
 
-	mockBasicRes()
+	mockBasicRes(t)
+
 	plan := make(plugin.PipelinePlan, len(bpScopes))
 	plan, err = makeDataSourcePipelinePlanV200(nil, plan, bpScopes, 1, syncPolicy)
 	assert.Nil(t, err)
@@ -78,7 +80,7 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	assert.Equal(t, expectScopes, scopes)
 }
 
-func mockBasicRes() {
+func mockBasicRes(t *testing.T) {
 	jenkinsJob := &models.JenkinsJob{
 		ConnectionId: 1,
 		FullName:     "a/b/ccc",
@@ -101,5 +103,7 @@ func mockBasicRes() {
 			*dst = *jenkinsJob
 		}).Return(nil)
 	})
-	Init(mockRes)
+	p := mockplugin.NewPluginMeta(t)
+	p.On("Name").Return("dummy").Maybe()
+	Init(mockRes, p)
 }

--- a/backend/plugins/jenkins/api/connection.go
+++ b/backend/plugins/jenkins/api/connection.go
@@ -134,7 +134,7 @@ func DeleteConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput
 		return nil, err
 	}
 	var refs *services.BlueprintProjectPairs
-	refs, err = connectionHelper.Delete(input.GetPlugin(), connection)
+	refs, err = connectionHelper.Delete(connection)
 	if err != nil {
 		return &plugin.ApiResourceOutput{Body: refs, Status: err.GetType().GetHttpCode()}, err
 	}

--- a/backend/plugins/jenkins/api/init.go
+++ b/backend/plugins/jenkins/api/init.go
@@ -19,6 +19,7 @@ package api
 
 import (
 	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/jenkins/models"
 	"github.com/go-playground/validator/v10"
@@ -32,12 +33,14 @@ var remoteHelper *api.RemoteApiHelper[models.JenkinsConnection, models.JenkinsJo
 var basicRes context.BasicRes
 var scHelper *api.ScopeConfigHelper[models.JenkinsScopeConfig]
 
-func Init(br context.BasicRes) {
+func Init(br context.BasicRes, p plugin.PluginMeta) {
+
 	basicRes = br
 	vld = validator.New()
 	connectionHelper = api.NewConnectionHelper(
 		basicRes,
 		vld,
+		p.Name(),
 	)
 	params := &api.ReflectionParameters{
 		ScopeIdFieldName:  "FullName",

--- a/backend/plugins/jenkins/impl/impl.go
+++ b/backend/plugins/jenkins/impl/impl.go
@@ -59,8 +59,8 @@ func (p Jenkins) Connection() dal.Tabler {
 	return &models.JenkinsConnection{}
 }
 
-func (p Jenkins) Scopes() []plugin.ToolLayerScope {
-	return []plugin.ToolLayerScope{&models.JenkinsJob{}}
+func (p Jenkins) Scope() plugin.ToolLayerScope {
+	return &models.JenkinsJob{}
 }
 
 func (p Jenkins) ScopeConfig() dal.Tabler {

--- a/backend/plugins/jenkins/impl/impl.go
+++ b/backend/plugins/jenkins/impl/impl.go
@@ -35,33 +35,35 @@ import (
 	"github.com/apache/incubator-devlake/plugins/jenkins/tasks"
 )
 
-var _ plugin.PluginMeta = (*Jenkins)(nil)
-var _ plugin.PluginInit = (*Jenkins)(nil)
-var _ plugin.PluginTask = (*Jenkins)(nil)
-var _ plugin.PluginApi = (*Jenkins)(nil)
-var _ plugin.PluginModel = (*Jenkins)(nil)
-var _ plugin.PluginMigration = (*Jenkins)(nil)
-var _ plugin.CloseablePluginTask = (*Jenkins)(nil)
-
-// var _ plugin.PluginSource = (*Jenkins)(nil)
-var _ plugin.DataSourcePluginBlueprintV200 = (*Jenkins)(nil)
+var _ interface {
+	plugin.PluginMeta
+	plugin.PluginInit
+	plugin.PluginTask
+	plugin.PluginApi
+	plugin.PluginModel
+	plugin.PluginMigration
+	plugin.CloseablePluginTask
+	plugin.PluginSource
+	plugin.DataSourcePluginBlueprintV200
+} = (*Jenkins)(nil)
 
 type Jenkins struct{}
 
 func (p Jenkins) Init(basicRes context.BasicRes) errors.Error {
-	api.Init(basicRes)
+	api.Init(basicRes, p)
+
 	return nil
 }
 
-func (p Jenkins) Connection() interface{} {
+func (p Jenkins) Connection() dal.Tabler {
 	return &models.JenkinsConnection{}
 }
 
-func (p Jenkins) Scope() interface{} {
-	return &models.JenkinsJob{}
+func (p Jenkins) Scopes() []dal.Tabler {
+	return []dal.Tabler{&models.JenkinsJob{}}
 }
 
-func (p Jenkins) ScopeConfig() interface{} {
+func (p Jenkins) ScopeConfig() dal.Tabler {
 	return &models.JenkinsScopeConfig{}
 }
 
@@ -80,6 +82,10 @@ func (p Jenkins) GetTablesInfo() []dal.Tabler {
 
 func (p Jenkins) Description() string {
 	return "To collect and enrich data from Jenkins"
+}
+
+func (p Jenkins) Name() string {
+	return "jenkins"
 }
 
 func (p Jenkins) SubTaskMetas() []plugin.SubTaskMeta {
@@ -108,6 +114,7 @@ func (p Jenkins) PrepareTaskData(taskCtx plugin.TaskContext, options map[string]
 	connectionHelper := helper.NewConnectionHelper(
 		taskCtx,
 		nil,
+		p.Name(),
 	)
 	if err != nil {
 		return nil, err

--- a/backend/plugins/jenkins/impl/impl.go
+++ b/backend/plugins/jenkins/impl/impl.go
@@ -59,8 +59,8 @@ func (p Jenkins) Connection() dal.Tabler {
 	return &models.JenkinsConnection{}
 }
 
-func (p Jenkins) Scopes() []dal.Tabler {
-	return []dal.Tabler{&models.JenkinsJob{}}
+func (p Jenkins) Scopes() []plugin.ToolLayerScope {
+	return []plugin.ToolLayerScope{&models.JenkinsJob{}}
 }
 
 func (p Jenkins) ScopeConfig() dal.Tabler {

--- a/backend/plugins/jira/api/blueprint_v200_test.go
+++ b/backend/plugins/jira/api/blueprint_v200_test.go
@@ -35,6 +35,7 @@ import (
 func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	mockMeta := mockplugin.NewPluginMeta(t)
 	mockMeta.On("RootPkgPath").Return("github.com/apache/incubator-devlake/plugins/jira")
+	mockMeta.On("Name").Return("jira").Maybe()
 	err := plugin.RegisterPlugin("jira", mockMeta)
 	assert.Nil(t, err)
 	bs := &plugin.BlueprintScopeV200{
@@ -44,7 +45,8 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	bpScopes := make([]*plugin.BlueprintScopeV200, 0)
 	bpScopes = append(bpScopes, bs)
 	plan := make(plugin.PipelinePlan, len(bpScopes))
-	mockBasicRes()
+	mockBasicRes(t)
+
 	plan, err = makeDataSourcePipelinePlanV200(nil, plan, bpScopes, uint64(1), syncPolicy)
 	assert.Nil(t, err)
 	scopes, err := makeScopesV200(bpScopes, uint64(1))
@@ -76,7 +78,7 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	assert.Equal(t, expectScopes, scopes)
 }
 
-func mockBasicRes() {
+func mockBasicRes(t *testing.T) {
 	jiraBoard := &models.JiraBoard{
 		ConnectionId: 1,
 		BoardId:      10,
@@ -99,5 +101,7 @@ func mockBasicRes() {
 			*dst = *jiraBoard
 		}).Return(nil)
 	})
-	Init(mockRes)
+	p := mockplugin.NewPluginMeta(t)
+	p.On("Name").Return("dummy").Maybe()
+	Init(mockRes, p)
 }

--- a/backend/plugins/jira/api/connection.go
+++ b/backend/plugins/jira/api/connection.go
@@ -179,7 +179,7 @@ func DeleteConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput
 		return nil, err
 	}
 	var refs *services.BlueprintProjectPairs
-	refs, err = connectionHelper.Delete(input.GetPlugin(), connection)
+	refs, err = connectionHelper.Delete(connection)
 	if err != nil {
 		return &plugin.ApiResourceOutput{Body: refs, Status: err.GetType().GetHttpCode()}, err
 	}

--- a/backend/plugins/jira/api/init.go
+++ b/backend/plugins/jira/api/init.go
@@ -19,6 +19,7 @@ package api
 
 import (
 	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/jira/models"
 	"github.com/apache/incubator-devlake/plugins/jira/tasks/apiv2models"
@@ -32,12 +33,14 @@ var remoteHelper *api.RemoteApiHelper[models.JiraConnection, models.JiraBoard, a
 var basicRes context.BasicRes
 var scHelper *api.ScopeConfigHelper[models.JiraScopeConfig]
 
-func Init(br context.BasicRes) {
+func Init(br context.BasicRes, p plugin.PluginMeta) {
+
 	basicRes = br
 	vld = validator.New()
 	connectionHelper = api.NewConnectionHelper(
 		basicRes,
 		vld,
+		p.Name(),
 	)
 	params := &api.ReflectionParameters{
 		ScopeIdFieldName:  "BoardId",

--- a/backend/plugins/jira/impl/impl.go
+++ b/backend/plugins/jira/impl/impl.go
@@ -52,8 +52,8 @@ func (p Jira) Connection() dal.Tabler {
 	return &models.JiraConnection{}
 }
 
-func (p Jira) Scopes() []dal.Tabler {
-	return []dal.Tabler{&models.JiraBoard{}}
+func (p Jira) Scopes() []plugin.ToolLayerScope {
+	return []plugin.ToolLayerScope{&models.JiraBoard{}}
 }
 
 func (p Jira) ScopeConfig() dal.Tabler {

--- a/backend/plugins/jira/impl/impl.go
+++ b/backend/plugins/jira/impl/impl.go
@@ -52,8 +52,8 @@ func (p Jira) Connection() dal.Tabler {
 	return &models.JiraConnection{}
 }
 
-func (p Jira) Scopes() []plugin.ToolLayerScope {
-	return []plugin.ToolLayerScope{&models.JiraBoard{}}
+func (p Jira) Scope() plugin.ToolLayerScope {
+	return &models.JiraBoard{}
 }
 
 func (p Jira) ScopeConfig() dal.Tabler {

--- a/backend/plugins/jira/impl/impl.go
+++ b/backend/plugins/jira/impl/impl.go
@@ -42,26 +42,27 @@ var _ interface {
 	plugin.PluginMigration
 	plugin.DataSourcePluginBlueprintV200
 	plugin.CloseablePluginTask
-	// plugin.PluginSource
+	plugin.PluginSource
 } = (*Jira)(nil)
 
 type Jira struct {
 }
 
-func (p Jira) Connection() interface{} {
+func (p Jira) Connection() dal.Tabler {
 	return &models.JiraConnection{}
 }
 
-func (p Jira) Scope() interface{} {
-	return &models.JiraBoard{}
+func (p Jira) Scopes() []dal.Tabler {
+	return []dal.Tabler{&models.JiraBoard{}}
 }
 
-func (p Jira) ScopeConfig() interface{} {
+func (p Jira) ScopeConfig() dal.Tabler {
 	return &models.JiraScopeConfig{}
 }
 
 func (p *Jira) Init(basicRes context.BasicRes) errors.Error {
-	api.Init(basicRes)
+	api.Init(basicRes, p)
+
 	return nil
 }
 
@@ -91,6 +92,10 @@ func (p Jira) GetTablesInfo() []dal.Tabler {
 
 func (p Jira) Description() string {
 	return "To collect and enrich data from JIRA"
+}
+
+func (p Jira) Name() string {
+	return "jira"
 }
 
 func (p Jira) SubTaskMetas() []plugin.SubTaskMeta {
@@ -167,6 +172,7 @@ func (p Jira) PrepareTaskData(taskCtx plugin.TaskContext, options map[string]int
 	connectionHelper := helper.NewConnectionHelper(
 		taskCtx,
 		nil,
+		p.Name(),
 	)
 	err = connectionHelper.FirstById(connection, op.ConnectionId)
 	if err != nil {

--- a/backend/plugins/org/impl/impl.go
+++ b/backend/plugins/org/impl/impl.go
@@ -27,11 +27,13 @@ import (
 	"github.com/apache/incubator-devlake/plugins/org/tasks"
 )
 
-var _ plugin.PluginMeta = (*Org)(nil)
-var _ plugin.PluginInit = (*Org)(nil)
-var _ plugin.PluginTask = (*Org)(nil)
-var _ plugin.PluginModel = (*Org)(nil)
-var _ plugin.ProjectMapper = (*Org)(nil)
+var _ interface {
+	plugin.PluginMeta
+	plugin.PluginInit
+	plugin.PluginTask
+	plugin.PluginModel
+	plugin.ProjectMapper
+} = (*Org)(nil)
 
 type Org struct {
 	handlers *api.Handlers
@@ -48,6 +50,10 @@ func (p Org) GetTablesInfo() []dal.Tabler {
 
 func (p Org) Description() string {
 	return "collect data related to team and organization"
+}
+
+func (p Org) Name() string {
+	return "org"
 }
 
 func (p Org) SubTaskMetas() []plugin.SubTaskMeta {

--- a/backend/plugins/pagerduty/api/connection.go
+++ b/backend/plugins/pagerduty/api/connection.go
@@ -110,7 +110,7 @@ func DeleteConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput
 		return nil, err
 	}
 	var refs *services.BlueprintProjectPairs
-	refs, err = connectionHelper.Delete(input.GetPlugin(), connection)
+	refs, err = connectionHelper.Delete(connection)
 	if err != nil {
 		return &plugin.ApiResourceOutput{Body: refs, Status: err.GetType().GetHttpCode()}, err
 	}

--- a/backend/plugins/pagerduty/api/init.go
+++ b/backend/plugins/pagerduty/api/init.go
@@ -19,6 +19,7 @@ package api
 
 import (
 	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/pagerduty/models"
 	"github.com/go-playground/validator/v10"
@@ -31,12 +32,14 @@ var scopeHelper *api.ScopeApiHelper[models.PagerDutyConnection, models.Service, 
 
 var basicRes context.BasicRes
 
-func Init(br context.BasicRes) {
+func Init(br context.BasicRes, p plugin.PluginMeta) {
+
 	basicRes = br
 	vld = validator.New()
 	connectionHelper = api.NewConnectionHelper(
 		basicRes,
 		vld,
+		p.Name(),
 	)
 	params := &api.ReflectionParameters{
 		ScopeIdFieldName:  "Id",

--- a/backend/plugins/pagerduty/e2e/incident_test.go
+++ b/backend/plugins/pagerduty/e2e/incident_test.go
@@ -33,24 +33,19 @@ import (
 func TestIncidentDataFlow(t *testing.T) {
 	var plugin impl.PagerDuty
 	dataflowTester := e2ehelper.NewDataFlowTester(t, "pagerduty", plugin)
-	scopeConfig := models.PagerdutyScopeConfig{
-		Name: "rule1",
-	}
 	options := tasks.PagerDutyOptions{
 		ConnectionId:         1,
 		ServiceId:            "PIKL83L",
 		ServiceName:          "DevService",
 		Tasks:                nil,
-		PagerdutyScopeConfig: &scopeConfig,
+		PagerdutyScopeConfig: nil,
 	}
 	taskData := &tasks.PagerDutyTaskData{
 		Options: &options,
 	}
 
-	dataflowTester.FlushTabler(&models.PagerdutyScopeConfig{})
 	dataflowTester.FlushTabler(&models.Service{})
 	// tx-rule
-	require.NoError(t, dataflowTester.Dal.CreateOrUpdate(&scopeConfig))
 	service := models.Service{
 		ConnectionId: options.ConnectionId,
 		Url:          fmt.Sprintf("https://keon-test.pagerduty.com/service-directory/%s", options.ServiceId),

--- a/backend/plugins/pagerduty/impl/impl.go
+++ b/backend/plugins/pagerduty/impl/impl.go
@@ -65,8 +65,8 @@ func (p PagerDuty) Connection() dal.Tabler {
 	return &models.PagerDutyConnection{}
 }
 
-func (p PagerDuty) Scopes() []dal.Tabler {
-	return []dal.Tabler{&models.Service{}}
+func (p PagerDuty) Scopes() []plugin.ToolLayerScope {
+	return []plugin.ToolLayerScope{&models.Service{}}
 }
 
 func (p PagerDuty) ScopeConfig() dal.Tabler {
@@ -84,10 +84,10 @@ func (p PagerDuty) SubTaskMetas() []plugin.SubTaskMeta {
 
 func (p PagerDuty) GetTablesInfo() []dal.Tabler {
 	return []dal.Tabler{
-		models.Service{},
-		models.Incident{},
-		models.User{},
-		models.Assignment{},
+		&models.Service{},
+		&models.Incident{},
+		&models.User{},
+		&models.Assignment{},
 	}
 }
 

--- a/backend/plugins/pagerduty/impl/impl.go
+++ b/backend/plugins/pagerduty/impl/impl.go
@@ -33,14 +33,17 @@ import (
 )
 
 // make sure interface is implemented
-var _ plugin.PluginMeta = (*PagerDuty)(nil)
-var _ plugin.PluginInit = (*PagerDuty)(nil)
-var _ plugin.PluginTask = (*PagerDuty)(nil)
-var _ plugin.PluginApi = (*PagerDuty)(nil)
 
-var _ plugin.PluginModel = (*PagerDuty)(nil)
-var _ plugin.DataSourcePluginBlueprintV200 = (*PagerDuty)(nil)
-var _ plugin.CloseablePluginTask = (*PagerDuty)(nil)
+var _ interface {
+	plugin.PluginMeta
+	plugin.PluginInit
+	plugin.PluginTask
+	plugin.PluginApi
+	plugin.PluginModel
+	plugin.DataSourcePluginBlueprintV200
+	plugin.CloseablePluginTask
+	plugin.PluginSource
+} = (*PagerDuty)(nil)
 
 type PagerDuty struct{}
 
@@ -48,8 +51,25 @@ func (p PagerDuty) Description() string {
 	return "collect some PagerDuty data"
 }
 
+func (p PagerDuty) Name() string {
+	return "pagerduty"
+}
+
 func (p PagerDuty) Init(basicRes context.BasicRes) errors.Error {
-	api.Init(basicRes)
+	api.Init(basicRes, p)
+
+	return nil
+}
+
+func (p PagerDuty) Connection() dal.Tabler {
+	return &models.PagerDutyConnection{}
+}
+
+func (p PagerDuty) Scopes() []dal.Tabler {
+	return []dal.Tabler{&models.Service{}}
+}
+
+func (p PagerDuty) ScopeConfig() dal.Tabler {
 	return nil
 }
 
@@ -79,6 +99,7 @@ func (p PagerDuty) PrepareTaskData(taskCtx plugin.TaskContext, options map[strin
 	connectionHelper := helper.NewConnectionHelper(
 		taskCtx,
 		nil,
+		p.Name(),
 	)
 	connection := &models.PagerDutyConnection{}
 	err = connectionHelper.FirstById(connection, op.ConnectionId)

--- a/backend/plugins/pagerduty/impl/impl.go
+++ b/backend/plugins/pagerduty/impl/impl.go
@@ -65,8 +65,8 @@ func (p PagerDuty) Connection() dal.Tabler {
 	return &models.PagerDutyConnection{}
 }
 
-func (p PagerDuty) Scopes() []plugin.ToolLayerScope {
-	return []plugin.ToolLayerScope{&models.Service{}}
+func (p PagerDuty) Scope() plugin.ToolLayerScope {
+	return &models.Service{}
 }
 
 func (p PagerDuty) ScopeConfig() dal.Tabler {

--- a/backend/plugins/pagerduty/models/scope_config.go
+++ b/backend/plugins/pagerduty/models/scope_config.go
@@ -26,7 +26,3 @@ type PagerdutyScopeConfig struct {
 	Name               string `mapstructure:"name" json:"name" gorm:"type:varchar(255);index:idx_name_github,unique" validate:"required"`
 	ConnectionId       uint64
 }
-
-func (PagerdutyScopeConfig) TableName() string {
-	return "_tool_pagerduty_scope_configs"
-}

--- a/backend/plugins/pagerduty/models/service.go
+++ b/backend/plugins/pagerduty/models/service.go
@@ -19,6 +19,7 @@ package models
 
 import (
 	"github.com/apache/incubator-devlake/core/models/common"
+	"github.com/apache/incubator-devlake/core/plugin"
 )
 
 type Service struct {
@@ -29,6 +30,16 @@ type Service struct {
 	Name         string `json:"name" mapstructure:"name"`
 }
 
-func (Service) TableName() string {
+func (s *Service) ScopeId() string {
+	return s.Name
+}
+
+func (s *Service) ScopeName() string {
+	return s.Name
+}
+
+func (s *Service) TableName() string {
 	return "_tool_pagerduty_services"
 }
+
+var _ plugin.ToolLayerScope = (*Service)(nil)

--- a/backend/plugins/pagerduty/models/service.go
+++ b/backend/plugins/pagerduty/models/service.go
@@ -30,15 +30,15 @@ type Service struct {
 	Name         string `json:"name" mapstructure:"name"`
 }
 
-func (s *Service) ScopeId() string {
+func (s Service) ScopeId() string {
 	return s.Name
 }
 
-func (s *Service) ScopeName() string {
+func (s Service) ScopeName() string {
 	return s.Name
 }
 
-func (s *Service) TableName() string {
+func (s Service) TableName() string {
 	return "_tool_pagerduty_services"
 }
 

--- a/backend/plugins/refdiff/impl/impl.go
+++ b/backend/plugins/refdiff/impl/impl.go
@@ -26,16 +26,22 @@ import (
 )
 
 // make sure interface is implemented
-var _ plugin.PluginMeta = (*RefDiff)(nil)
-var _ plugin.PluginTask = (*RefDiff)(nil)
-var _ plugin.PluginApi = (*RefDiff)(nil)
-var _ plugin.PluginModel = (*RefDiff)(nil)
-var _ plugin.PluginMetric = (*RefDiff)(nil)
+var _ interface {
+	plugin.PluginMeta
+	plugin.PluginTask
+	plugin.PluginApi
+	plugin.PluginModel
+	plugin.PluginMetric
+} = (*RefDiff)(nil)
 
 type RefDiff struct{}
 
 func (p RefDiff) Description() string {
 	return "Calculate commits diff for specified ref pairs based on `commits` and `commit_parents` tables"
+}
+
+func (p RefDiff) Name() string {
+	return "refdiff"
 }
 
 func (p RefDiff) RequiredDataEntities() (data []map[string]interface{}, err errors.Error) {

--- a/backend/plugins/slack/api/connection.go
+++ b/backend/plugins/slack/api/connection.go
@@ -111,7 +111,7 @@ func DeleteConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput
 		return nil, err
 	}
 	var refs *services.BlueprintProjectPairs
-	refs, err = connectionHelper.Delete(input.GetPlugin(), connection)
+	refs, err = connectionHelper.Delete(connection)
 	if err != nil {
 		return &plugin.ApiResourceOutput{Body: refs, Status: err.GetType().GetHttpCode()}, err
 	}

--- a/backend/plugins/slack/api/init.go
+++ b/backend/plugins/slack/api/init.go
@@ -19,6 +19,7 @@ package api
 
 import (
 	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/go-playground/validator/v10"
 )
@@ -27,11 +28,13 @@ var vld *validator.Validate
 var connectionHelper *api.ConnectionApiHelper
 var basicRes context.BasicRes
 
-func Init(br context.BasicRes) {
+func Init(br context.BasicRes, p plugin.PluginMeta) {
+
 	basicRes = br
 	vld = validator.New()
 	connectionHelper = api.NewConnectionHelper(
 		basicRes,
 		vld,
+		p.Name(),
 	)
 }

--- a/backend/plugins/slack/impl/impl.go
+++ b/backend/plugins/slack/impl/impl.go
@@ -68,7 +68,7 @@ func (p Slack) Connection() dal.Tabler {
 	return &models.SlackConnection{}
 }
 
-func (p Slack) Scopes() []plugin.ToolLayerScope {
+func (p Slack) Scope() plugin.ToolLayerScope {
 	return nil
 }
 

--- a/backend/plugins/slack/impl/impl.go
+++ b/backend/plugins/slack/impl/impl.go
@@ -31,18 +31,22 @@ import (
 	"github.com/apache/incubator-devlake/plugins/slack/tasks"
 )
 
-var _ plugin.PluginMeta = (*Slack)(nil)
-var _ plugin.PluginInit = (*Slack)(nil)
-var _ plugin.PluginTask = (*Slack)(nil)
-var _ plugin.PluginApi = (*Slack)(nil)
-var _ plugin.PluginModel = (*Slack)(nil)
-var _ plugin.PluginMigration = (*Slack)(nil)
-var _ plugin.CloseablePluginTask = (*Slack)(nil)
+var _ interface {
+	plugin.PluginMeta
+	plugin.PluginInit
+	plugin.PluginTask
+	plugin.PluginApi
+	plugin.PluginModel
+	plugin.PluginMigration
+	plugin.CloseablePluginTask
+	plugin.PluginSource
+} = (*Slack)(nil)
 
 type Slack struct{}
 
 func (p Slack) Init(basicRes context.BasicRes) errors.Error {
-	api.Init(basicRes)
+	api.Init(basicRes, p)
+
 	return nil
 }
 
@@ -54,6 +58,22 @@ func (p Slack) GetTablesInfo() []dal.Tabler {
 
 func (p Slack) Description() string {
 	return "To collect and enrich data from Slack"
+}
+
+func (p Slack) Name() string {
+	return "slack"
+}
+
+func (p Slack) Connection() dal.Tabler {
+	return &models.SlackConnection{}
+}
+
+func (p Slack) Scopes() []dal.Tabler {
+	return nil
+}
+
+func (p Slack) ScopeConfig() dal.Tabler {
+	return nil
 }
 
 func (p Slack) SubTaskMetas() []plugin.SubTaskMeta {
@@ -78,6 +98,7 @@ func (p Slack) PrepareTaskData(taskCtx plugin.TaskContext, options map[string]in
 	connectionHelper := helper.NewConnectionHelper(
 		taskCtx,
 		nil,
+		p.Name(),
 	)
 	connection := &models.SlackConnection{}
 	err := connectionHelper.FirstById(connection, op.ConnectionId)

--- a/backend/plugins/slack/impl/impl.go
+++ b/backend/plugins/slack/impl/impl.go
@@ -68,7 +68,7 @@ func (p Slack) Connection() dal.Tabler {
 	return &models.SlackConnection{}
 }
 
-func (p Slack) Scopes() []dal.Tabler {
+func (p Slack) Scopes() []plugin.ToolLayerScope {
 	return nil
 }
 

--- a/backend/plugins/sonarqube/api/blueprint_v200_test.go
+++ b/backend/plugins/sonarqube/api/blueprint_v200_test.go
@@ -34,6 +34,7 @@ import (
 func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	mockMeta := mockplugin.NewPluginMeta(t)
 	mockMeta.On("RootPkgPath").Return("github.com/apache/incubator-devlake/plugins/sonarqube")
+	mockMeta.On("Name").Return("sonarqube").Maybe()
 	err := plugin.RegisterPlugin("sonarqube", mockMeta)
 	assert.Nil(t, err)
 	bs := &plugin.BlueprintScopeV200{
@@ -46,6 +47,7 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	plan, err = makeDataSourcePipelinePlanV200(nil, plan, bpScopes, uint64(1), syncPolicy)
 	assert.Nil(t, err)
 	basicRes = NewMockBasicRes()
+
 	scopes, err := makeScopesV200(bpScopes, uint64(1))
 	assert.Nil(t, err)
 

--- a/backend/plugins/sonarqube/api/connection.go
+++ b/backend/plugins/sonarqube/api/connection.go
@@ -139,7 +139,7 @@ func DeleteConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput
 		return nil, err
 	}
 	var refs *services.BlueprintProjectPairs
-	refs, err = connectionHelper.Delete(input.GetPlugin(), connection)
+	refs, err = connectionHelper.Delete(connection)
 	if err != nil {
 		return &plugin.ApiResourceOutput{Body: refs, Status: err.GetType().GetHttpCode()}, err
 	}

--- a/backend/plugins/sonarqube/api/init.go
+++ b/backend/plugins/sonarqube/api/init.go
@@ -19,6 +19,7 @@ package api
 
 import (
 	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/sonarqube/models"
 	"github.com/go-playground/validator/v10"
@@ -30,12 +31,14 @@ var scopeHelper *api.ScopeApiHelper[models.SonarqubeConnection, models.Sonarqube
 var remoteHelper *api.RemoteApiHelper[models.SonarqubeConnection, models.SonarqubeProject, models.SonarqubeApiProject, api.NoRemoteGroupResponse]
 var basicRes context.BasicRes
 
-func Init(br context.BasicRes) {
+func Init(br context.BasicRes, p plugin.PluginMeta) {
+
 	basicRes = br
 	vld = validator.New()
 	connectionHelper = api.NewConnectionHelper(
 		basicRes,
 		vld,
+		p.Name(),
 	)
 	params := &api.ReflectionParameters{
 		ScopeIdFieldName:  "ProjectKey",

--- a/backend/plugins/sonarqube/impl/impl.go
+++ b/backend/plugins/sonarqube/impl/impl.go
@@ -64,8 +64,8 @@ func (p Sonarqube) Connection() dal.Tabler {
 	return &models.SonarqubeConnection{}
 }
 
-func (p Sonarqube) Scopes() []plugin.ToolLayerScope {
-	return []plugin.ToolLayerScope{&models.SonarqubeProject{}}
+func (p Sonarqube) Scope() plugin.ToolLayerScope {
+	return &models.SonarqubeProject{}
 }
 
 func (p Sonarqube) ScopeConfig() dal.Tabler {

--- a/backend/plugins/sonarqube/impl/impl.go
+++ b/backend/plugins/sonarqube/impl/impl.go
@@ -64,8 +64,8 @@ func (p Sonarqube) Connection() dal.Tabler {
 	return &models.SonarqubeConnection{}
 }
 
-func (p Sonarqube) Scopes() []dal.Tabler {
-	return []dal.Tabler{&models.SonarqubeProject{}}
+func (p Sonarqube) Scopes() []plugin.ToolLayerScope {
+	return []plugin.ToolLayerScope{&models.SonarqubeProject{}}
 }
 
 func (p Sonarqube) ScopeConfig() dal.Tabler {

--- a/backend/plugins/sonarqube/impl/impl.go
+++ b/backend/plugins/sonarqube/impl/impl.go
@@ -41,7 +41,7 @@ var _ interface {
 	plugin.PluginMigration
 	plugin.DataSourcePluginBlueprintV200
 	plugin.CloseablePluginTask
-	// plugin.PluginSource
+	plugin.PluginSource
 } = (*Sonarqube)(nil)
 
 type Sonarqube struct{}
@@ -50,20 +50,25 @@ func (p Sonarqube) Description() string {
 	return "collect some Sonarqube data"
 }
 
+func (p Sonarqube) Name() string {
+	return "dbt"
+}
+
 func (p Sonarqube) Init(br context.BasicRes) errors.Error {
-	api.Init(br)
+	api.Init(br, p)
+
 	return nil
 }
 
-func (p Sonarqube) Connection() interface{} {
+func (p Sonarqube) Connection() dal.Tabler {
 	return &models.SonarqubeConnection{}
 }
 
-func (p Sonarqube) Scope() interface{} {
-	return &models.SonarqubeProject{}
+func (p Sonarqube) Scopes() []dal.Tabler {
+	return []dal.Tabler{&models.SonarqubeProject{}}
 }
 
-func (p Sonarqube) TransformationRule() interface{} {
+func (p Sonarqube) ScopeConfig() dal.Tabler {
 	return nil
 }
 
@@ -109,6 +114,7 @@ func (p Sonarqube) PrepareTaskData(taskCtx plugin.TaskContext, options map[strin
 	connectionHelper := helper.NewConnectionHelper(
 		taskCtx,
 		nil,
+		p.Name(),
 	)
 	connection := &models.SonarqubeConnection{}
 	err = connectionHelper.FirstById(connection, op.ConnectionId)

--- a/backend/plugins/starrocks/impl/impl.go
+++ b/backend/plugins/starrocks/impl/impl.go
@@ -28,9 +28,11 @@ import (
 type StarRocks string
 
 // make sure interface is implemented
-var _ plugin.PluginMeta = (*StarRocks)(nil)
-var _ plugin.PluginTask = (*StarRocks)(nil)
-var _ plugin.PluginModel = (*StarRocks)(nil)
+var _ interface {
+	plugin.PluginMeta
+	plugin.PluginTask
+	plugin.PluginModel
+} = (*StarRocks)(nil)
 
 func (s StarRocks) SubTaskMetas() []plugin.SubTaskMeta {
 	return []plugin.SubTaskMeta{
@@ -56,6 +58,10 @@ func (s StarRocks) GetTablesInfo() []dal.Tabler {
 
 func (s StarRocks) Description() string {
 	return "Sync data from database to StarRocks"
+}
+
+func (s StarRocks) Name() string {
+	return "starrocks"
 }
 
 func (s StarRocks) RootPkgPath() string {

--- a/backend/plugins/tapd/api/blueprint_v200_test.go
+++ b/backend/plugins/tapd/api/blueprint_v200_test.go
@@ -35,6 +35,7 @@ import (
 func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	mockMeta := mockplugin.NewPluginMeta(t)
 	mockMeta.On("RootPkgPath").Return("github.com/apache/incubator-devlake/plugins/tapd")
+	mockMeta.On("Name").Return("dummy").Maybe()
 	err := plugin.RegisterPlugin("tapd", mockMeta)
 	assert.Nil(t, err)
 	bs := &plugin.BlueprintScopeV200{
@@ -44,7 +45,8 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	bpScopes := make([]*plugin.BlueprintScopeV200, 0)
 	bpScopes = append(bpScopes, bs)
 	plan := make(plugin.PipelinePlan, len(bpScopes))
-	mockBasicRes()
+	mockBasicRes(t)
+
 	plan, err = makeDataSourcePipelinePlanV200(nil, plan, bpScopes, uint64(1), syncPolicy)
 	assert.Nil(t, err)
 	scopes, err := makeScopesV200(bpScopes, uint64(1))
@@ -77,7 +79,7 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	assert.Equal(t, expectScopes, scopes)
 }
 
-func mockBasicRes() {
+func mockBasicRes(t *testing.T) {
 	tapdWorkspace := &models.TapdWorkspace{
 		ConnectionId: 1,
 		Id:           10,
@@ -99,5 +101,7 @@ func mockBasicRes() {
 			*dst = *tapdWorkspace
 		}).Return(nil)
 	})
-	Init(mockRes)
+	p := mockplugin.NewPluginMeta(t)
+	p.On("Name").Return("dummy").Maybe()
+	Init(mockRes, p)
 }

--- a/backend/plugins/tapd/api/connection.go
+++ b/backend/plugins/tapd/api/connection.go
@@ -130,7 +130,7 @@ func DeleteConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput
 		return nil, err
 	}
 	var refs *services.BlueprintProjectPairs
-	refs, err = connectionHelper.Delete(input.GetPlugin(), connection)
+	refs, err = connectionHelper.Delete(connection)
 	if err != nil {
 		return &plugin.ApiResourceOutput{Body: refs, Status: err.GetType().GetHttpCode()}, err
 	}

--- a/backend/plugins/tapd/api/init.go
+++ b/backend/plugins/tapd/api/init.go
@@ -19,6 +19,7 @@ package api
 
 import (
 	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/tapd/models"
 	"github.com/go-playground/validator/v10"
@@ -31,12 +32,14 @@ var scopeHelper *api.ScopeApiHelper[models.TapdConnection, models.TapdWorkspace,
 var remoteHelper *api.RemoteApiHelper[models.TapdConnection, models.TapdWorkspace, models.TapdWorkspace, api.BaseRemoteGroupResponse]
 var scHelper *api.ScopeConfigHelper[models.TapdScopeConfig]
 
-func Init(br context.BasicRes) {
+func Init(br context.BasicRes, p plugin.PluginMeta) {
+
 	basicRes = br
 	vld = validator.New()
 	connectionHelper = api.NewConnectionHelper(
 		basicRes,
 		vld,
+		p.Name(),
 	)
 	params := &api.ReflectionParameters{
 		ScopeIdFieldName:  "Id",

--- a/backend/plugins/tapd/impl/impl.go
+++ b/backend/plugins/tapd/impl/impl.go
@@ -55,8 +55,8 @@ func (p Tapd) Connection() dal.Tabler {
 	return &models.TapdConnection{}
 }
 
-func (p Tapd) Scopes() []plugin.ToolLayerScope {
-	return []plugin.ToolLayerScope{&models.TapdWorkspace{}}
+func (p Tapd) Scope() plugin.ToolLayerScope {
+	return &models.TapdWorkspace{}
 }
 
 func (p Tapd) ScopeConfig() dal.Tabler {

--- a/backend/plugins/tapd/impl/impl.go
+++ b/backend/plugins/tapd/impl/impl.go
@@ -55,8 +55,8 @@ func (p Tapd) Connection() dal.Tabler {
 	return &models.TapdConnection{}
 }
 
-func (p Tapd) Scopes() []dal.Tabler {
-	return []dal.Tabler{&models.TapdWorkspace{}}
+func (p Tapd) Scopes() []plugin.ToolLayerScope {
+	return []plugin.ToolLayerScope{&models.TapdWorkspace{}}
 }
 
 func (p Tapd) ScopeConfig() dal.Tabler {

--- a/backend/plugins/tapd/tasks/shared_test.go
+++ b/backend/plugins/tapd/tasks/shared_test.go
@@ -240,6 +240,7 @@ func TestGenerateDomainAccountIdForUsers(t *testing.T) {
 	}
 	mockMeta := mockplugin.NewPluginMeta(t)
 	mockMeta.On("RootPkgPath").Return("github.com/apache/incubator-devlake/plugins/tapd")
+	mockMeta.On("Name").Return("tapd").Maybe()
 	err := plugin.RegisterPlugin("tapd", mockMeta)
 	assert.Nil(t, err)
 	for _, testCase := range testCases {

--- a/backend/plugins/teambition/api/connection.go
+++ b/backend/plugins/teambition/api/connection.go
@@ -139,7 +139,7 @@ func DeleteConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput
 		return nil, err
 	}
 	var refs *services.BlueprintProjectPairs
-	refs, err = connectionHelper.Delete(input.GetPlugin(), connection)
+	refs, err = connectionHelper.Delete(connection)
 	if err != nil {
 		return &plugin.ApiResourceOutput{Body: refs, Status: err.GetType().GetHttpCode()}, err
 	}

--- a/backend/plugins/teambition/api/init.go
+++ b/backend/plugins/teambition/api/init.go
@@ -19,6 +19,7 @@ package api
 
 import (
 	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/plugin"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/go-playground/validator/v10"
 )
@@ -27,11 +28,13 @@ var vld *validator.Validate
 var connectionHelper *helper.ConnectionApiHelper
 var basicRes context.BasicRes
 
-func Init(br context.BasicRes) {
+func Init(br context.BasicRes, p plugin.PluginMeta) {
+
 	basicRes = br
 	vld = validator.New()
 	connectionHelper = helper.NewConnectionHelper(
 		basicRes,
 		vld,
+		p.Name(),
 	)
 }

--- a/backend/plugins/teambition/impl/impl.go
+++ b/backend/plugins/teambition/impl/impl.go
@@ -77,7 +77,7 @@ func (p Teambition) Connection() dal.Tabler {
 	return &models.TeambitionConnection{}
 }
 
-func (p Teambition) Scopes() []plugin.ToolLayerScope {
+func (p Teambition) Scope() plugin.ToolLayerScope {
 	return nil
 }
 

--- a/backend/plugins/teambition/impl/impl.go
+++ b/backend/plugins/teambition/impl/impl.go
@@ -77,7 +77,7 @@ func (p Teambition) Connection() dal.Tabler {
 	return &models.TeambitionConnection{}
 }
 
-func (p Teambition) Scopes() []dal.Tabler {
+func (p Teambition) Scopes() []plugin.ToolLayerScope {
 	return nil
 }
 

--- a/backend/plugins/teambition/impl/impl.go
+++ b/backend/plugins/teambition/impl/impl.go
@@ -33,11 +33,15 @@ import (
 )
 
 // make sure interface is implemented
-var _ plugin.PluginMeta = (*Teambition)(nil)
-var _ plugin.PluginInit = (*Teambition)(nil)
-var _ plugin.PluginTask = (*Teambition)(nil)
-var _ plugin.PluginApi = (*Teambition)(nil)
-var _ plugin.CloseablePluginTask = (*Teambition)(nil)
+
+var _ interface {
+	plugin.PluginMeta
+	plugin.PluginInit
+	plugin.PluginTask
+	plugin.PluginApi
+	plugin.CloseablePluginTask
+	plugin.PluginSource
+} = (*Teambition)(nil)
 
 type Teambition struct{}
 
@@ -45,8 +49,13 @@ func (p Teambition) Description() string {
 	return "collect some Teambition data"
 }
 
+func (p Teambition) Name() string {
+	return "teambition"
+}
+
 func (p Teambition) Init(br context.BasicRes) errors.Error {
-	api.Init(br)
+	api.Init(br, p)
+
 	return nil
 }
 
@@ -62,6 +71,18 @@ func (p Teambition) GetTablesInfo() []dal.Tabler {
 		&models.TeambitionTaskWorktime{},
 		&models.TeambitionProject{},
 	}
+}
+
+func (p Teambition) Connection() dal.Tabler {
+	return &models.TeambitionConnection{}
+}
+
+func (p Teambition) Scopes() []dal.Tabler {
+	return nil
+}
+
+func (p Teambition) ScopeConfig() dal.Tabler {
+	return nil
 }
 
 func (p Teambition) SubTaskMetas() []plugin.SubTaskMeta {
@@ -107,6 +128,7 @@ func (p Teambition) PrepareTaskData(taskCtx plugin.TaskContext, options map[stri
 	connectionHelper := helper.NewConnectionHelper(
 		taskCtx,
 		nil,
+		p.Name(),
 	)
 	connection := &models.TeambitionConnection{}
 	err = connectionHelper.FirstById(connection, op.ConnectionId)

--- a/backend/plugins/trello/api/connection.go
+++ b/backend/plugins/trello/api/connection.go
@@ -125,7 +125,7 @@ func DeleteConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput
 		return nil, err
 	}
 	var refs *services.BlueprintProjectPairs
-	refs, err = connectionHelper.Delete(input.GetPlugin(), connection)
+	refs, err = connectionHelper.Delete(connection)
 	if err != nil {
 		return &plugin.ApiResourceOutput{Body: refs, Status: err.GetType().GetHttpCode()}, err
 	}

--- a/backend/plugins/trello/api/init.go
+++ b/backend/plugins/trello/api/init.go
@@ -19,6 +19,7 @@ package api
 
 import (
 	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/trello/models"
 	"github.com/go-playground/validator/v10"
@@ -30,12 +31,13 @@ var scopeHelper *api.ScopeApiHelper[models.TrelloConnection, models.TrelloBoard,
 var basicRes context.BasicRes
 var scHelper *api.ScopeConfigHelper[models.TrelloScopeConfig]
 
-func Init(br context.BasicRes) {
+func Init(br context.BasicRes, p plugin.PluginMeta) {
 	basicRes = br
 	vld = validator.New()
 	connectionHelper = api.NewConnectionHelper(
 		basicRes,
 		vld,
+		p.Name(),
 	)
 	params := &api.ReflectionParameters{
 		ScopeIdFieldName:  "BoardId",

--- a/backend/plugins/trello/impl/impl.go
+++ b/backend/plugins/trello/impl/impl.go
@@ -46,7 +46,8 @@ var _ interface {
 type Trello struct{}
 
 func (p Trello) Init(basicRes context.BasicRes) errors.Error {
-	api.Init(basicRes)
+	api.Init(basicRes, p)
+
 	return nil
 }
 
@@ -64,6 +65,10 @@ func (p Trello) GetTablesInfo() []dal.Tabler {
 
 func (p Trello) Description() string {
 	return "To collect and enrich data from Trello"
+}
+
+func (p Trello) Name() string {
+	return "trello"
 }
 
 func (p Trello) SubTaskMetas() []plugin.SubTaskMeta {
@@ -105,6 +110,7 @@ func (p Trello) PrepareTaskData(taskCtx plugin.TaskContext, options map[string]i
 	connectionHelper := helper.NewConnectionHelper(
 		taskCtx,
 		nil,
+		p.Name(),
 	)
 	err = connectionHelper.FirstById(connection, op.ConnectionId)
 
@@ -129,12 +135,16 @@ func (p Trello) MigrationScripts() []plugin.MigrationScript {
 	return migrationscripts.All()
 }
 
-func (p Trello) Connection() interface{} {
+func (p Trello) Connection() dal.Tabler {
 	return &models.TrelloConnection{}
 }
 
-func (p Trello) Scope() interface{} {
-	return &models.TrelloBoard{}
+func (p Trello) Scopes() []dal.Tabler {
+	return []dal.Tabler{&models.TrelloBoard{}}
+}
+
+func (p Trello) ScopeConfig() dal.Tabler {
+	return &models.TrelloScopeConfig{}
 }
 
 func (p Trello) ApiResources() map[string]map[string]plugin.ApiResourceHandler {

--- a/backend/plugins/trello/impl/impl.go
+++ b/backend/plugins/trello/impl/impl.go
@@ -139,8 +139,8 @@ func (p Trello) Connection() dal.Tabler {
 	return &models.TrelloConnection{}
 }
 
-func (p Trello) Scopes() []plugin.ToolLayerScope {
-	return []plugin.ToolLayerScope{&models.TrelloBoard{}}
+func (p Trello) Scope() plugin.ToolLayerScope {
+	return &models.TrelloBoard{}
 }
 
 func (p Trello) ScopeConfig() dal.Tabler {

--- a/backend/plugins/trello/impl/impl.go
+++ b/backend/plugins/trello/impl/impl.go
@@ -139,8 +139,8 @@ func (p Trello) Connection() dal.Tabler {
 	return &models.TrelloConnection{}
 }
 
-func (p Trello) Scopes() []dal.Tabler {
-	return []dal.Tabler{&models.TrelloBoard{}}
+func (p Trello) Scopes() []plugin.ToolLayerScope {
+	return []plugin.ToolLayerScope{&models.TrelloBoard{}}
 }
 
 func (p Trello) ScopeConfig() dal.Tabler {

--- a/backend/plugins/trello/models/board.go
+++ b/backend/plugins/trello/models/board.go
@@ -19,6 +19,7 @@ package models
 
 import (
 	"github.com/apache/incubator-devlake/core/models/common"
+	"github.com/apache/incubator-devlake/core/plugin"
 )
 
 type TrelloBoard struct {
@@ -29,6 +30,16 @@ type TrelloBoard struct {
 	Name             string `json:"name" mapstructure:"name" gorm:"type:varchar(255)"`
 }
 
+func (b TrelloBoard) ScopeId() string {
+	return b.BoardId
+}
+
+func (b TrelloBoard) ScopeName() string {
+	return b.Name
+}
+
 func (TrelloBoard) TableName() string {
 	return "_tool_trello_boards"
 }
+
+var _ plugin.ToolLayerScope = (*TrelloBoard)(nil)

--- a/backend/plugins/webhook/api/connection.go
+++ b/backend/plugins/webhook/api/connection.go
@@ -80,7 +80,7 @@ func DeleteConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput
 		return nil, err
 	}
 	var refs *services.BlueprintProjectPairs
-	refs, err = connectionHelper.Delete(input.GetPlugin(), connection)
+	refs, err = connectionHelper.Delete(connection)
 	if err != nil {
 		return &plugin.ApiResourceOutput{Body: refs, Status: err.GetType().GetHttpCode()}, err
 	}

--- a/backend/plugins/webhook/api/init.go
+++ b/backend/plugins/webhook/api/init.go
@@ -19,6 +19,7 @@ package api
 
 import (
 	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/go-playground/validator/v10"
 )
@@ -27,11 +28,13 @@ var vld *validator.Validate
 var connectionHelper *api.ConnectionApiHelper
 var basicRes context.BasicRes
 
-func Init(br context.BasicRes) {
+func Init(br context.BasicRes, p plugin.PluginMeta) {
+
 	basicRes = br
 	vld = validator.New()
 	connectionHelper = api.NewConnectionHelper(
 		basicRes,
 		vld,
+		p.Name(),
 	)
 }

--- a/backend/plugins/webhook/impl/impl.go
+++ b/backend/plugins/webhook/impl/impl.go
@@ -27,11 +27,13 @@ import (
 )
 
 // make sure interface is implemented
-var _ plugin.PluginMeta = (*Webhook)(nil)
-var _ plugin.PluginInit = (*Webhook)(nil)
-var _ plugin.PluginApi = (*Webhook)(nil)
-var _ plugin.PluginModel = (*Webhook)(nil)
-var _ plugin.PluginMigration = (*Webhook)(nil)
+var _ interface {
+	plugin.PluginMeta
+	plugin.PluginInit
+	plugin.PluginApi
+	plugin.PluginModel
+	plugin.PluginMigration
+} = (*Webhook)(nil)
 
 type Webhook struct{}
 
@@ -39,8 +41,13 @@ func (p Webhook) Description() string {
 	return "collect some Webhook data"
 }
 
+func (p Webhook) Name() string {
+	return "webhook"
+}
+
 func (p Webhook) Init(basicRes context.BasicRes) errors.Error {
-	api.Init(basicRes)
+	api.Init(basicRes, p)
+
 	return nil
 }
 

--- a/backend/plugins/zentao/api/blueprint_V200_test.go
+++ b/backend/plugins/zentao/api/blueprint_V200_test.go
@@ -55,10 +55,12 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	}
 	mockMeta := mockplugin.NewPluginMeta(t)
 	mockMeta.On("RootPkgPath").Return("github.com/apache/incubator-devlake/plugins/zentao")
+	mockMeta.On("Name").Return("zentao").Maybe()
 	err := plugin.RegisterPlugin("zentao", mockMeta)
 	assert.Nil(t, err)
 	// Refresh Global Variables and set the sql mock
-	mockBasicRes()
+	mockBasicRes(t)
+
 	bs := &plugin.BlueprintScopeV200{
 		Id: "project/1",
 	}
@@ -125,7 +127,7 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 }
 
 // mockBasicRes FIXME ...
-func mockBasicRes() {
+func mockBasicRes(t *testing.T) {
 	testZentaoProduct := &models.ZentaoProduct{
 		ConnectionId:  1,
 		Id:            1,
@@ -155,5 +157,7 @@ func mockBasicRes() {
 			panic("The empty scope should not call First() for ZentaoScopeConfig")
 		}).Return(nil)
 	})
-	Init(mockRes)
+	p := mockplugin.NewPluginMeta(t)
+	p.On("Name").Return("dummy").Maybe()
+	Init(mockRes, p)
 }

--- a/backend/plugins/zentao/api/blueprint_v200.go
+++ b/backend/plugins/zentao/api/blueprint_v200.go
@@ -30,11 +30,9 @@ import (
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/zentao/models"
 	"github.com/apache/incubator-devlake/plugins/zentao/tasks"
-	"github.com/go-playground/validator/v10"
 )
 
 func MakeDataSourcePipelinePlanV200(subtaskMetas []plugin.SubTaskMeta, connectionId uint64, bpScopes []*plugin.BlueprintScopeV200, syncPolicy *plugin.BlueprintSyncPolicy) (plugin.PipelinePlan, []plugin.Scope, errors.Error) {
-	connectionHelper := helper.NewConnectionHelper(basicRes, validator.New())
 	// get the connection info for url
 	connection := &models.ZentaoConnection{}
 	err := connectionHelper.FirstById(connection, connectionId)

--- a/backend/plugins/zentao/api/connection.go
+++ b/backend/plugins/zentao/api/connection.go
@@ -114,7 +114,7 @@ func DeleteConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput
 		return nil, err
 	}
 	var refs *services.BlueprintProjectPairs
-	refs, err = connectionHelper.Delete(input.GetPlugin(), connection)
+	refs, err = connectionHelper.Delete(connection)
 	if err != nil {
 		return &plugin.ApiResourceOutput{Body: refs, Status: err.GetType().GetHttpCode()}, err
 	}

--- a/backend/plugins/zentao/api/init.go
+++ b/backend/plugins/zentao/api/init.go
@@ -19,6 +19,7 @@ package api
 
 import (
 	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/zentao/models"
 	"github.com/go-playground/validator/v10"
@@ -39,12 +40,14 @@ var projectRemoteHelper *api.RemoteApiHelper[models.ZentaoConnection, models.Zen
 var basicRes context.BasicRes
 var scHelper *api.ScopeConfigHelper[models.ZentaoScopeConfig]
 
-func Init(br context.BasicRes) {
+func Init(br context.BasicRes, p plugin.PluginMeta) {
+
 	basicRes = br
 	vld = validator.New()
 	connectionHelper = api.NewConnectionHelper(
 		basicRes,
 		vld,
+		p.Name(),
 	)
 	productParams := &api.ReflectionParameters{
 		ScopeIdFieldName:  "Id",

--- a/backend/plugins/zentao/impl/impl.go
+++ b/backend/plugins/zentao/impl/impl.go
@@ -35,13 +35,17 @@ import (
 )
 
 // make sure interface is implemented
-var _ plugin.PluginMeta = (*Zentao)(nil)
-var _ plugin.PluginInit = (*Zentao)(nil)
-var _ plugin.PluginTask = (*Zentao)(nil)
-var _ plugin.PluginApi = (*Zentao)(nil)
 
-// var _ plugin.CompositePluginBlueprintV200 = (*Zentao)(nil)
-var _ plugin.CloseablePluginTask = (*Zentao)(nil)
+var _ interface {
+	plugin.PluginMeta
+	plugin.PluginInit
+	plugin.PluginTask
+	plugin.PluginApi
+	//plugin.CompositePluginBlueprintV200
+	plugin.PluginModel
+	plugin.PluginSource
+	plugin.CloseablePluginTask
+} = (*Zentao)(nil)
 
 type Zentao struct{}
 
@@ -49,9 +53,52 @@ func (p Zentao) Description() string {
 	return "collect some Zentao data"
 }
 
+func (p Zentao) Name() string {
+	return "zentao"
+}
+
 func (p Zentao) Init(basicRes context.BasicRes) errors.Error {
-	api.Init(basicRes)
+	api.Init(basicRes, p)
+
 	return nil
+}
+
+func (p Zentao) GetTablesInfo() []dal.Tabler {
+	return []dal.Tabler{
+		&models.ZentaoAccount{},
+		&models.ZentaoBug{},
+		&models.ZentaoBugCommit{},
+		&models.ZentaoChangelog{},
+		&models.ZentaoChangelogDetail{},
+		&models.ZentaoDepartment{},
+		&models.ZentaoExecution{},
+		&models.ZentaoProduct{},
+		&models.ZentaoProject{},
+		&models.ZentaoRemoteDbAction{},
+		&models.ZentaoRemoteDbActionHistory{},
+		&models.ZentaoRemoteDbHistory{},
+		&models.ZentaoStory{},
+		&models.ZentaoStoryCommit{},
+		&models.ZentaoStoryRepoCommit{},
+		&models.ZentaoTask{},
+		&models.ZentaoTaskCommit{},
+		&models.ZentaoTaskRepoCommit{},
+	}
+}
+
+func (p Zentao) Connection() dal.Tabler {
+	return &models.ZentaoConnection{}
+}
+
+func (p Zentao) Scopes() []dal.Tabler {
+	return []dal.Tabler{
+		&models.ZentaoProduct{},
+		&models.ZentaoProject{},
+	}
+}
+
+func (p Zentao) ScopeConfig() dal.Tabler {
+	return &models.ZentaoScopeConfig{}
 }
 
 func (p Zentao) SubTaskMetas() []plugin.SubTaskMeta {
@@ -114,6 +161,7 @@ func (p Zentao) PrepareTaskData(taskCtx plugin.TaskContext, options map[string]i
 	connectionHelper := helper.NewConnectionHelper(
 		taskCtx,
 		nil,
+		p.Name(),
 	)
 	connection := &models.ZentaoConnection{}
 	err = connectionHelper.FirstById(connection, op.ConnectionId)

--- a/backend/plugins/zentao/impl/impl.go
+++ b/backend/plugins/zentao/impl/impl.go
@@ -90,11 +90,8 @@ func (p Zentao) Connection() dal.Tabler {
 	return &models.ZentaoConnection{}
 }
 
-func (p Zentao) Scopes() []plugin.ToolLayerScope {
-	return []plugin.ToolLayerScope{
-		&models.ZentaoProduct{},
-		&models.ZentaoProject{},
-	}
+func (p Zentao) Scope() plugin.ToolLayerScope {
+	return &models.ZentaoProject{}
 }
 
 func (p Zentao) ScopeConfig() dal.Tabler {

--- a/backend/plugins/zentao/impl/impl.go
+++ b/backend/plugins/zentao/impl/impl.go
@@ -90,8 +90,8 @@ func (p Zentao) Connection() dal.Tabler {
 	return &models.ZentaoConnection{}
 }
 
-func (p Zentao) Scopes() []dal.Tabler {
-	return []dal.Tabler{
+func (p Zentao) Scopes() []plugin.ToolLayerScope {
+	return []plugin.ToolLayerScope{
 		&models.ZentaoProduct{},
 		&models.ZentaoProject{},
 	}

--- a/backend/server/services/remote/models/conversion.go
+++ b/backend/server/services/remote/models/conversion.go
@@ -32,7 +32,7 @@ import (
 	"gorm.io/datatypes"
 )
 
-func LoadTableModel(tableName string, schema utils.JsonObject, parentModel any) (*models.DynamicTabler, errors.Error) {
+func LoadTableModel(tableName string, schema utils.JsonObject, parentModel any) (models.DynamicTabler, errors.Error) {
 	structType, err := GenerateStructType(schema, reflect.TypeOf(parentModel))
 	if err != nil {
 		return nil, err

--- a/backend/server/services/remote/models/models.go
+++ b/backend/server/services/remote/models/models.go
@@ -76,16 +76,16 @@ type DynamicScopeModel struct {
 
 func NewDynamicScopeModel(model models.DynamicTabler) *DynamicScopeModel {
 	return &DynamicScopeModel{
-		DynamicTabler: model,
+		DynamicTabler: model.New(),
 	}
 }
 
 func (d *DynamicScopeModel) ScopeId() string {
-	return reflect.ValueOf(d.DynamicTabler).Elem().FieldByName("Id").String()
+	return reflect.ValueOf(d.DynamicTabler.Unwrap()).Elem().FieldByName("Id").String()
 }
 
 func (d *DynamicScopeModel) ScopeName() string {
-	return reflect.ValueOf(d.DynamicTabler).Elem().FieldByName("Name").String()
+	return reflect.ValueOf(d.DynamicTabler.Unwrap()).Elem().FieldByName("Name").String()
 }
 
 type ScopeConfigModel struct {

--- a/backend/server/services/remote/models/models.go
+++ b/backend/server/services/remote/models/models.go
@@ -22,6 +22,7 @@ import (
 	"github.com/apache/incubator-devlake/core/models"
 	"github.com/apache/incubator-devlake/core/models/common"
 	"github.com/apache/incubator-devlake/core/plugin"
+	"reflect"
 )
 
 type PluginExtension string
@@ -57,7 +58,7 @@ type DynamicModelInfo struct {
 	TableName  string         `json:"table_name" validate:"required"`
 }
 
-func (d DynamicModelInfo) LoadDynamicTabler(parentModel any) (*models.DynamicTabler, errors.Error) {
+func (d DynamicModelInfo) LoadDynamicTabler(parentModel any) (models.DynamicTabler, errors.Error) {
 	return LoadTableModel(d.TableName, d.JsonSchema, parentModel)
 }
 
@@ -67,6 +68,24 @@ type ScopeModel struct {
 	ConnectionId     uint64 `gorm:"primaryKey" json:"connectionId"`
 	Name             string `json:"name" validate:"required"`
 	ScopeConfigId    uint64 `json:"scopeConfigId"`
+}
+
+type DynamicScopeModel struct {
+	models.DynamicTabler
+}
+
+func NewDynamicScopeModel(model models.DynamicTabler) *DynamicScopeModel {
+	return &DynamicScopeModel{
+		DynamicTabler: model,
+	}
+}
+
+func (d *DynamicScopeModel) ScopeId() string {
+	return reflect.ValueOf(d.DynamicTabler).Elem().FieldByName("Id").String()
+}
+
+func (d *DynamicScopeModel) ScopeName() string {
+	return reflect.ValueOf(d.DynamicTabler).Elem().FieldByName("Name").String()
 }
 
 type ScopeConfigModel struct {
@@ -94,3 +113,5 @@ type PipelineData struct {
 	Plan   plugin.PipelinePlan  `json:"plan"`
 	Scopes []DynamicDomainScope `json:"scopes"`
 }
+
+var _ plugin.ToolLayerScope = (*DynamicScopeModel)(nil)

--- a/backend/server/services/remote/models/plugin_remote.go
+++ b/backend/server/services/remote/models/plugin_remote.go
@@ -30,5 +30,6 @@ type RemotePlugin interface {
 	plugin.PluginOpenApiSpec
 	plugin.PluginModel
 	plugin.PluginMigration
+	plugin.PluginSource
 	RunAutoMigrations() errors.Error
 }

--- a/backend/server/services/remote/plugin/connection_api.go
+++ b/backend/server/services/remote/plugin/connection_api.go
@@ -53,7 +53,7 @@ func (pa *pluginAPI) TestConnection(input *plugin.ApiResourceInput) (*plugin.Api
 
 func (pa *pluginAPI) PostConnections(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
 	connection := pa.connType.New()
-	err := pa.helper.Create(connection, input)
+	err := pa.connhelper.Create(connection, input)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func (pa *pluginAPI) PostConnections(input *plugin.ApiResourceInput) (*plugin.Ap
 
 func (pa *pluginAPI) ListConnections(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
 	connections := pa.connType.NewSlice()
-	err := pa.helper.List(connections)
+	err := pa.connhelper.List(connections)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func (pa *pluginAPI) ListConnections(input *plugin.ApiResourceInput) (*plugin.Ap
 
 func (pa *pluginAPI) GetConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
 	connection := pa.connType.New()
-	err := pa.helper.First(connection, input.Params)
+	err := pa.connhelper.First(connection, input.Params)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func (pa *pluginAPI) GetConnection(input *plugin.ApiResourceInput) (*plugin.ApiR
 
 func (pa *pluginAPI) PatchConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
 	connection := pa.connType.New()
-	err := pa.helper.Patch(connection, input)
+	err := pa.connhelper.Patch(connection, input)
 	if err != nil {
 		return nil, err
 	}
@@ -93,11 +93,11 @@ func (pa *pluginAPI) PatchConnection(input *plugin.ApiResourceInput) (*plugin.Ap
 
 func (pa *pluginAPI) DeleteConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
 	connection := pa.connType.New()
-	err := pa.helper.First(connection, input.Params)
+	err := pa.connhelper.First(connection, input.Params)
 	if err != nil {
 		return nil, err
 	}
-	refs, err := pa.helper.Delete(input.GetPlugin(), connection)
+	refs, err := pa.connhelper.Delete(connection)
 	if err != nil {
 		return &plugin.ApiResourceOutput{Body: refs, Status: err.GetType().GetHttpCode()}, err
 	}

--- a/backend/server/services/remote/plugin/default_api.go
+++ b/backend/server/services/remote/plugin/default_api.go
@@ -27,18 +27,18 @@ import (
 
 type pluginAPI struct {
 	invoker         bridge.Invoker
-	connType        *models.DynamicTabler
-	scopeType       *models.DynamicTabler
-	scopeConfigType *models.DynamicTabler
+	connType        models.DynamicTabler
+	scopeType       models.DynamicTabler
+	scopeConfigType models.DynamicTabler
 	connhelper      *api.ConnectionApiHelper
 	scopeHelper     *api.GenericScopeApiHelper[remoteModel.RemoteConnection, remoteModel.RemoteScope, remoteModel.RemoteScopeConfig]
 }
 
 func GetDefaultAPI(
 	invoker bridge.Invoker,
-	connType *models.DynamicTabler,
-	scopeConfigType *models.DynamicTabler,
-	scopeType *models.DynamicTabler,
+	connType models.DynamicTabler,
+	scopeConfigType models.DynamicTabler,
+	scopeType models.DynamicTabler,
 	connHelper *api.ConnectionApiHelper,
 ) map[string]map[string]plugin.ApiResourceHandler {
 	papi := &pluginAPI{

--- a/backend/server/services/remote/plugin/init.go
+++ b/backend/server/services/remote/plugin/init.go
@@ -20,26 +20,19 @@ package plugin
 import (
 	"github.com/apache/incubator-devlake/core/context"
 	"github.com/apache/incubator-devlake/core/errors"
-	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/server/services/remote/bridge"
 	"github.com/apache/incubator-devlake/server/services/remote/models"
 	"github.com/go-playground/validator/v10"
 )
 
 var (
-	connectionHelper *api.ConnectionApiHelper
-	scopeHelper      *api.GenericScopeApiHelper[models.RemoteConnection, models.RemoteScope, models.RemoteScopeConfig]
-	basicRes         context.BasicRes
-	vld              *validator.Validate
+	basicRes context.BasicRes
+	vld      *validator.Validate
 )
 
 func Init(br context.BasicRes) {
 	vld = validator.New()
 	basicRes = br
-	connectionHelper = api.NewConnectionHelper(
-		br,
-		vld,
-	)
 }
 
 func NewRemotePlugin(info *models.PluginInfo) (models.RemotePlugin, errors.Error) {

--- a/backend/server/services/remote/plugin/plugin_extensions.go
+++ b/backend/server/services/remote/plugin/plugin_extensions.go
@@ -41,7 +41,7 @@ func (p remoteMetricPlugin) MakeMetricPluginPipelinePlanV200(projectName string,
 
 func (p remoteDatasourcePlugin) MakeDataSourcePipelinePlanV200(connectionId uint64, bpScopes []*plugin.BlueprintScopeV200, syncPolicy plugin.BlueprintSyncPolicy) (plugin.PipelinePlan, []plugin.Scope, errors.Error) {
 	connection := p.connectionTabler.New()
-	err := connectionHelper.FirstById(connection, connectionId)
+	err := p.connHelper.FirstById(connection, connectionId)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/backend/server/services/remote/plugin/plugin_impl.go
+++ b/backend/server/services/remote/plugin/plugin_impl.go
@@ -38,10 +38,10 @@ type (
 		pluginPath        string
 		description       string
 		invoker           bridge.Invoker
-		connectionTabler  *coreModels.DynamicTabler
-		scopeTabler       *coreModels.DynamicTabler
-		scopeConfigTabler *coreModels.DynamicTabler
-		toolModelTablers  []*coreModels.DynamicTabler
+		connectionTabler  coreModels.DynamicTabler
+		scopeTabler       coreModels.DynamicTabler
+		scopeConfigTabler coreModels.DynamicTabler
+		toolModelTablers  []coreModels.DynamicTabler
 		migrationScripts  []plugin.MigrationScript
 		resources         map[string]map[string]plugin.ApiResourceHandler
 		openApiSpec       string
@@ -70,9 +70,9 @@ func newPlugin(info *models.PluginInfo, invoker bridge.Invoker) (*remotePluginIm
 		return nil, errors.Default.Wrap(err, fmt.Sprintf("Couldn't load ScopeConfig type for plugin %s", info.Name))
 	}
 	// put the scope and connection models in the tool list to be consistent with Go plugins
-	toolModelTablers := []*coreModels.DynamicTabler{
+	toolModelTablers := []coreModels.DynamicTabler{
 		connectionTabler.New(),
-		scopeTabler.New(),
+		models.NewDynamicScopeModel(scopeTabler),
 	}
 	for _, toolModelInfo := range info.ToolModelInfos {
 		toolModelTabler, err := toolModelInfo.LoadDynamicTabler(common.NoPKModel{})
@@ -140,8 +140,8 @@ func (p *remotePluginImpl) Connection() dal.Tabler {
 	return p.connectionTabler.New()
 }
 
-func (p *remotePluginImpl) Scopes() []dal.Tabler {
-	return []dal.Tabler{p.scopeTabler.New()}
+func (p *remotePluginImpl) Scopes() []plugin.ToolLayerScope {
+	return []plugin.ToolLayerScope{models.NewDynamicScopeModel(p.scopeTabler)}
 }
 
 func (p *remotePluginImpl) ScopeConfig() dal.Tabler {

--- a/backend/server/services/remote/plugin/plugin_impl.go
+++ b/backend/server/services/remote/plugin/plugin_impl.go
@@ -140,8 +140,8 @@ func (p *remotePluginImpl) Connection() dal.Tabler {
 	return p.connectionTabler.New()
 }
 
-func (p *remotePluginImpl) Scopes() []plugin.ToolLayerScope {
-	return []plugin.ToolLayerScope{models.NewDynamicScopeModel(p.scopeTabler)}
+func (p *remotePluginImpl) Scope() plugin.ToolLayerScope {
+	return models.NewDynamicScopeModel(p.scopeTabler)
 }
 
 func (p *remotePluginImpl) ScopeConfig() dal.Tabler {

--- a/backend/server/services/remote/plugin/remote_scope_api.go
+++ b/backend/server/services/remote/plugin/remote_scope_api.go
@@ -45,7 +45,7 @@ func (pa *pluginAPI) GetRemoteScopes(input *plugin.ApiResourceInput) (*plugin.Ap
 	}
 
 	connection := pa.connType.New()
-	err := pa.helper.First(connection, input.Params)
+	err := pa.connhelper.First(connection, input.Params)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/server/services/remote/plugin/scope_api.go
+++ b/backend/server/services/remote/plugin/scope_api.go
@@ -47,7 +47,7 @@ func (pa *pluginAPI) PutScope(input *plugin.ApiResourceInput) (*plugin.ApiResour
 		}
 		slice = append(slice, &obj)
 	}
-	apiScopes, err := scopeHelper.PutScopes(input, slice)
+	apiScopes, err := pa.scopeHelper.PutScopes(input, slice)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (pa *pluginAPI) PutScope(input *plugin.ApiResourceInput) (*plugin.ApiResour
 }
 
 func (pa *pluginAPI) UpdateScope(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
-	apiScopes, err := scopeHelper.UpdateScope(input)
+	apiScopes, err := pa.scopeHelper.UpdateScope(input)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func (pa *pluginAPI) UpdateScope(input *plugin.ApiResourceInput) (*plugin.ApiRes
 }
 
 func (pa *pluginAPI) ListScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
-	scopes, err := scopeHelper.GetScopes(input)
+	scopes, err := pa.scopeHelper.GetScopes(input)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func (pa *pluginAPI) ListScopes(input *plugin.ApiResourceInput) (*plugin.ApiReso
 }
 
 func (pa *pluginAPI) GetScope(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
-	scope, err := scopeHelper.GetScope(input)
+	scope, err := pa.scopeHelper.GetScope(input)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func (pa *pluginAPI) GetScope(input *plugin.ApiResourceInput) (*plugin.ApiResour
 }
 
 func (pa *pluginAPI) DeleteScope(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
-	refs, err := scopeHelper.DeleteScope(input)
+	refs, err := pa.scopeHelper.DeleteScope(input)
 	if err != nil {
 		return &plugin.ApiResourceOutput{Body: refs, Status: err.GetType().GetHttpCode()}, nil
 	}

--- a/backend/server/services/remote/plugin/scope_db_helper.go
+++ b/backend/server/services/remote/plugin/scope_db_helper.go
@@ -43,7 +43,7 @@ func NewScopeDatabaseHelperImpl(pa *pluginAPI, basicRes context.BasicRes, params
 		pa:         pa,
 		db:         basicRes.GetDal(),
 		params:     params,
-		connHelper: connectionHelper,
+		connHelper: pa.connhelper,
 	}
 }
 

--- a/backend/test/e2e/remote/python_plugin_test.go
+++ b/backend/test/e2e/remote/python_plugin_test.go
@@ -118,18 +118,20 @@ func TestCreateScope(t *testing.T) {
 	conn := CreateTestConnection(client)
 	scopeConfig := CreateTestScopeConfig(client, conn.ID)
 	scope := CreateTestScope(client, scopeConfig, conn.ID)
-
 	scopes := client.ListScopes(PLUGIN_NAME, conn.ID, false)
 	require.Equal(t, 1, len(scopes))
-
-	cicdScope := helper.Cast[FakeProject](scopes[0].Scope)
+	cicdScope := helper.Cast[FakeProject](client.GetScope(PLUGIN_NAME, conn.ID, scope.Id, false).Scope)
+	require.Equal(t, scope.Id, cicdScope.Id)
+	cicdScope0 := helper.Cast[FakeProject](scopes[0].Scope)
+	require.Equal(t, scope.Id, cicdScope0.Id)
 	require.Equal(t, conn.ID, cicdScope.ConnectionId)
 	require.Equal(t, "p1", cicdScope.Id)
 	require.Equal(t, "Project 1", cicdScope.Name)
 	require.Equal(t, "http://fake.org/api/project/p1", cicdScope.Url)
-
 	cicdScope.Name = "scope-name-2"
-	client.UpdateScope(PLUGIN_NAME, conn.ID, cicdScope.Id, scope)
+	client.UpdateScope(PLUGIN_NAME, conn.ID, cicdScope.Id, cicdScope)
+	cicdScope = helper.Cast[FakeProject](client.GetScope(PLUGIN_NAME, conn.ID, scope.Id, false).Scope)
+	require.Equal(t, "scope-name-2", cicdScope.Name)
 }
 
 func TestRunPipeline(t *testing.T) {

--- a/backend/test/helper/api.go
+++ b/backend/test/helper/api.go
@@ -27,7 +27,6 @@ import (
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/models"
 	"github.com/apache/incubator-devlake/core/plugin"
-	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/server/api/blueprints"
 	apiProject "github.com/apache/incubator-devlake/server/api/project"
 	"github.com/stretchr/testify/require"
@@ -220,12 +219,13 @@ func (d *DevlakeClient) ListScopes(pluginName string, connectionId uint64, listB
 	return responses
 }
 
-func (d *DevlakeClient) GetScope(pluginName string, connectionId uint64, scopeId string, listBlueprints bool) any {
-	return sendHttpRequest[api.ScopeRes[any, any]](d.testCtx, d.timeout, &testContext{
+func (d *DevlakeClient) GetScope(pluginName string, connectionId uint64, scopeId string, listBlueprints bool) ScopeResponse {
+	scopeRaw := sendHttpRequest[map[string]any](d.testCtx, d.timeout, &testContext{
 		client:       d,
 		printPayload: true,
 		inlineJson:   false,
 	}, http.MethodGet, fmt.Sprintf("%s/plugins/%s/connections/%d/scopes/%s?blueprints=%v", d.Endpoint, pluginName, connectionId, scopeId, listBlueprints), nil, nil)
+	return getScopeResponse(scopeRaw)
 }
 
 func (d *DevlakeClient) DeleteScope(pluginName string, connectionId uint64, scopeId string, deleteDataOnly bool) services.BlueprintProjectPairs {


### PR DESCRIPTION
### Summary
What does this PR do?
1. Most plugins now implement the PluginSource interface. This makes the plugins expose their Connection, Scope and ScopeConfig types explicitly (Scope needed by ConnectionHelper for now).
2. All Scope models have been adapted to the ToolLayerScope interface for standardization.
3. ConnectionHelper now check for the Scope(s) of a plugin before deleting the connection. If there's one or more, error 409 is returned. "PluginSource" is leveraged to discover the Scope(s). (See https://github.com/apache/incubator-devlake/pull/5506#discussion_r1232442767)
4. ConnectionHelper is now instantiated with the plugin name. A new Name() method added to PluginMeta to standardize plugin name declaration. (See https://github.com/apache/incubator-devlake/pull/5506#discussion_r1232001686)
5. Zentao plugin was not returning tool models which would have broken the Delete logic. Fixed.
6. (For remote plugins), DynamicTabler converted into an interface from struct (Impl is now DynamicTablerImpl). This was needed to have remote plugins implement the ToolLayerScope interface.
7. Found other minor issues that I also fixed. See commits. 

### Does this close any open issues?
Closes #5513 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
