### PR TITLE
fix: check and fix missing models returned by GetTablesInfo

### DIFF
--- a/backend/core/domain_tables_info_test.go
+++ b/backend/core/domain_tables_info_test.go
@@ -15,33 +15,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package codequality
+package core
 
 import (
-	"github.com/apache/incubator-devlake/core/models/domainlayer"
-	"github.com/apache/incubator-devlake/core/plugin"
-	"github.com/apache/incubator-devlake/helpers/utils"
+	"github.com/apache/incubator-devlake/core/models/domainlayer/domaininfo"
+	"github.com/apache/incubator-devlake/core/utils"
+	"testing"
 )
 
-var _ plugin.Scope = (*CqProject)(nil)
-
-type CqProject struct {
-	domainlayer.DomainEntity
-	Name             string `gorm:"type:varchar(255)"`
-	Qualifier        string `gorm:"type:varchar(255)"`
-	Visibility       string `gorm:"type:varchar(64)"`
-	LastAnalysisDate *utils.Iso8601Time
-	CommitSha        string `gorm:"type:varchar(128)"`
-}
-
-func (CqProject) TableName() string {
-	return "cq_projects"
-}
-
-func (s *CqProject) ScopeId() string {
-	return s.Id
-}
-
-func (s *CqProject) ScopeName() string {
-	return s.Name
+func Test_GetDomainTablesInfo(t *testing.T) {
+	checker := utils.NewTableInfoChecker(utils.TableInfoCheckerConfig{})
+	checker.FeedIn("models/domainlayer", domaininfo.GetDomainTablesInfo)
+	err := checker.Verify()
+	if err != nil {
+		t.Error(err)
+	}
 }

--- a/backend/core/models/domainlayer/codequality/cq_issues.go
+++ b/backend/core/models/domainlayer/codequality/cq_issues.go
@@ -19,7 +19,7 @@ package codequality
 
 import (
 	"github.com/apache/incubator-devlake/core/models/domainlayer"
-	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/helpers/utils"
 )
 
 type CqIssue struct {
@@ -45,8 +45,8 @@ type CqIssue struct {
 	EndOffset                int    `json:"endOffset"`
 	VulnerabilityProbability string `gorm:"type:varchar(100)"`
 	SecurityCategory         string `gorm:"type:varchar(100)"`
-	CreatedDate              *api.Iso8601Time
-	UpdatedDate              *api.Iso8601Time
+	CreatedDate              *utils.Iso8601Time
+	UpdatedDate              *utils.Iso8601Time
 }
 
 func (CqIssue) TableName() string {

--- a/backend/core/models/domainlayer/didgen/domain_id_generator_test.go
+++ b/backend/core/models/domainlayer/didgen/domain_id_generator_test.go
@@ -29,6 +29,10 @@ import (
 
 type FooPlugin string
 
+func (f *FooPlugin) Name() string {
+	return "foo"
+}
+
 func (f *FooPlugin) Description() string {
 	return "foo"
 }

--- a/backend/core/models/domainlayer/domaininfo/domaininfo.go
+++ b/backend/core/models/domainlayer/domaininfo/domaininfo.go
@@ -18,24 +18,23 @@ limitations under the License.
 package domaininfo
 
 import (
+	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/models/domainlayer/code"
+	"github.com/apache/incubator-devlake/core/models/domainlayer/codequality"
 	"github.com/apache/incubator-devlake/core/models/domainlayer/crossdomain"
 	"github.com/apache/incubator-devlake/core/models/domainlayer/devops"
 	"github.com/apache/incubator-devlake/core/models/domainlayer/ticket"
 )
 
-type Tabler interface {
-	TableName() string
-}
-
-func GetDomainTablesInfo() []Tabler {
-	return []Tabler{
+func GetDomainTablesInfo() []dal.Tabler {
+	return []dal.Tabler{
 		// code
 		&code.Commit{},
 		&code.CommitFile{},
 		&code.CommitFileComponent{},
 		&code.CommitParent{},
 		&code.Component{},
+		&code.CommitLineChange{},
 		&code.PullRequest{},
 		&code.PullRequestComment{},
 		&code.PullRequestCommit{},
@@ -47,12 +46,20 @@ func GetDomainTablesInfo() []Tabler {
 		&code.Repo{},
 		&code.RepoCommit{},
 		&code.RepoLanguage{},
+		&code.RepoSnapshot{},
+		// codequality
+		&codequality.CqFileMetrics{},
+		&codequality.CqIssueCodeBlock{},
+		&codequality.CqIssue{},
+		&codequality.CqProject{},
 		// crossdomain
 		&crossdomain.Account{},
 		&crossdomain.BoardRepo{},
 		&crossdomain.IssueCommit{},
 		&crossdomain.IssueRepoCommit{},
 		&crossdomain.ProjectMapping{},
+		&crossdomain.ProjectIssueMetric{},
+		&crossdomain.ProjectPrMetric{},
 		&crossdomain.PullRequestIssue{},
 		&crossdomain.RefsIssuesDiffs{},
 		&crossdomain.Team{},
@@ -62,6 +69,9 @@ func GetDomainTablesInfo() []Tabler {
 		// devops
 		&devops.CICDPipeline{},
 		&devops.CICDTask{},
+		&devops.CicdDeploymentCommit{},
+		&devops.CiCDPipelineCommit{},
+		&devops.CicdScope{},
 		// didgen no table
 		// ticket
 		&ticket.Board{},

--- a/backend/core/utils/table_info_checker.go
+++ b/backend/core/utils/table_info_checker.go
@@ -1,0 +1,107 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"sort"
+	"strings"
+
+	"github.com/apache/incubator-devlake/core/dal"
+	"github.com/apache/incubator-devlake/core/errors"
+)
+
+type TableInfoChecker struct {
+	tables  map[string]struct{}
+	prefix  string
+	ignores []string
+}
+
+func NewTableInfoChecker(prefix string, ignores []string) *TableInfoChecker {
+	return &TableInfoChecker{tables: make(map[string]struct{}), prefix: prefix, ignores: ignores}
+}
+
+// The FeedIn function iterates through the model definitions,
+// identifies all the tables by parsing the source files,
+// and then compares them with the output obtained from the GetTablesInfo function.
+func (checker *TableInfoChecker) FeedIn(modelsDir string, f func() []dal.Tabler) {
+	set := token.NewFileSet()
+	packs, err := parser.ParseDir(set, modelsDir, nil, 0)
+	if err != nil {
+		panic(err)
+	}
+	funcs := checker.getTableNameFuncs(packs)
+	for _, fun := range funcs {
+		s := checker.getTableName(fun)
+		if strings.HasPrefix(s, checker.prefix) {
+			checker.tables[s] = struct{}{}
+		}
+	}
+	for _, tb := range checker.ignores {
+		delete(checker.tables, tb)
+	}
+	for _, tabler := range f() {
+		delete(checker.tables, tabler.TableName())
+	}
+}
+
+func (checker *TableInfoChecker) Verify() errors.Error {
+	for _, tb := range checker.ignores {
+		delete(checker.tables, tb)
+	}
+	if len(checker.tables) == 0 {
+		return nil
+	}
+	tableNames := make([]string, 0, len(checker.tables))
+	sb := strings.Builder{}
+	sb.WriteString("The following tables are not returned by the GetTablesInfo\n")
+	for t := range checker.tables {
+		tableNames = append(tableNames, t)
+	}
+	// sort the table names so that the tables of the same plugin are together
+	sort.Strings(tableNames)
+	sb.WriteString(strings.Join(tableNames, "\n"))
+	return errors.Default.New(sb.String())
+}
+
+func (checker *TableInfoChecker) getTableNameFuncs(pks map[string]*ast.Package) []*ast.FuncDecl {
+	var funcs []*ast.FuncDecl
+	for _, pack := range pks {
+		for _, f := range pack.Files {
+			for _, d := range f.Decls {
+				if fn, isFn := d.(*ast.FuncDecl); isFn && fn.Name.String() == "TableName" {
+					funcs = append(funcs, fn)
+				}
+			}
+		}
+	}
+	return funcs
+}
+
+func (checker *TableInfoChecker) getTableName(fn *ast.FuncDecl) string {
+	for _, stmt := range fn.Body.List {
+		if rs, isReturn := stmt.(*ast.ReturnStmt); isReturn {
+			if lit, ok := rs.Results[0].(*ast.BasicLit); ok {
+				return strings.Trim(lit.Value, `"`)
+			}
+		}
+	}
+	return ""
+}

--- a/backend/core/utils/table_info_checker.go
+++ b/backend/core/utils/table_info_checker.go
@@ -71,13 +71,13 @@ func (checker *TableInfoChecker) Verify() errors.Error {
 	}
 	tableNames := make([]string, 0, len(checker.tables))
 	sb := strings.Builder{}
-	sb.WriteString("The following tables are not returned by the GetTablesInfo\n")
+	_, _ = sb.WriteString("The following tables are not returned by the GetTablesInfo\n")
 	for t := range checker.tables {
 		tableNames = append(tableNames, t)
 	}
 	// sort the table names so that the tables of the same plugin are together
 	sort.Strings(tableNames)
-	sb.WriteString(strings.Join(tableNames, "\n"))
+	_, _ = sb.WriteString(strings.Join(tableNames, "\n"))
 	return errors.Default.New(sb.String())
 }
 

--- a/backend/helpers/utils/iso8601time.go
+++ b/backend/helpers/utils/iso8601time.go
@@ -1,0 +1,171 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+/*
+parse iso8601 datetime format for json.Unmarshal
+
+declare your field type as:
+
+type Foo struct {
+	Created Iso8601Time
+}
+
+foo := &Foo{}
+err := errors.ConvertError(json.Unmarshal("{\"created\": \"2021-02-19T01:53:35.340+0800\"}", foo))
+var time time.Time
+time = foo.Created.ToTime()
+*/
+
+// DateTimeFormatItem FIXME ...
+// TODO: move this to helper
+type DateTimeFormatItem struct {
+	Matcher *regexp.Regexp
+	Format  string
+}
+
+// DateTimeFormats FIXME ...
+var DateTimeFormats []DateTimeFormatItem
+
+func init() {
+	DateTimeFormats = []DateTimeFormatItem{
+		{
+			Matcher: regexp.MustCompile(`[+-][\d]{4}$`),
+			Format:  "2006-01-02T15:04:05-0700",
+		},
+		{
+			Matcher: regexp.MustCompile(`[\d]{3}[+-][\d]{2}:[\d]{2}$`),
+			Format:  "2006-01-02T15:04:05.000-07:00",
+		},
+		{
+			Matcher: regexp.MustCompile(`[+-][\d]{2}:[\d]{2}$`),
+			Format:  "2006-01-02T15:04:05-07:00",
+		},
+		{
+			Matcher: regexp.MustCompile(`[\d]{4}-[\d]{2}-[\d]{2} [\d]{2}:[\d]{2}:[\d]{2}$`),
+			Format:  "2006-01-02 15:04:05",
+		},
+		{
+			Matcher: regexp.MustCompile(`[+-][\d]{2}-[\d]{2}$`),
+			Format:  "2006-01-02",
+		},
+	}
+}
+
+// Iso8601Time is type time.Time
+type Iso8601Time struct {
+	time   time.Time
+	format string
+}
+
+func (jt *Iso8601Time) String() string {
+	format := jt.format
+	if format == "" {
+		format = DateTimeFormats[0].Format
+	}
+	return jt.time.Format(format)
+}
+
+// MarshalJSON FIXME ...
+func (jt Iso8601Time) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, jt.String())), nil
+}
+
+// UnmarshalJSON FIXME ...
+func (jt *Iso8601Time) UnmarshalJSON(b []byte) error {
+	timeString := string(b)
+	if timeString == "null" {
+		return nil
+	}
+	if strings.Contains(timeString, "0000-00-00") {
+		return nil
+	}
+	timeString = strings.Trim(timeString, `"`)
+	t, err := ConvertStringToTime(timeString)
+	if err != nil {
+		return err
+	}
+	jt.time = t
+	return nil
+}
+
+// ToTime FIXME ...
+func (jt *Iso8601Time) ToTime() time.Time {
+	return jt.time
+}
+
+// ToNullableTime FIXME ...
+func (jt *Iso8601Time) ToNullableTime() *time.Time {
+	if jt == nil {
+		return nil
+	}
+	return &jt.time
+}
+
+// ConvertStringToTime FIXME ...
+func ConvertStringToTime(timeString string) (t time.Time, err error) {
+	for _, formatItem := range DateTimeFormats {
+		if formatItem.Matcher.MatchString(timeString) {
+			return time.Parse(formatItem.Format, timeString)
+		}
+	}
+	return time.Parse(time.RFC3339, timeString)
+}
+
+// Iso8601TimeToTime FIXME ...
+func Iso8601TimeToTime(iso8601Time *Iso8601Time) *time.Time {
+	if iso8601Time == nil {
+		return nil
+	}
+	t := iso8601Time.ToTime()
+	return &t
+}
+
+// Value FIXME ...
+func (jt *Iso8601Time) Value() (driver.Value, error) {
+	if jt == nil {
+		return nil, nil
+	}
+	var zeroTime time.Time
+	t := jt.time
+	if t.UnixNano() == zeroTime.UnixNano() {
+		return nil, nil
+	}
+	return t, nil
+}
+
+// Scan FIXME ...
+func (jt *Iso8601Time) Scan(v interface{}) error {
+	value, ok := v.(time.Time)
+	if ok {
+		*jt = Iso8601Time{
+			time:   value,
+			format: time.RFC3339,
+		}
+		return nil
+	}
+	return fmt.Errorf("can not convert %v to timestamp", v)
+}

--- a/backend/helpers/utils/iso8601time_test.go
+++ b/backend/helpers/utils/iso8601time_test.go
@@ -1,0 +1,167 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"github.com/apache/incubator-devlake/core/errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type Iso8601TimeRecord struct {
+	Created Iso8601Time
+}
+
+type Iso8601TimeRecordP struct {
+	Created *Iso8601Time
+}
+
+type TimeRecord struct {
+	Created time.Time
+}
+
+func TimeMustParse(text string) time.Time {
+	t, err := time.Parse(time.RFC3339, text)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+func TestIso8601Time(t *testing.T) {
+	pairs := map[string]time.Time{
+		`{ "Created": "2021-07-30T19:14:33Z" }`:          TimeMustParse("2021-07-30T19:14:33Z"),
+		`{ "Created": "2021-07-30T19:14:33-0100" }`:      TimeMustParse("2021-07-30T20:14:33Z"),
+		`{ "Created": "2021-07-30T19:14:33+0100" }`:      TimeMustParse("2021-07-30T18:14:33Z"),
+		`{ "Created": "2021-07-30T19:14:33.000-01:00" }`: TimeMustParse("2021-07-30T20:14:33Z"),
+		`{ "Created": "2021-07-30T19:14:33.000+01:00" }`: TimeMustParse("2021-07-30T18:14:33Z"),
+		`{ "Created": "2021-07-30T19:14:33+01:00" }`:     TimeMustParse("2021-07-30T18:14:33Z"),
+	}
+
+	for input, expected := range pairs {
+		var record Iso8601TimeRecord
+		err := errors.Convert(json.Unmarshal([]byte(input), &record))
+		assert.Nil(t, err)
+		assert.Equal(t, expected, record.Created.ToTime().UTC())
+
+		var ms map[string]interface{}
+		err = errors.Convert(json.Unmarshal([]byte(input), &ms))
+		assert.Nil(t, err)
+
+		var record2 Iso8601TimeRecord
+		err = DecodeMapStruct(ms, &record2, true)
+		assert.Nil(t, err)
+		assert.Equal(t, expected, record2.Created.ToTime().UTC())
+
+		var record3 Iso8601TimeRecordP
+		err = DecodeMapStruct(ms, &record3, true)
+		assert.Nil(t, err)
+		assert.Equal(t, expected, record3.Created.ToTime().UTC())
+
+		var record4 TimeRecord
+		err = DecodeMapStruct(ms, &record4, true)
+		assert.Nil(t, err)
+		assert.Equal(t, expected, record4.Created.UTC())
+	}
+}
+
+func TestIso8601Time_Value(t *testing.T) {
+	zeroTime := time.Time{}
+	testCases := []struct {
+		name   string
+		input  *Iso8601Time
+		output driver.Value
+		err    error
+	}{
+		{
+			name:   "Nil value",
+			input:  nil,
+			output: nil,
+			err:    nil,
+		},
+		{
+			name: "Valid time value",
+			input: &Iso8601Time{
+				time:   time.Date(2023, 2, 28, 10, 30, 0, 0, time.UTC),
+				format: time.RFC3339,
+			},
+			output: time.Date(2023, 2, 28, 10, 30, 0, 0, time.UTC),
+			err:    nil,
+		},
+		{
+			name: "Zero time value",
+			input: &Iso8601Time{
+				time:   zeroTime,
+				format: time.RFC3339,
+			},
+			output: nil,
+			err:    nil,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := tc.input.Value()
+			if output != tc.output {
+				t.Errorf("Expected output to be %v, but got %v", tc.output, output)
+			}
+			if err != tc.err {
+				t.Errorf("Expected error to be %v, but got %v", tc.err, err)
+			}
+		})
+	}
+}
+
+func TestIso8601Time_Scan(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  interface{}
+		output *Iso8601Time
+		err    error
+	}{
+		{
+			name:   "Valid time value",
+			input:  time.Date(2023, 2, 28, 10, 30, 0, 0, time.UTC),
+			output: &Iso8601Time{time: time.Date(2023, 2, 28, 10, 30, 0, 0, time.UTC), format: time.RFC3339},
+			err:    nil,
+		},
+		{
+			name:   "Invalid input value",
+			input:  "invalid",
+			output: &Iso8601Time{},
+			err:    fmt.Errorf("can not convert %v to timestamp", "invalid"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var output Iso8601Time
+			err := output.Scan(tc.input)
+			if !reflect.DeepEqual(tc.output, &output) {
+				t.Errorf("Expected output to be %v, but got %v", tc.output, output)
+			}
+			if !reflect.DeepEqual(tc.err, err) {
+				t.Errorf("Expected error to be %v, but got %v", tc.err, err)
+			}
+		})
+	}
+}

--- a/backend/helpers/utils/mapstructure.go
+++ b/backend/helpers/utils/mapstructure.go
@@ -1,0 +1,95 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"encoding/json"
+	"github.com/apache/incubator-devlake/core/models"
+	"reflect"
+	"time"
+
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/go-playground/validator/v10"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+func DecodeHook(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+	if data == nil {
+		return nil, nil
+	}
+	if t == reflect.TypeOf(json.RawMessage{}) {
+		return json.Marshal(data)
+	}
+
+	if t != reflect.TypeOf(Iso8601Time{}) && t != reflect.TypeOf(time.Time{}) {
+		return data, nil
+	}
+
+	var tt time.Time
+	var err error
+
+	switch f.Kind() {
+	case reflect.String:
+		tt, err = ConvertStringToTime(data.(string))
+	case reflect.Float64:
+		tt = time.Unix(0, int64(data.(float64))*int64(time.Millisecond))
+	case reflect.Int64:
+		tt = time.Unix(0, data.(int64)*int64(time.Millisecond))
+	}
+	if err != nil {
+		return data, nil
+	}
+
+	if t == reflect.TypeOf(Iso8601Time{}) {
+		return Iso8601Time{time: tt}, nil
+	}
+	return tt, nil
+}
+
+// DecodeMapStruct with time.Time and Iso8601Time support
+func DecodeMapStruct(input map[string]interface{}, result interface{}, zeroFields bool) errors.Error {
+	result = models.UnwrapObject(result)
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		ZeroFields: zeroFields,
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(DecodeHook),
+		Result:     result,
+	})
+	if err != nil {
+		return errors.Convert(err)
+	}
+
+	if err := decoder.Decode(input); err != nil {
+		return errors.Convert(err)
+	}
+	return errors.Convert(err)
+}
+
+// Decode decodes `source` into `target`. Pass an optional validator to validate the target.
+func Decode(source interface{}, target interface{}, vld *validator.Validate) errors.Error {
+	target = models.UnwrapObject(target)
+	if err := mapstructure.Decode(source, &target); err != nil {
+		return errors.Default.Wrap(err, "error decoding map into target type")
+	}
+	if vld != nil {
+		if err := vld.Struct(target); err != nil {
+			return errors.Default.Wrap(err, "error validating target")
+		}
+	}
+	return nil
+}

