### PR TITLE
fix: tapd status extraction error

### DIFF
--- a/backend/plugins/tapd/tasks/bug_status_extractor.go
+++ b/backend/plugins/tapd/tasks/bug_status_extractor.go
@@ -18,7 +18,6 @@ limitations under the License.
 package tasks
 
 import (
-	"encoding/json"
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
@@ -40,18 +39,12 @@ func ExtractBugStatus(taskCtx plugin.SubTaskContext) errors.Error {
 	extractor, err := api.NewApiExtractor(api.ApiExtractorArgs{
 		RawDataSubTaskArgs: *rawDataSubTaskArgs,
 		Extract: func(row *api.RawData) ([]interface{}, errors.Error) {
-			if string(row.Data) == "[]" {
-				return nil, nil
-			}
-			var statusRes struct {
-				Data map[string]string
-			}
-			err := errors.Convert(json.Unmarshal(row.Data, &statusRes))
+			var results []interface{}
+			status, err := extractStatus(row.Data)
 			if err != nil {
 				return nil, err
 			}
-			results := make([]interface{}, 0)
-			for k, v := range statusRes.Data {
+			for k, v := range status {
 				toolL := &models.TapdBugStatus{
 					ConnectionId: data.Options.ConnectionId,
 					WorkspaceId:  data.Options.WorkspaceId,

--- a/backend/plugins/tapd/tasks/shared.go
+++ b/backend/plugins/tapd/tasks/shared.go
@@ -334,3 +334,25 @@ func generateDomainAccountIdForUsers(param string, connectionId uint64) string {
 	}
 	return strings.Join(res, ",")
 }
+
+// extractStatus extracts the status from the given blob and returns a map of status names to status values.
+func extractStatus(blob []byte) (map[string]string, errors.Error) {
+	var statusRes struct {
+		Data interface{} `json:"data"`
+	}
+	err := errors.Convert(json.Unmarshal(blob, &statusRes))
+	if err != nil {
+		return nil, err
+	}
+	data, ok := statusRes.Data.(map[string]interface{})
+	if !ok {
+		return nil, nil
+	}
+	results := make(map[string]string)
+	for k, v := range data {
+		if value, ok := v.(string); ok {
+			results[k] = value
+		}
+	}
+	return results, nil
+}

--- a/backend/plugins/tapd/tasks/shared_test.go
+++ b/backend/plugins/tapd/tasks/shared_test.go
@@ -250,3 +250,47 @@ func TestGenerateDomainAccountIdForUsers(t *testing.T) {
 		}
 	}
 }
+
+func Test_extractStatus(t *testing.T) {
+	type args struct {
+		blob []byte
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  map[string]string
+		want1 errors.Error
+	}{
+		{
+			"non-empty array",
+			args{
+				blob: []byte(`{"data":[{"id":1,"name":"已完成","is_last_step":true},{"id":2,"name":"进行中"}],"status":1,"message":"success"}`),
+			},
+			nil,
+			nil,
+		},
+		{
+			"empty array",
+			args{
+				blob: []byte(`{"status":1,"data":[],"info":"success"}`),
+			},
+			nil,
+			nil,
+		},
+		{
+			"object",
+			args{
+				blob: []byte(`{"status":1,"data":{"new":"新建","in_progress":"开发处理"},"info":"success"}`),
+			},
+			map[string]string{"new": "新建", "in_progress": "开发处理"},
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := extractStatus(tt.args.blob)
+			assert.Equalf(t, tt.want, got, "extractStatus(%v)", tt.args.blob)
+			assert.Equalf(t, tt.want1, got1, "extractStatus(%v)", tt.args.blob)
+		})
+	}
+}

--- a/backend/plugins/tapd/tasks/story_status_extractor.go
+++ b/backend/plugins/tapd/tasks/story_status_extractor.go
@@ -18,7 +18,6 @@ limitations under the License.
 package tasks
 
 import (
-	"encoding/json"
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
@@ -40,18 +39,12 @@ func ExtractStoryStatus(taskCtx plugin.SubTaskContext) errors.Error {
 	extractor, err := api.NewApiExtractor(api.ApiExtractorArgs{
 		RawDataSubTaskArgs: *rawDataSubTaskArgs,
 		Extract: func(row *api.RawData) ([]interface{}, errors.Error) {
-			if string(row.Data) == "[]" {
-				return nil, nil
-			}
-			var storyStatusRes struct {
-				Data map[string]string
-			}
-			err := errors.Convert(json.Unmarshal(row.Data, &storyStatusRes))
+			var results []interface{}
+			status, err := extractStatus(row.Data)
 			if err != nil {
 				return nil, err
 			}
-			results := make([]interface{}, 0)
-			for k, v := range storyStatusRes.Data {
+			for k, v := range status {
 				toolL := &models.TapdStoryStatus{
 					ConnectionId: data.Options.ConnectionId,
 					WorkspaceId:  data.Options.WorkspaceId,


### PR DESCRIPTION
### Summary
Fix #5573 ([Bug][TAPD] ExtractBugStatus Task, an error reported If there is no “Bug Status“ data). This bug is caused by incorrect handling of empty arrays.

### Does this close any open issues?
Closes #5573 

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/8455907/f2083827-a53b-4357-9810-9b3112611d07)



