### PR TITLE
fix: issue_assignees was missing

### DIFF
--- a/backend/core/models/domainlayer/domaininfo/domaininfo.go
+++ b/backend/core/models/domainlayer/domaininfo/domaininfo.go
@@ -74,5 +74,6 @@ func GetDomainTablesInfo() []Tabler {
 		&ticket.IssueWorklog{},
 		&ticket.Sprint{},
 		&ticket.SprintIssue{},
+		&ticket.IssueAssignee{},
 	}
 }


### PR DESCRIPTION
### Summary
Fix #5536 ([Bug][framework] the table issue_assignees was missing in the return of GetDomainTablesInfo)

### Does this close any open issues?
Closes #5536