--- a/backend/helpers/utils/mapstructure_test.go
+++ b/backend/helpers/utils/mapstructure_test.go
@@ -1,0 +1,81 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/apache/incubator-devlake/core/errors"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type DecodeMapStructJson struct {
+	Id       int
+	Settings json.RawMessage
+	Plan     json.RawMessage
+	Existing json.RawMessage
+}
+
+func TestDecodeMapStructJsonRawMessage(t *testing.T) {
+	input := map[string]interface{}{
+		"id": 100,
+		"settings": map[string]interface{}{
+			"version": "1.0.0",
+		},
+	}
+
+	decoded := &DecodeMapStructJson{
+		Settings: json.RawMessage(`{"version": "1.0.101"}`),
+		Existing: json.RawMessage(`{"hello", "world"}`),
+	}
+	err := DecodeMapStruct(input, decoded, true)
+	fmt.Println(string(decoded.Settings))
+	assert.Nil(t, err)
+	assert.Equal(t, decoded.Id, 100)
+	assert.Nil(t, decoded.Plan)
+	assert.NotNil(t, decoded.Settings)
+	settings := make(map[string]string)
+	err = errors.Convert(json.Unmarshal(decoded.Settings, &settings))
+	assert.Nil(t, err)
+	assert.Equal(t, settings["version"], "1.0.0")
+	assert.Equal(t, decoded.Existing, json.RawMessage(`{"hello", "world"}`))
+}
+
+type StringSliceField struct {
+	Entities []string `gorm:"type:json;serializer:json" mapstructure:"entities"`
+}
+
+func TestStringSliceFieldShouldBeOverwrited(t *testing.T) {
+	decoded := &StringSliceField{
+		Entities: []string{"hello", "world"},
+	}
+	input := map[string]interface{}{
+		"entities": []string{"foo"},
+	}
+	err := DecodeMapStruct(input, decoded, true)
+	assert.Nil(t, err)
+	assert.Equal(t, decoded.Entities, []string{"foo"})
+
+	input = map[string]interface{}{}
+	err = DecodeMapStruct(input, decoded, true)
+	assert.Nil(t, err)
+	assert.Equal(t, decoded.Entities, []string{"foo"})
+}

