### PR TITLE
Fix the migration for the introduction of the squash and diff columns

### DIFF
--- a/backend/plugins/gitlab/models/migrationscripts/20230625_add_mr_commitsha.go
+++ b/backend/plugins/gitlab/models/migrationscripts/20230625_add_mr_commitsha.go
@@ -26,7 +26,7 @@ import (
 type addMrCommitSha struct{}
 
 type GitlabMergeRequest20230625 struct {
-	MergeCommitSha  string `gorm:"type:varchar(255)"`
+	DiffHeadSha     string `gorm:"type:varchar(255)"`
 	SquashCommitSha string `gorm:"type:varchar(255)"`
 }
 
@@ -51,5 +51,5 @@ func (*addMrCommitSha) Version() uint64 {
 }
 
 func (*addMrCommitSha) Name() string {
-	return "add _tool_gitlab_issue_assignees table"
+	return "add squash and diff sha columns"
 }


### PR DESCRIPTION
As noted [here](https://github.com/apache/incubator-devlake/pull/5577/files#r1244735425) the fix for `gitlab commit sha` introduced an erroneous migration which this PR should fix.

- Should this PR be on `release-17` or `master`?
- Should this be a new migration? (as i guess the previous migration hasn't been tagged yet)