### PR TITLE
fix:SELinux context not set crashes container

### DIFF
--- a/devops/releases/lake-v0.17.0/docker-compose.yml
+++ b/devops/releases/lake-v0.17.0/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - 8080:8080
     restart: always
     volumes:
-      - ./.env:/app/.env
+      - ./.env:/app/.env:z
       - ./logs:/app/logs
     environment:
       LOGGING_DIR: /app/logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       - "127.0.0.1:8080:8080"
     restart: always
     volumes:
-      - ./.env:/app/.env
+      - ./.env:/app/.env:z
       - ./logs:/app/logs
     environment:
       LOGGING_DIR: /app/logs


### PR DESCRIPTION
reworking the PR per #5554#issuecomment-1605815004 Added SEContext to mount

Closes #5474

### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
a modification to the docker-compose file to set the SELinux context on .env for
the devlake container

### Does this close any open issues?
Closes #5474 

### Screenshots
Include any relevant screenshots here.

### Other Information
REDO of my First PR (#5554) on this project. I hope I targetted the right file. Would appreciate insights, feedback and thanks for taking time to review. Thanks @klesh and @hezyin on your ongoing support. I hope I nailed your intentions on this one :)