--- a/backend/plugins/bamboo/impl/impl.go
+++ b/backend/plugins/bamboo/impl/impl.go
@@ -77,6 +77,9 @@ func (p Bamboo) GetTablesInfo() []dal.Tabler {
 		&models.BambooPlanBuild{},
 		&models.BambooPlanBuildVcsRevision{},
 		&models.BambooJobBuild{},
+		&models.BambooDeployBuild{},
+		&models.BambooDeployEnvironment{},
+		&models.BambooScopeConfig{},
 	}
 }
 

--- a/backend/plugins/bitbucket/impl/impl.go
+++ b/backend/plugins/bitbucket/impl/impl.go
@@ -77,6 +77,10 @@ func (p Bitbucket) GetTablesInfo() []dal.Tabler {
 		&models.BitbucketPipeline{},
 		&models.BitbucketRepo{},
 		&models.BitbucketRepoCommit{},
+		&models.BitbucketDeployment{},
+		&models.BitbucketPipelineStep{},
+		&models.BitbucketPrCommit{},
+		&models.BitbucketScopeConfig{},
 	}
 }
 

--- a/backend/plugins/customize/impl/impl.go
+++ b/backend/plugins/customize/impl/impl.go
@@ -23,6 +23,7 @@ import (
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/plugins/customize/api"
+	"github.com/apache/incubator-devlake/plugins/customize/models"
 	"github.com/apache/incubator-devlake/plugins/customize/models/migrationscripts"
 	"github.com/apache/incubator-devlake/plugins/customize/tasks"
 	"github.com/mitchellh/mapstructure"
@@ -46,7 +47,9 @@ func (p *Customize) Init(basicRes context.BasicRes) errors.Error {
 }
 
 func (p Customize) GetTablesInfo() []dal.Tabler {
-	return []dal.Tabler{}
+	return []dal.Tabler{
+		&models.CustomizedField{},
+	}
 }
 
 func (p Customize) SubTaskMetas() []plugin.SubTaskMeta {

--- a/backend/plugins/feishu/impl/impl.go
+++ b/backend/plugins/feishu/impl/impl.go
@@ -54,6 +54,8 @@ func (p Feishu) GetTablesInfo() []dal.Tabler {
 	return []dal.Tabler{
 		&models.FeishuConnection{},
 		&models.FeishuMeetingTopUserItem{},
+		&models.FeishuChatItem{},
+		&models.FeishuMessage{},
 	}
 }
 

--- a/backend/plugins/github/impl/impl.go
+++ b/backend/plugins/github/impl/impl.go
@@ -89,6 +89,8 @@ func (p Github) GetTablesInfo() []dal.Tabler {
 		&models.GithubRepoCommit{},
 		&models.GithubReviewer{},
 		&models.GithubRun{},
+		&models.GithubIssueAssignee{},
+		&models.GithubScopeConfig{},
 	}
 }
 

--- a/backend/plugins/gitlab/impl/impl.go
+++ b/backend/plugins/gitlab/impl/impl.go
@@ -95,6 +95,8 @@ func (p Gitlab) GetTablesInfo() []dal.Tabler {
 		&models.GitlabProjectCommit{},
 		&models.GitlabReviewer{},
 		&models.GitlabTag{},
+		&models.GitlabIssueAssignee{},
+		&models.GitlabScopeConfig{},
 	}
 }
 

