### PR TITLE
Add missing name to gitextractor task

### DIFF
--- a/backend/python/plugins/azuredevops/azuredevops/main.py
+++ b/backend/python/plugins/azuredevops/azuredevops/main.py
@@ -128,7 +128,7 @@ class AzureDevOpsPlugin(Plugin):
         if DomainType.CODE in scope_config.domain_types and not scope.is_external():
             url = urlparse(scope.remote_url)
             url = url._replace(netloc=f'{url.username}:{connection.token.get_secret_value()}@{url.hostname}')
-            yield gitextractor(url.geturl(), scope.domain_id(), connection.proxy)
+            yield gitextractor(url.geturl(), scope.name, scope.domain_id(), connection.proxy)
 
     def extra_stages(self, scope_config_pairs: list[tuple[GitRepository, GitRepositoryConfig]], _):
         for scope, config in scope_config_pairs:

--- a/backend/python/pydevlake/pydevlake/pipeline_tasks.py
+++ b/backend/python/pydevlake/pydevlake/pipeline_tasks.py
@@ -21,12 +21,13 @@ from pydantic import BaseModel
 from pydevlake.message import PipelineTask
 
 
-def gitextractor(url: str, repo_id: str, proxy: Optional[str]):
+def gitextractor(url: str, repo_name: str, scope_id: str, proxy: Optional[str]):
     return PipelineTask(
         plugin="gitextractor",
         options={
             "url": url,
-            "repoId": repo_id,
+            "name": repo_name,
+            "repoId": scope_id,
             "proxy": proxy
         },
     )


### PR DESCRIPTION
### Summary

Frontend expects gitextractor task to have a `name` property in its options.