### PR TITLE
Proxy fixes for github_graphql and gitextractor

### DIFF
--- a/backend/plugins/gitextractor/parser/clone.go
+++ b/backend/plugins/gitextractor/parser/clone.go
@@ -59,7 +59,7 @@ func (l *GitRepoCreator) CloneOverHTTP(repoId, url, user, password, proxy string
 	return withTempDirectory(func(dir string) (*GitRepo, error) {
 		cloneOptions := &git.CloneOptions{Bare: true}
 		if proxy != "" {
-			cloneOptions.FetchOptions.ProxyOptions.Type = git.ProxyTypeAuto
+			cloneOptions.FetchOptions.ProxyOptions.Type = git.ProxyTypeSpecified
 			cloneOptions.FetchOptions.ProxyOptions.Url = proxy
 		}
 		if user != "" {

--- a/backend/plugins/github_graphql/impl/impl.go
+++ b/backend/plugins/github_graphql/impl/impl.go
@@ -189,7 +189,6 @@ func (p GithubGraphql) PrepareTaskData(taskCtx plugin.TaskContext, options map[s
 		}
 	}
 
-
 	httpClient := oauth2.NewClient(oauthContext, src)
 	endpoint, err := errors.Convert01(url.JoinPath(connection.Endpoint, `graphql`))
 	if err != nil {

--- a/backend/plugins/github_graphql/impl/impl.go
+++ b/backend/plugins/github_graphql/impl/impl.go
@@ -20,6 +20,7 @@ package impl
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"reflect"
 	"strings"
@@ -166,7 +167,30 @@ func (p GithubGraphql) PrepareTaskData(taskCtx plugin.TaskContext, options map[s
 	src := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: tokens[0]},
 	)
-	httpClient := oauth2.NewClient(taskCtx.GetContext(), src)
+	oauthContext := taskCtx.GetContext()
+	proxy := connection.GetProxy()
+	if proxy != "" {
+		pu, err := url.Parse(proxy)
+		if err != nil {
+			return nil, errors.Convert(err)
+		}
+		if pu.Scheme == "http" || pu.Scheme == "socks5" {
+			proxyClient := &http.Client{
+				Transport: &http.Transport{Proxy: http.ProxyURL(pu)},
+			}
+			oauthContext = context.WithValue(
+				taskCtx.GetContext(),
+				oauth2.HTTPClient,
+				proxyClient,
+			)
+			logger.Debug("Proxy set in oauthContext to %s", proxy)
+		} else {
+			return nil, errors.BadInput.New("Unsupported scheme set in proxy")
+		}
+	}
+
+
+	httpClient := oauth2.NewClient(oauthContext, src)
 	endpoint, err := errors.Convert01(url.JoinPath(connection.Endpoint, `graphql`))
 	if err != nil {
 		return nil, errors.BadInput.Wrap(err, fmt.Sprintf("malformed connection endpoint supplied: %s", connection.Endpoint))


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
Fix for github_graphql and gitextractor when running devlake behind a corporate proxy. Currently both connections ignores the proxy configuration option and times out when trying to connect to github.

#### gitextractor
The proxy option `git.ProxyTypeAuto` in libgit2 seems to only use proxy when http proxy environment variables are set, instead `git.ProxyTypeSpecified`should be used to correctly specify proxy url.

#### github_graphql
To set proxy config on oauth2 one has to pass a custom `http.Client` object to the library through the context when creating the oauth2 client:
https://cs.opensource.google/go/x/oauth2/+/refs/tags/v0.9.0:oauth2.go;l=334

### Does this close any open issues?
Closes #5502