--- a/backend/plugins/impl_test.go
+++ b/backend/plugins/impl_test.go
@@ -1,0 +1,70 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"testing"
+
+	"github.com/apache/incubator-devlake/core/utils"
+	ae "github.com/apache/incubator-devlake/plugins/ae/impl"
+	bamboo "github.com/apache/incubator-devlake/plugins/bamboo/impl"
+	bitbucket "github.com/apache/incubator-devlake/plugins/bitbucket/impl"
+	dora "github.com/apache/incubator-devlake/plugins/dora/impl"
+	feishu "github.com/apache/incubator-devlake/plugins/feishu/impl"
+	gitee "github.com/apache/incubator-devlake/plugins/gitee/impl"
+	github "github.com/apache/incubator-devlake/plugins/github/impl"
+	gitlab "github.com/apache/incubator-devlake/plugins/gitlab/impl"
+	icla "github.com/apache/incubator-devlake/plugins/icla/impl"
+	jenkins "github.com/apache/incubator-devlake/plugins/jenkins/impl"
+	jira "github.com/apache/incubator-devlake/plugins/jira/impl"
+	pagerduty "github.com/apache/incubator-devlake/plugins/pagerduty/impl"
+	slack "github.com/apache/incubator-devlake/plugins/slack/impl"
+	sonarqube "github.com/apache/incubator-devlake/plugins/sonarqube/impl"
+	tapd "github.com/apache/incubator-devlake/plugins/tapd/impl"
+	teambition "github.com/apache/incubator-devlake/plugins/teambition/impl"
+	trello "github.com/apache/incubator-devlake/plugins/trello/impl"
+	webhook "github.com/apache/incubator-devlake/plugins/webhook/impl"
+	zentao "github.com/apache/incubator-devlake/plugins/zentao/impl"
+)
+
+func Test_GetTablesInfo2(t *testing.T) {
+	checker := utils.NewTableInfoChecker("", nil)
+	checker.FeedIn("ae/models", ae.AE{}.GetTablesInfo)
+	checker.FeedIn("bamboo/models", bamboo.Bamboo{}.GetTablesInfo)
+	checker.FeedIn("bitbucket/models", bitbucket.Bitbucket("").GetTablesInfo)
+	checker.FeedIn("dora/models", dora.Dora{}.GetTablesInfo)
+	checker.FeedIn("feishu/models", feishu.Feishu{}.GetTablesInfo)
+	checker.FeedIn("gitee/models", gitee.Gitee("").GetTablesInfo)
+	checker.FeedIn("github/models", github.Github{}.GetTablesInfo)
+	checker.FeedIn("gitlab/models", gitlab.Gitlab("").GetTablesInfo)
+	checker.FeedIn("icla/models", icla.Icla{}.GetTablesInfo)
+	checker.FeedIn("jenkins/models", jenkins.Jenkins{}.GetTablesInfo)
+	checker.FeedIn("jira/models", jira.Jira{}.GetTablesInfo)
+	checker.FeedIn("pagerduty/models", pagerduty.PagerDuty{}.GetTablesInfo)
+	checker.FeedIn("slack/models", slack.Slack{}.GetTablesInfo)
+	checker.FeedIn("sonarqube/models", sonarqube.Sonarqube{}.GetTablesInfo)
+	checker.FeedIn("tapd/models", tapd.Tapd{}.GetTablesInfo)
+	checker.FeedIn("teambition/models", teambition.Teambition{}.GetTablesInfo)
+	checker.FeedIn("trello/models", trello.Trello{}.GetTablesInfo)
+	checker.FeedIn("webhook/models", webhook.Webhook{}.GetTablesInfo)
+	checker.FeedIn("zentao/models", zentao.Zentao{}.GetTablesInfo)
+	err := checker.Verify()
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/backend/plugins/jenkins/impl/impl.go
+++ b/backend/plugins/jenkins/impl/impl.go
@@ -75,6 +75,7 @@ func (p Jenkins) GetTablesInfo() []dal.Tabler {
 		&models.JenkinsJob{},
 		&models.JenkinsJobDag{},
 		&models.JenkinsStage{},
+		&models.JenkinsScopeConfig{},
 	}
 }
 

