### PR TITLE
fix: ignore 404 when collecting gitlab mr detail

### DIFF
--- a/.github/workflows/commit-msg.yml
+++ b/.github/workflows/commit-msg.yml
@@ -35,5 +35,5 @@ jobs:
       - name: Lint commit message
         run: |
           ! git log --oneline ${{ github.event.pull_request.base.sha }}... \
-            | grep -vP '^\w{8} Merge ' \
-            | grep -vP '^\w{8} (feat|fix|build|chore|docs|style|refactor|perf|test|ci)(\(\w+(-\w+)?\))?:(\s*).*'
+            | grep -vP '^\w{8,40} Merge ' \
+            | grep -vP '^\w{8,40} (feat|fix|build|chore|docs|style|refactor|perf|test|ci)(\(\w+(-\w+)?\))?:(\s*).*'

--- a/backend/plugins/gitlab/tasks/api_client.go
+++ b/backend/plugins/gitlab/tasks/api_client.go
@@ -75,3 +75,10 @@ func ignoreHTTPStatus403(res *http.Response) errors.Error {
 	}
 	return nil
 }
+
+func ignoreHTTPStatus404(res *http.Response) errors.Error {
+	if res.StatusCode == http.StatusNotFound {
+		return api.ErrIgnoreAndContinue
+	}
+	return nil
+}

--- a/backend/plugins/gitlab/tasks/mr_commit_collector.go
+++ b/backend/plugins/gitlab/tasks/mr_commit_collector.go
@@ -60,6 +60,7 @@ func CollectApiMergeRequestsCommits(taskCtx plugin.SubTaskContext) errors.Error 
 		Query:          GetQuery,
 		GetTotalPages:  GetTotalPagesFromResponse,
 		ResponseParser: GetRawMessageFromResponse,
+		AfterResponse:  ignoreHTTPStatus404,
 	})
 	if err != nil {
 		return err

--- a/backend/plugins/gitlab/tasks/mr_detail_collector.go
+++ b/backend/plugins/gitlab/tasks/mr_detail_collector.go
@@ -65,6 +65,7 @@ func CollectApiMergeRequestDetails(taskCtx plugin.SubTaskContext) errors.Error {
 			return query, nil
 		},
 		ResponseParser: GetOneRawMessageFromResponse,
+		AfterResponse:  ignoreHTTPStatus404,
 	})
 	if err != nil {
 		return err

--- a/backend/plugins/gitlab/tasks/mr_note_collector.go
+++ b/backend/plugins/gitlab/tasks/mr_note_collector.go
@@ -62,6 +62,7 @@ func CollectApiMergeRequestsNotes(taskCtx plugin.SubTaskContext) errors.Error {
 		Query:          GetQuery,
 		GetTotalPages:  GetTotalPagesFromResponse,
 		ResponseParser: GetRawMessageFromResponse,
+		AfterResponse:  ignoreHTTPStatus404,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
### Summary
ignore 404 errors when collecting merge request detail.

### Does this close any open issues?
Closes #5385 

### Screenshots
fabricated a missing MR
![gitlab-1](https://github.com/apache/incubator-devlake/assets/61080/369096e8-7fd0-44f2-8571-fd755867cbfc)

Fixed
![gitlab-2](https://github.com/apache/incubator-devlake/assets/61080/a14bba36-df2a-444b-9f09-902653386ce9)
![image](https://github.com/apache/incubator-devlake/assets/61080/70c34bc4-5fb7-4450-bd93-6bdbecd27177)

Without ignoring
![gitlab-0](https://github.com/apache/incubator-devlake/assets/61080/a18e39a4-5755-4306-9b6c-9a5e53d4a10e)

