### PR TITLE
fix: boards.type

### DIFF
--- a/backend/plugins/gitlab/tasks/pipeline_commit_convertor.go
+++ b/backend/plugins/gitlab/tasks/pipeline_commit_convertor.go
@@ -26,7 +26,6 @@ import (
 	"github.com/apache/incubator-devlake/core/models/domainlayer/didgen"
 	"github.com/apache/incubator-devlake/core/plugin"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
-	"github.com/apache/incubator-devlake/plugins/gitlab/models"
 	gitlabModels "github.com/apache/incubator-devlake/plugins/gitlab/models"
 )
 
@@ -67,7 +66,7 @@ func ConvertPipelineCommits(taskCtx plugin.SubTaskContext) errors.Error {
 		Input:        cursor,
 		RawDataSubTaskArgs: helper.RawDataSubTaskArgs{
 			Ctx: taskCtx,
-			Params: models.GitlabApiParams{
+			Params: gitlabModels.GitlabApiParams{
 				ConnectionId: data.Options.ConnectionId,
 				ProjectId:    data.Options.ProjectId,
 			},

--- a/backend/plugins/gitlab/tasks/pipeline_convertor.go
+++ b/backend/plugins/gitlab/tasks/pipeline_convertor.go
@@ -29,7 +29,6 @@ import (
 	"github.com/apache/incubator-devlake/core/models/domainlayer/didgen"
 	"github.com/apache/incubator-devlake/core/plugin"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
-	"github.com/apache/incubator-devlake/plugins/gitlab/models"
 	gitlabModels "github.com/apache/incubator-devlake/plugins/gitlab/models"
 )
 
@@ -65,7 +64,7 @@ func ConvertPipelines(taskCtx plugin.SubTaskContext) errors.Error {
 		Input:        cursor,
 		RawDataSubTaskArgs: helper.RawDataSubTaskArgs{
 			Ctx: taskCtx,
-			Params: models.GitlabApiParams{
+			Params: gitlabModels.GitlabApiParams{
 				ConnectionId: data.Options.ConnectionId,
 				ProjectId:    data.Options.ProjectId,
 			},

--- a/backend/plugins/jira/api/blueprint_v200.go
+++ b/backend/plugins/jira/api/blueprint_v200.go
@@ -103,6 +103,8 @@ func makeScopesV200(
 					Id: didgen.NewDomainIdGenerator(&models.JiraBoard{}).Generate(jiraBoard.ConnectionId, jiraBoard.BoardId),
 				},
 				Name: jiraBoard.Name,
+				Url:  jiraBoard.Self,
+				Type: jiraBoard.Type,
 			}
 			scopes = append(scopes, domainBoard)
 		}

--- a/backend/plugins/zentao/tasks/project_convertor.go
+++ b/backend/plugins/zentao/tasks/project_convertor.go
@@ -79,7 +79,7 @@ func ConvertProjects(taskCtx plugin.SubTaskContext) errors.Error {
 				Name:        toolProject.Name,
 				Description: toolProject.Description,
 				CreatedDate: toolProject.OpenedDate.ToNullableTime(),
-				Type:        toolProject.Type + "/" + toolProject.ProjectType,
+				Type:        "scrum",
 				Url:         fmt.Sprintf("/project-index-%d.html", data.Options.ProjectId),
 			}
 			results := make([]interface{}, 0)


### PR DESCRIPTION
### Summary
- Set `boards.url` and `boards.type` on creating a pipeline for Jira
- Set `boards.type` as 'scrum' on converting project for Zentao