--- a/backend/plugins/jira/impl/impl.go
+++ b/backend/plugins/jira/impl/impl.go
@@ -87,6 +87,8 @@ func (p Jira) GetTablesInfo() []dal.Tabler {
 		&models.JiraSprintIssue{},
 		&models.JiraStatus{},
 		&models.JiraWorklog{},
+		&models.JiraIssueComment{},
+		&models.JiraScopeConfig{},
 	}
 }
 

--- a/backend/plugins/pagerduty/impl/impl.go
+++ b/backend/plugins/pagerduty/impl/impl.go
@@ -88,6 +88,7 @@ func (p PagerDuty) GetTablesInfo() []dal.Tabler {
 		&models.Incident{},
 		&models.User{},
 		&models.Assignment{},
+		&models.PagerDutyConnection{},
 	}
 }
 

--- a/backend/plugins/refdiff/e2e/deployment_commit_diff_test.go
+++ b/backend/plugins/refdiff/e2e/deployment_commit_diff_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/apache/incubator-devlake/core/models/domainlayer/devops"
 	"github.com/apache/incubator-devlake/helpers/e2ehelper"
 	"github.com/apache/incubator-devlake/plugins/refdiff/impl"
+	"github.com/apache/incubator-devlake/plugins/refdiff/models"
 	"github.com/apache/incubator-devlake/plugins/refdiff/tasks"
 )
 
@@ -47,14 +48,14 @@ func TestDeploymentCommitDiffDataFlow(t *testing.T) {
 
 	// verify extraction
 	dataflowTester.FlushTabler(&code.CommitsDiff{})
-	dataflowTester.FlushTabler(&code.FinishedCommitsDiff{})
+	dataflowTester.FlushTabler(&models.FinishedCommitsDiff{})
 
 	dataflowTester.Subtask(tasks.CalculateDeploymentCommitsDiffMeta, taskData)
 	dataflowTester.VerifyTableWithOptions(&code.CommitsDiff{}, e2ehelper.TableOptions{
 		CSVRelPath: "./deployment_commit_diff/commits_diffs.csv",
 	})
 
-	dataflowTester.VerifyTableWithOptions(&code.FinishedCommitsDiff{}, e2ehelper.TableOptions{
+	dataflowTester.VerifyTableWithOptions(&models.FinishedCommitsDiff{}, e2ehelper.TableOptions{
 		CSVRelPath: "./deployment_commit_diff/_tool_refdiff_finished_commits_diffs.csv",
 	})
 }

--- a/backend/plugins/refdiff/impl/impl.go
+++ b/backend/plugins/refdiff/impl/impl.go
@@ -22,6 +22,7 @@ import (
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/plugins/refdiff/models"
 	"github.com/apache/incubator-devlake/plugins/refdiff/tasks"
 )
 
@@ -49,7 +50,9 @@ func (p RefDiff) RequiredDataEntities() (data []map[string]interface{}, err erro
 }
 
 func (p RefDiff) GetTablesInfo() []dal.Tabler {
-	return []dal.Tabler{}
+	return []dal.Tabler{
+		&models.FinishedCommitsDiff{},
+	}
 }
 
 func (p RefDiff) IsProjectMetric() bool {

--- a/backend/plugins/refdiff/models/finished_commits_diffs.go
+++ b/backend/plugins/refdiff/models/finished_commits_diffs.go
@@ -15,26 +15,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package code
+package models
 
-type CommitsDiff struct {
+type FinishedCommitsDiff struct {
 	NewCommitSha string `gorm:"primaryKey;type:varchar(40)"`
 	OldCommitSha string `gorm:"primaryKey;type:varchar(40)"`
-	CommitSha    string `gorm:"primaryKey;type:varchar(40)"`
-	SortingIndex int
 }
 
-func (CommitsDiff) TableName() string {
-	return "commits_diffs"
-}
-
-type RefCommit struct {
-	NewRefId     string `gorm:"primaryKey;type:varchar(255)"`
-	OldRefId     string `gorm:"primaryKey;type:varchar(255)"`
-	NewCommitSha string `gorm:"type:varchar(40)"`
-	OldCommitSha string `gorm:"type:varchar(40)"`
-}
-
-func (RefCommit) TableName() string {
-	return "ref_commits"
+func (FinishedCommitsDiff) TableName() string {
+	return "_tool_refdiff_finished_commits_diffs"
 }

--- a/backend/plugins/refdiff/tasks/commit_diff_calculator.go
+++ b/backend/plugins/refdiff/tasks/commit_diff_calculator.go
@@ -19,12 +19,14 @@ package tasks
 
 import (
 	"fmt"
+	"reflect"
+
 	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/models/domainlayer/code"
 	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/plugins/refdiff/models"
 	"github.com/apache/incubator-devlake/plugins/refdiff/utils"
-	"reflect"
 )
 
 func CalculateCommitsDiff(taskCtx plugin.SubTaskContext) errors.Error {
@@ -103,7 +105,7 @@ func CalculateCommitsDiff(taskCtx plugin.SubTaskContext) errors.Error {
 
 	// calculate diffs for commits pairs and store them into database
 	commitsDiff := &code.CommitsDiff{}
-	finishedCommitDiff := &code.FinishedCommitsDiff{}
+	finishedCommitDiff := &models.FinishedCommitsDiff{}
 	lenCommitPairs := len(commitPairs)
 	taskCtx.SetProgress(0, lenCommitPairs)
 
@@ -133,7 +135,7 @@ func CalculateCommitsDiff(taskCtx plugin.SubTaskContext) errors.Error {
 
 		commitsDiffs := []code.CommitsDiff{}
 		refCommits := []code.RefCommit{}
-		finishedCommitDiffs := []code.FinishedCommitsDiff{}
+		finishedCommitDiffs := []models.FinishedCommitsDiff{}
 
 		commitsDiff.SortingIndex = 1
 		for _, sha := range lostSha {

--- a/backend/plugins/refdiff/tasks/deployment_commit_diff_calculator.go
+++ b/backend/plugins/refdiff/tasks/deployment_commit_diff_calculator.go
@@ -26,6 +26,7 @@ import (
 	"github.com/apache/incubator-devlake/core/models/domainlayer/code"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/plugins/refdiff/models"
 	"github.com/apache/incubator-devlake/plugins/refdiff/utils"
 )
 
@@ -113,7 +114,7 @@ func CalculateDeploymentCommitsDiff(taskCtx plugin.SubTaskContext) errors.Error 
 			return err
 		}
 		// mark commits_diff were calculated, no need to do it again in the future
-		finishedCommitsDiff := &code.FinishedCommitsDiff{
+		finishedCommitsDiff := &models.FinishedCommitsDiff{
 			NewCommitSha: pair.CommitSha,
 			OldCommitSha: pair.PrevCommitSha,
 		}

--- a/backend/plugins/slack/impl/impl.go
+++ b/backend/plugins/slack/impl/impl.go
@@ -53,6 +53,8 @@ func (p Slack) Init(basicRes context.BasicRes) errors.Error {
 func (p Slack) GetTablesInfo() []dal.Tabler {
 	return []dal.Tabler{
 		&models.SlackConnection{},
+		&models.SlackChannelMessage{},
+		&models.SlackChannel{},
 	}
 }
 

--- a/backend/plugins/sonarqube/models/sonarqube_hotspot.go
+++ b/backend/plugins/sonarqube/models/sonarqube_hotspot.go
@@ -19,7 +19,7 @@ package models
 
 import (
 	"github.com/apache/incubator-devlake/core/models/common"
-	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/helpers/utils"
 )
 
 type SonarqubeHotspot struct {
@@ -35,8 +35,8 @@ type SonarqubeHotspot struct {
 	Assignee                 string `gorm:"type:varchar(100)"`
 	SecurityCategory         string `gorm:"type:varchar(100)"`
 	VulnerabilityProbability string `gorm:"type:varchar(100)"`
-	CreationDate             *api.Iso8601Time
-	UpdateDate               *api.Iso8601Time
+	CreationDate             *utils.Iso8601Time
+	UpdateDate               *utils.Iso8601Time
 	common.NoPKModel
 }
 

--- a/backend/plugins/sonarqube/models/sonarqube_issue.go
+++ b/backend/plugins/sonarqube/models/sonarqube_issue.go
@@ -19,7 +19,7 @@ package models
 
 import (
 	"github.com/apache/incubator-devlake/core/models/common"
-	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/helpers/utils"
 )
 
 type SonarqubeIssue struct {
@@ -43,8 +43,8 @@ type SonarqubeIssue struct {
 	EndLine      int
 	StartOffset  int
 	EndOffset    int
-	CreationDate *api.Iso8601Time
-	UpdateDate   *api.Iso8601Time
+	CreationDate *utils.Iso8601Time
+	UpdateDate   *utils.Iso8601Time
 	common.NoPKModel
 }
 

--- a/backend/plugins/sonarqube/models/sonarqube_project.go
+++ b/backend/plugins/sonarqube/models/sonarqube_project.go
@@ -20,7 +20,7 @@ package models
 import (
 	"github.com/apache/incubator-devlake/core/models/common"
 	"github.com/apache/incubator-devlake/core/plugin"
-	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/helpers/utils"
 )
 
 var _ plugin.ToolLayerScope = (*SonarqubeProject)(nil)
@@ -28,13 +28,13 @@ var _ plugin.ApiScope = (*SonarqubeApiProject)(nil)
 
 type SonarqubeProject struct {
 	common.NoPKModel `json:"-" mapstructure:"-"`
-	ConnectionId     uint64           `json:"connectionId" validate:"required" gorm:"primaryKey" mapstructure:"connectionId"`
-	ProjectKey       string           `json:"projectKey" validate:"required" gorm:"type:varchar(255);primaryKey" mapstructure:"projectKey"`
-	Name             string           `json:"name" gorm:"type:varchar(255)" mapstructure:"name"`
-	Qualifier        string           `json:"qualifier" gorm:"type:varchar(255)" mapstructure:"qualifier"`
-	Visibility       string           `json:"visibility" gorm:"type:varchar(64)" mapstructure:"visibility"`
-	LastAnalysisDate *api.Iso8601Time `json:"lastAnalysisDate" mapstructure:"lastAnalysisDate"`
-	Revision         string           `json:"revision" gorm:"type:varchar(128)" mapstructure:"revision"`
+	ConnectionId     uint64             `json:"connectionId" validate:"required" gorm:"primaryKey" mapstructure:"connectionId"`
+	ProjectKey       string             `json:"projectKey" validate:"required" gorm:"type:varchar(255);primaryKey" mapstructure:"projectKey"`
+	Name             string             `json:"name" gorm:"type:varchar(255)" mapstructure:"name"`
+	Qualifier        string             `json:"qualifier" gorm:"type:varchar(255)" mapstructure:"qualifier"`
+	Visibility       string             `json:"visibility" gorm:"type:varchar(64)" mapstructure:"visibility"`
+	LastAnalysisDate *utils.Iso8601Time `json:"lastAnalysisDate" mapstructure:"lastAnalysisDate"`
+	Revision         string             `json:"revision" gorm:"type:varchar(128)" mapstructure:"revision"`
 }
 
 func (SonarqubeProject) TableName() string {
@@ -57,12 +57,12 @@ func (p SonarqubeProject) ScopeParams() interface{} {
 }
 
 type SonarqubeApiProject struct {
-	ProjectKey       string           `json:"key"`
-	Name             string           `json:"name"`
-	Qualifier        string           `json:"qualifier"`
-	Visibility       string           `json:"visibility"`
-	LastAnalysisDate *api.Iso8601Time `json:"lastAnalysisDate"`
-	Revision         string           `json:"revision"`
+	ProjectKey       string             `json:"key"`
+	Name             string             `json:"name"`
+	Qualifier        string             `json:"qualifier"`
+	Visibility       string             `json:"visibility"`
+	LastAnalysisDate *utils.Iso8601Time `json:"lastAnalysisDate"`
+	Revision         string             `json:"revision"`
 }
 
 // Convert the API response to our DB model instance

--- a/backend/plugins/sonarqube/tasks/hotspots_extractor.go
+++ b/backend/plugins/sonarqube/tasks/hotspots_extractor.go
@@ -22,6 +22,7 @@ import (
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/helpers/utils"
 	"github.com/apache/incubator-devlake/plugins/sonarqube/models"
 )
 
@@ -34,19 +35,19 @@ func ExtractHotspots(taskCtx plugin.SubTaskContext) errors.Error {
 		RawDataSubTaskArgs: *rawDataSubTaskArgs,
 		Extract: func(resData *helper.RawData) ([]interface{}, errors.Error) {
 			var res struct {
-				Key                      string              `json:"key" gorm:"primaryKey"`
-				RuleKey                  string              `json:"ruleKey"`
-				Component                string              `json:"component" gorm:"index"`
-				ProjectKey               string              `json:"project" gorm:"index"`
-				Line                     int                 `json:"line"`
-				Status                   string              `json:"status"`
-				Message                  string              `json:"message"`
-				Author                   string              `json:"author"`
-				Assignee                 string              `json:"assignee"`
-				SecurityCategory         string              `json:"securityCategory"`
-				VulnerabilityProbability string              `json:"vulnerabilityProbability"`
-				CreationDate             *helper.Iso8601Time `json:"creationDate"`
-				UpdateDate               *helper.Iso8601Time `json:"updateDate"`
+				Key                      string             `json:"key" gorm:"primaryKey"`
+				RuleKey                  string             `json:"ruleKey"`
+				Component                string             `json:"component" gorm:"index"`
+				ProjectKey               string             `json:"project" gorm:"index"`
+				Line                     int                `json:"line"`
+				Status                   string             `json:"status"`
+				Message                  string             `json:"message"`
+				Author                   string             `json:"author"`
+				Assignee                 string             `json:"assignee"`
+				SecurityCategory         string             `json:"securityCategory"`
+				VulnerabilityProbability string             `json:"vulnerabilityProbability"`
+				CreationDate             *utils.Iso8601Time `json:"creationDate"`
+				UpdateDate               *utils.Iso8601Time `json:"updateDate"`
 			}
 			err := errors.Convert(json.Unmarshal(resData.Data, &res))
 			if err != nil {

--- a/backend/plugins/sonarqube/tasks/issues_extractor.go
+++ b/backend/plugins/sonarqube/tasks/issues_extractor.go
@@ -23,6 +23,7 @@ import (
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/helpers/utils"
 	"github.com/apache/incubator-devlake/plugins/sonarqube/models"
 	"strings"
 )
@@ -137,18 +138,18 @@ type IssuesResponse struct {
 		StartOffset int `json:"startOffset"`
 		EndOffset   int `json:"endOffset"`
 	} `json:"textRange"`
-	Flows             []flow              `json:"flows"`
-	Status            string              `json:"status"`
-	Message           string              `json:"message"`
-	Effort            string              `json:"effort"`
-	Debt              string              `json:"debt"`
-	Author            string              `json:"author"`
-	Tags              []string            `json:"tags"`
-	CreationDate      *helper.Iso8601Time `json:"creationDate"`
-	UpdateDate        *helper.Iso8601Time `json:"updateDate"`
-	Type              string              `json:"type"`
-	Scope             string              `json:"scope"`
-	QuickFixAvailable bool                `json:"quickFixAvailable"`
+	Flows             []flow             `json:"flows"`
+	Status            string             `json:"status"`
+	Message           string             `json:"message"`
+	Effort            string             `json:"effort"`
+	Debt              string             `json:"debt"`
+	Author            string             `json:"author"`
+	Tags              []string           `json:"tags"`
+	CreationDate      *utils.Iso8601Time `json:"creationDate"`
+	UpdateDate        *utils.Iso8601Time `json:"updateDate"`
+	Type              string             `json:"type"`
+	Scope             string             `json:"scope"`
+	QuickFixAvailable bool               `json:"quickFixAvailable"`
 }
 
 type flow struct {

--- a/backend/plugins/table_info_test.go
+++ b/backend/plugins/table_info_test.go
@@ -24,17 +24,24 @@ import (
 	ae "github.com/apache/incubator-devlake/plugins/ae/impl"
 	bamboo "github.com/apache/incubator-devlake/plugins/bamboo/impl"
 	bitbucket "github.com/apache/incubator-devlake/plugins/bitbucket/impl"
+	customize "github.com/apache/incubator-devlake/plugins/customize/impl"
+	dbt "github.com/apache/incubator-devlake/plugins/dbt/impl"
 	dora "github.com/apache/incubator-devlake/plugins/dora/impl"
 	feishu "github.com/apache/incubator-devlake/plugins/feishu/impl"
 	gitee "github.com/apache/incubator-devlake/plugins/gitee/impl"
+	gitextractor "github.com/apache/incubator-devlake/plugins/gitextractor/impl"
 	github "github.com/apache/incubator-devlake/plugins/github/impl"
+	githubGraphql "github.com/apache/incubator-devlake/plugins/github_graphql/impl"
 	gitlab "github.com/apache/incubator-devlake/plugins/gitlab/impl"
 	icla "github.com/apache/incubator-devlake/plugins/icla/impl"
 	jenkins "github.com/apache/incubator-devlake/plugins/jenkins/impl"
 	jira "github.com/apache/incubator-devlake/plugins/jira/impl"
+	org "github.com/apache/incubator-devlake/plugins/org/impl"
 	pagerduty "github.com/apache/incubator-devlake/plugins/pagerduty/impl"
+	refdiff "github.com/apache/incubator-devlake/plugins/refdiff/impl"
 	slack "github.com/apache/incubator-devlake/plugins/slack/impl"
 	sonarqube "github.com/apache/incubator-devlake/plugins/sonarqube/impl"
+	starrocks "github.com/apache/incubator-devlake/plugins/starrocks/impl"
 	tapd "github.com/apache/incubator-devlake/plugins/tapd/impl"
 	teambition "github.com/apache/incubator-devlake/plugins/teambition/impl"
 	trello "github.com/apache/incubator-devlake/plugins/trello/impl"
@@ -42,22 +49,32 @@ import (
 	zentao "github.com/apache/incubator-devlake/plugins/zentao/impl"
 )
 
-func Test_GetTablesInfo2(t *testing.T) {
-	checker := utils.NewTableInfoChecker("", nil)
+func Test_GetPluginTablesInfo(t *testing.T) {
+	// Make sure EVERY Go plugin is listed here
+	checker := utils.NewTableInfoChecker(utils.TableInfoCheckerConfig{
+		ValidatePluginCount: true,
+	})
 	checker.FeedIn("ae/models", ae.AE{}.GetTablesInfo)
 	checker.FeedIn("bamboo/models", bamboo.Bamboo{}.GetTablesInfo)
 	checker.FeedIn("bitbucket/models", bitbucket.Bitbucket("").GetTablesInfo)
+	checker.FeedIn("customize/models", customize.Customize{}.GetTablesInfo)
+	checker.FeedIn("dbt", dbt.Dbt{}.GetTablesInfo)
 	checker.FeedIn("dora/models", dora.Dora{}.GetTablesInfo)
 	checker.FeedIn("feishu/models", feishu.Feishu{}.GetTablesInfo)
 	checker.FeedIn("gitee/models", gitee.Gitee("").GetTablesInfo)
+	checker.FeedIn("gitextractor/models", gitextractor.GitExtractor{}.GetTablesInfo)
 	checker.FeedIn("github/models", github.Github{}.GetTablesInfo)
+	checker.FeedIn("github_graphql", githubGraphql.GithubGraphql{}.GetTablesInfo)
 	checker.FeedIn("gitlab/models", gitlab.Gitlab("").GetTablesInfo)
 	checker.FeedIn("icla/models", icla.Icla{}.GetTablesInfo)
 	checker.FeedIn("jenkins/models", jenkins.Jenkins{}.GetTablesInfo)
 	checker.FeedIn("jira/models", jira.Jira{}.GetTablesInfo)
+	checker.FeedIn("org", org.Org{}.GetTablesInfo)
 	checker.FeedIn("pagerduty/models", pagerduty.PagerDuty{}.GetTablesInfo)
+	checker.FeedIn("refdiff/models", refdiff.RefDiff{}.GetTablesInfo)
 	checker.FeedIn("slack/models", slack.Slack{}.GetTablesInfo)
 	checker.FeedIn("sonarqube/models", sonarqube.Sonarqube{}.GetTablesInfo)
+	checker.FeedIn("starrocks", starrocks.StarRocks("").GetTablesInfo)
 	checker.FeedIn("tapd/models", tapd.Tapd{}.GetTablesInfo)
 	checker.FeedIn("teambition/models", teambition.Teambition{}.GetTablesInfo)
 	checker.FeedIn("trello/models", trello.Trello{}.GetTablesInfo)

--- a/backend/plugins/tapd/impl/impl.go
+++ b/backend/plugins/tapd/impl/impl.go
@@ -102,6 +102,8 @@ func (p Tapd) GetTablesInfo() []dal.Tabler {
 		&models.TapdStoryCustomFieldValue{},
 		&models.TapdTaskCustomFieldValue{},
 		&models.TapdBugCustomFieldValue{},
+		&models.TapdScopeConfig{},
+		&models.TapdWorkitemType{},
 	}
 }
 

--- a/backend/plugins/teambition/impl/impl.go
+++ b/backend/plugins/teambition/impl/impl.go
@@ -70,6 +70,8 @@ func (p Teambition) GetTablesInfo() []dal.Tabler {
 		&models.TeambitionTaskActivity{},
 		&models.TeambitionTaskWorktime{},
 		&models.TeambitionProject{},
+		&models.TeambitionTaskFlowStatus{},
+		&models.TeambitionTaskScenario{},
 	}
 }
 

--- a/backend/plugins/trello/impl/impl.go
+++ b/backend/plugins/trello/impl/impl.go
@@ -60,6 +60,7 @@ func (p Trello) GetTablesInfo() []dal.Tabler {
 		&models.TrelloLabel{},
 		&models.TrelloMember{},
 		&models.TrelloCheckItem{},
+		&models.TrelloScopeConfig{},
 	}
 }
 

--- a/backend/plugins/webhook/impl/impl.go
+++ b/backend/plugins/webhook/impl/impl.go
@@ -23,6 +23,7 @@ import (
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/plugins/webhook/api"
+	"github.com/apache/incubator-devlake/plugins/webhook/models"
 	"github.com/apache/incubator-devlake/plugins/webhook/models/migrationscripts"
 )
 
@@ -52,7 +53,9 @@ func (p Webhook) Init(basicRes context.BasicRes) errors.Error {
 }
 
 func (p Webhook) GetTablesInfo() []dal.Tabler {
-	return []dal.Tabler{}
+	return []dal.Tabler{
+		&models.WebhookConnection{},
+	}
 }
 
 func (p Webhook) MakeDataSourcePipelinePlanV200(connectionId uint64, _ []*plugin.BlueprintScopeV200, _ plugin.BlueprintSyncPolicy) (pp plugin.PipelinePlan, sc []plugin.Scope, err errors.Error) {

--- a/backend/plugins/zentao/impl/impl.go
+++ b/backend/plugins/zentao/impl/impl.go
@@ -83,6 +83,9 @@ func (p Zentao) GetTablesInfo() []dal.Tabler {
 		&models.ZentaoTask{},
 		&models.ZentaoTaskCommit{},
 		&models.ZentaoTaskRepoCommit{},
+		&models.ZentaoBugRepoCommit{},
+		&models.ZentaoConnection{},
+		&models.ZentaoScopeConfig{},
 	}
 }
 

--- a/backend/scripts/compile-plugins.sh
+++ b/backend/scripts/compile-plugins.sh
@@ -39,7 +39,7 @@ PLUGIN_SRC_DIR=$SCRIPT_DIR/../plugins
 PLUGIN_OUTPUT_DIR=$SCRIPT_DIR/../bin/plugins
 
 if [ -z "$PLUGIN" ]; then
-    PLUGINS=$(find $PLUGIN_SRC_DIR/* -maxdepth 0 -type d -not -name core -not -name helper -not -empty)
+    PLUGINS=$(find $PLUGIN_SRC_DIR/* -maxdepth 0 -type d -not -name core -not -name helper -not -name logs -not -empty)
 else
     PLUGINS=
     for p in $(echo "$PLUGIN" | tr "," "\n"); do


### PR DESCRIPTION
### Summary
- introduced a new unit test to identify all tables omitted by `GetTablesInfo`
- added the following tool layer tables to the `GetTablesInfo` functions
 `_tool_bamboo_scope_configs`
        `_tool_zentao_scope_configs`
        `_tool_tapd_workitem_types`
        `_tool_teambition_task_flow_status`
        `_tool_jira_scope_configs`
        `_tool_bitbucket_pipeline_steps`
        `_tool_jenkins_scope_configs`
        `_tool_feishu_chats`
        `_tool_gitlab_issue_assignees`
        `_tool_webhook_connections`
        `_tool_zentao_bug_repo_commits`
        `_tool_github_scope_configs`
        `_tool_teambition_task_scenarios`
        `_tool_bitbucket_deployments`
        `_tool_tapd_scope_configs`
        `_tool_jira_issue_comments`
        `_tool_zentao_connections`
        `_tool_feishu_messages`
        `_tool_pagerduty_connections`
        `_tool_bamboo_deploy_environment`
        `_tool_bamboo_deploy_build`
        `_tool_github_issue_assignees`
        `_tool_bitbucket_pull_request_commits`
        `_tool_gitlab_scope_configs`
        `_tool_slack_channels`
        `_tool_trello_scope_configs`
        `_tool_slack_channel_messages`
        `_tool_bitbucket_scope_configs`
  

### Does this close any open issues?
part of #5534 

